### PR TITLE
fix: 🐛 code review fixes for HA 2026.2 compatibility

### DIFF
--- a/custom_components/vistapool/binary_sensor.py
+++ b/custom_components/vistapool/binary_sensor.py
@@ -29,12 +29,12 @@ _LOGGER = logging.getLogger(__name__)
 DISABLED_SUFFIXES = [
     " measurement active",
     " pump active",
-    " Acid Pump",
+    " acid pump",
     " shock mode",
-    " On Target",
-    " Low Flow",
+    " on target",
+    " low flow",
     " input active",
-    " indicator FL2",
+    " indicator fl2",
 ]
 
 
@@ -116,7 +116,7 @@ async def async_setup_entry(
 
         # Check if the entity should be enabled by default
         # Disable some entities by default based on their key
-        if any(key.lower().endswith(suf) for suf in DISABLED_SUFFIXES):
+        if any(key.lower().endswith(suf.lower()) for suf in DISABLED_SUFFIXES):
             sensor_props["enabled_default"] = False
         else:
             sensor_props["enabled_default"] = True

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -62,6 +62,8 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
         self.entry_id = entry_id
         self.device_name = entry.data.get(CONF_NAME, DOMAIN)
         self.auto_time_sync = self.entry.options.get("auto_time_sync", False)
+        self._firmware = "?"
+        self._model = "Unknown"
 
     async def _async_update_data(self):
         try:

--- a/custom_components/vistapool/helpers.py
+++ b/custom_components/vistapool/helpers.py
@@ -47,7 +47,7 @@ def get_device_time(data, hass=None) -> datetime.datetime | None:
 
 # This function prepares the device time for writing to the device
 # It takes the current time in the local timezone and converts it to a format suitable for the device
-def prepare_device_time(hass=None) -> list[int, int]:
+def prepare_device_time(hass=None) -> list[int]:
     """
     Prepare device time for writing to the device.
     Returns a list of two integers representing the low and high parts of the time.

--- a/custom_components/vistapool/number.py
+++ b/custom_components/vistapool/number.py
@@ -83,10 +83,6 @@ async def async_setup_entry(
 class VistaPoolNumber(VistaPoolEntity, NumberEntity):
     """Representation of a VistaPool number entity."""
 
-    _pending_write_task = None
-    _pending_value = None
-    _debounce_delay = 2.0
-
     def __init__(self, coordinator, entry_id, key, props) -> None:
         """Initialize the VistaPool number entity."""
         super().__init__(coordinator, entry_id)
@@ -111,6 +107,9 @@ class VistaPoolNumber(VistaPoolEntity, NumberEntity):
         self._attr_device_class = props.get("device_class") or None
         self._attr_entity_category = props.get("entity_category") or None
         self._attr_icon = props.get("icon")
+        self._pending_write_task = None
+        self._pending_value = None
+        self._debounce_delay = 2.0
 
         _LOGGER.debug(
             f"INIT: suggested_object_id={self._attr_suggested_object_id}, translation_key={self._attr_translation_key}, has_entity_name={getattr(self, 'has_entity_name', None)}"

--- a/custom_components/vistapool/options_flow.py
+++ b/custom_components/vistapool/options_flow.py
@@ -15,7 +15,6 @@
 """VistaPool Integration for Home Assistant - Options Flow Module"""
 
 import logging
-import asyncio
 import voluptuous as vol
 from datetime import date
 from homeassistant import config_entries
@@ -28,19 +27,18 @@ _LOGGER = logging.getLogger(__name__)
 class VistaPoolOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow for VistaPool integration."""
 
-    def __init__(self, config_entry) -> None:
+    def __init__(self, config_entry=None) -> None:
         """Initialize the options flow handler."""
         super().__init__()
-        self._config_entry = config_entry
         self._base_options = {}
 
     async def async_step_init(self, user_input=None) -> dict:
         """Handle the initial step of the options flow."""
         # Get current options from the config entry
-        options = dict(self._config_entry.options)
+        options = dict(self.config_entry.options)
         already_enabled = options.get("enable_backwash_option", False)
 
-        device_slug = self._config_entry.unique_id or slugify(
+        device_slug = self.config_entry.unique_id or slugify(
             self.config_entry.data.get("name")
         )
         expected = f"{device_slug}{date.today().year}"
@@ -122,7 +120,7 @@ class VistaPoolOptionsFlowHandler(config_entries.OptionsFlow):
                     )
             data = user_input.copy()
             data.pop("unlock_advanced", None)
-            prev_options = dict(self._config_entry.options)
+            prev_options = dict(self.config_entry.options)
             result = self.async_create_entry(title="", data=data)
 
             # Dynamically collect all 'use_*' option keys to compare changes and trigger reload if needed
@@ -134,9 +132,8 @@ class VistaPoolOptionsFlowHandler(config_entries.OptionsFlow):
                 }
             )
             if any(prev_options.get(k) != user_input.get(k) for k in reload_keys):
