### PR TITLE
fix(sensor defs): set unit for pH measurement

### DIFF
--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -103,7 +103,7 @@ SENSOR_DEFINITIONS = {
     },
     "MBF_MEASURE_PH": {
         "name": "pH Level",
-        "unit": None,
+        "unit": "pH",
         "device_class": SensorDeviceClass.PH,
         "state_class": SensorStateClass.MEASUREMENT,
         "icon": "mdi:ph",


### PR DESCRIPTION
This allows it to share a graph with the setpoint.

Resolves #59 