-                self.hass.loop.call_soon(
-                    asyncio.create_task,
-                    self.hass.config_entries.async_reload(self._config_entry.entry_id),
+                self.hass.async_create_task(
+                    self.hass.config_entries.async_reload(self.config_entry.entry_id)
                 )
 
             return result
@@ -149,7 +146,7 @@ class VistaPoolOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_advanced(self, user_input=None) -> dict:
         """Handle the advanced options step."""
-        options = dict(self._config_entry.options)
+        options = dict(self.config_entry.options)
         advanced_schema = vol.Schema(
             {
                 vol.Optional(
@@ -169,7 +166,7 @@ class VistaPoolOptionsFlowHandler(config_entries.OptionsFlow):
         )
 
         if user_input is not None:
-            prev_options = dict(self._config_entry.options)
+            prev_options = dict(self.config_entry.options)
             all_options = {**self._base_options, **user_input}
             result = self.async_create_entry(title="", data=all_options)
 
@@ -183,9 +180,8 @@ class VistaPoolOptionsFlowHandler(config_entries.OptionsFlow):
                 }
             )
             if any(prev_options.get(k) != all_options.get(k) for k in reload_keys):
-                self.hass.loop.call_soon(
-                    asyncio.create_task,
-                    self.hass.config_entries.async_reload(self._config_entry.entry_id),
+                self.hass.async_create_task(
+                    self.hass.config_entries.async_reload(self.config_entry.entry_id)
                 )
 
             return result


### PR DESCRIPTION
## 🐛 Code review fixes for HA 2026.2 compatibility

This PR addresses several bugs and compatibility issues found during a full project code review.

### 🔧 Changes

#### 🔴 `binary_sensor.py` — entity default visibility bug
`DISABLED_SUFFIXES` contained mixed-case strings (e.g. `" On Target"`, `" Acid Pump"`) but the
comparison used `key.lower()`. The suffixes were never matched, so entities like `HIDRO On Target`,
`ION Low Flow`, `pH Acid Pump` and `HIDRO Chlorine flow indicator FL2` were always enabled by
default instead of being hidden. Fixed by normalizing all suffixes to lowercase and comparing
with `.lower()`.

#### 🔴 `coordinator.py` — AttributeError before first data fetch
`_firmware` and `_model` were only assigned inside `_async_update_data()`. Any code path that
accessed `coordinator.firmware` or `coordinator.model` (e.g. `device_info`) before the first
successful poll would raise `AttributeError`. Both attributes are now initialized in `__init__`
with safe fallback values.

#### 🟡 `helpers.py` — invalid type annotation
`prepare_device_time()` was annotated as `-> list[int, int]`. Python's `list` type accepts only
a single type argument. Corrected to `-> list[int]`.

#### 🟡 `number.py` — class-level mutable state
`_pending_write_task`, `_pending_value`, and `_debounce_delay` were defined as class-level
attributes. If multiple `VistaPoolNumber` instances existed, they would share the same
`_pending_write_task` and `_pending_value`, causing race conditions and incorrect debounce
behavior. Moved to `__init__` as proper instance attributes.

#### 🟠 `options_flow.py` — deprecated `hass.loop` access (HA 2025+)
`self.hass.loop.call_soon(asyncio.create_task, ...)` is deprecated since HA 2025. Replaced with
`self.hass.async_create_task(coro)` in both `async_step_init` and `async_step_advanced`.
The now-unused `import asyncio` was also removed.

#### 🟠 `options_flow.py` — migrate to new `OptionsFlow` API
`OptionsFlowWithConfigEntry` is being phased out in HA. Migrated to the base `OptionsFlow` class,
which exposes `config_entry` as a read-only property resolved via `hass.config_entries`. Updated
tests to use a `make_flow()` helper that correctly sets up the mock via
`hass.config_entries.async_get_known_entry`.
