### PR TITLE
feat(button): ✨ add backwash button and logic for automatic filtration valve

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ If you find this integration useful, consider supporting its development:
 - **Reliable single Modbus TCP connection per device/hub** (improves stability, avoids connection issues).
 - **Multi-hub support**: Add multiple VistaPool devices, each with a custom prefix (used in entity IDs).
 - **Sensors**:
-  pH, Redox (ORP), Salt, Conductivity, Water Temperature, Ionization, Hydrolysis Intensity/Voltage, Device Time, Status/Alarm bits, Filtration speed _(if supported)_.
+  pH, Redox (ORP), Salt, Conductivity, Water Temperature, Ionization, Hydrolysis Intensity/Voltage, Device Time, Status/Alarm bits, Filtration speed _(if supported)_, Backwash remaining time _(if Besgo automatic filter valve is configured)_.
 - **Numbers**:
   Setpoints for pH, Redox, Chlorine, Temperature, Hydrolysis production, Hydrolysis cover reduction % _(if hydrolysis module present + cover sensor enabled)_, Hydrolysis shutdown temperature threshold _(if hydrolysis module + temperature sensor + cover sensor enabled)_.
 - **Switches**:
   Manual filtration, relays (_Light & AUX1–AUX4_, can be enabled in Options), automatic time sync to Home Assistant (default: disabled), **winter mode** (suspends Modbus communication while keeping all entities registered in Home Assistant), Hydrolysis cover reduction enable _(if hydrolysis module present + cover sensor enabled)_, Hydrolysis temperature shutdown enable _(if hydrolysis module + temperature sensor + cover sensor enabled)_.
 - **Selects**:
-  Filtration mode (Manual, Auto, Heating, Smart, Intelligent), timers for automatic filtration, filtration speed _(if supported)_, boost control _(if Hydro/Electrolysis module is present)_, pH pump activation delay.
+  Filtration mode (Manual, Auto, Heating, Smart, Intelligent, **Backwash** _(auto-enabled if Besgo valve configured)_), timers for automatic filtration, filtration speed _(if supported)_, boost control _(if Hydro/Electrolysis module is present)_, pH pump activation delay, **Backwash Repeat Interval** _(if Besgo valve configured)_, **Backwash Valve Mode** _(if Besgo valve configured)_.
 - **Buttons**:
   Manual time sync, reset alarm/error states, **Start Backwash** _(only if Besgo automatic filter valve is configured on the device)_.
 
@@ -198,11 +198,20 @@ To enable it:
 
 ### Start Backwash Button (Besgo Automatic Filter Valve)
 
-If your device is configured with a **Besgo automatic filter valve** (`MBF_PAR_FILTVALVE_ENABLE = 1`), a dedicated **`Start Backwash`** button (`button.<name>_backwash`) is automatically available - no unlock code required.
+If your device is configured with a **Besgo automatic filter valve** (`MBF_PAR_FILTVALVE_ENABLE = 1`), a dedicated **`Start Backwash`** button (`button.<name>_backwash`) is automatically available — no unlock code required.
 
-- Pressing it sets the filtration mode to backwash (mode 13) and the controller opens the Besgo valve, then runs the cleaning cycle for the duration stored in the device (`MBF_PAR_FILTVALVE_INTERVAL`).
-- When switching **from manual filtration mode to backwash** on a device with a Besgo valve, the pump is intentionally **not** stopped before the mode change - this ensures the valve opens correctly under pressure.
+- Pressing it sets the filtration mode to backwash (mode 13) and the controller opens the Besgo valve, then runs the cleaning cycle automatically.
+- When switching **from manual filtration mode to backwash** on a device with a Besgo valve, the pump is intentionally **not** stopped before the mode change — this ensures the valve opens correctly under pressure.
 - On devices **without** a Besgo valve (manual multi-way valve), the pump IS stopped first so the user can safely rotate the valve before the backwash cycle begins.
+- The **Backwash** option in the filtration mode select is **automatically shown** when a Besgo valve is detected (no unlock code needed).
+
+Additional Besgo-only entities are created automatically when `MBF_PAR_FILTVALVE_ENABLE = 1`:
+
+| Entity                                   | Description                                                 |
+| ---------------------------------------- | ----------------------------------------------------------- |
+| `sensor.<name>_filtvalve_remaining`      | Remaining time (s) of the current backwash cycle            |
+| `select.<name>_filtvalve_period_minutes` | How often automatic backwash is triggered (1 day – 4 weeks) |
+| `select.<name>_filtvalve_mode`           | Valve timer mode: Automatic / Always On / Always Off        |
 
 > **⚠️ WARNING:**
 > Always verify that your filtration system is correctly set up before triggering a backwash remotely.
@@ -216,7 +225,8 @@ Entities are lowercased and prefixed by your custom name, e.g. `sensor.pool1_fil
 
 - **Sensors**:
   `sensor.<name>_measure_ph`, `sensor.<name>_measure_temperature`, `sensor.<name>_filt_mode`,
-  `sensor.<name>_filtration_speed` _(if supported)_
+  `sensor.<name>_filtration_speed` _(if supported)_,
+  `sensor.<name>_filtvalve_remaining` _(if Besgo valve configured)_
 - **Numbers**:
   `number.<name>_hidro`, `number.<name>_ph1`,
   `number.<name>_heating_temp` _(if supported)_,
@@ -230,7 +240,8 @@ Entities are lowercased and prefixed by your custom name, e.g. `sensor.pool1_fil
   `select.<name>_filt_mode`, `select.<name>_filtration1_start`, `select.<name>_filtration1_stop`,
   `select.<name>_filtration_speed` _(if supported)_,
   `select.<name>_cell_boost` _(if supported)_,
-  `select.<name>_relay_activation_delay`
+  `select.<name>_relay_activation_delay`,
+  `select.<name>_filtvalve_period_minutes`, `select.<name>_filtvalve_mode` _(if Besgo valve configured)_
 - **Buttons**:
   `button.<name>_sync_time`, `button.<name>_escape`,
   `button.<name>_backwash` _(if Besgo automatic filter valve is configured)_
@@ -245,6 +256,7 @@ Entities are lowercased and prefixed by your custom name, e.g. `sensor.pool1_fil
 - **Entities cache last value** if there is a Modbus communication problem.
 - **Backwash (filtration mode select):** Hidden by default; unlock via advanced options. See above for details.
 - **Backwash button:** Automatically available when a Besgo automatic filter valve is configured on the device. See above for details.
+- **Besgo valve entities** (`sensor filtvalve_remaining`, `select filtvalve_period_minutes`, `select filtvalve_mode`): Only created when Besgo valve is detected (`MBF_PAR_FILTVALVE_ENABLE = 1`).
 - **Reload on options change:** Integration is reloaded automatically on option changes.
 - **Filtration speed sensor/control:** Only available for variable-speed pump models.
 - **Boost control (select):** Only if Hydro/Electrolysis module is present.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If you find this integration useful, consider supporting its development:
 - **Selects**:
   Filtration mode (Manual, Auto, Heating, Smart, Intelligent), timers for automatic filtration, filtration speed _(if supported)_, boost control _(if Hydro/Electrolysis module is present)_, pH pump activation delay.
 - **Buttons**:
-  Manual time sync, reset alarm/error states.
+  Manual time sync, reset alarm/error states, **Start Backwash** _(only if Besgo automatic filter valve is configured on the device)_.
 
 ---
 
@@ -164,7 +164,7 @@ If your pool controller is **physically disconnected during winter** (e.g. drain
 
 ### Advanced Options: Unlocking “Backwash” Mode
 
-The “Backwash” filtration mode is hidden by default, as its remote use can be risky and is intended only for advanced users.
+The "Backwash" option in the **filtration mode select** is hidden by default, as its remote use can be risky and is intended only for advanced users.
 
 To enable it:
 
@@ -172,14 +172,26 @@ To enable it:
 2. In the options dialog, find the field **Unlock advanced options**.
 3. Enter the code: `<device_prefix><current_year>`
 
-- Example: If your pool’s prefix is `vistapool` and the year is 2025, enter `vistapool2025`.
+- Example: If your pool's prefix is `vistapool` and the year is 2025, enter `vistapool2025`.
 - The prefix is the same as in your entity IDs (e.g., `switch.vistapool_light`).
 
-4. Submit the form. The advanced settings page will open, allowing you to enable “Backwash” mode.
+4. Submit the form. The advanced settings page will open, allowing you to enable "Backwash" mode.
 
 > **⚠️ WARNING:**
-> Enabling “Backwash” exposes this function in filtration mode selection.
+> Enabling "Backwash" exposes this function in filtration mode selection.
 > **Improper use may damage your filtration system! Only activate if you fully understand the risks.**
+
+### Start Backwash Button (Besgo Automatic Filter Valve)
+
+If your device is configured with a **Besgo automatic filter valve** (`MBF_PAR_FILTVALVE_ENABLE = 1`), a dedicated **`Start Backwash`** button (`button.<name>_backwash`) is automatically available - no unlock code required.
+
+- Pressing it sets the filtration mode to backwash (mode 13) and the controller opens the Besgo valve, then runs the cleaning cycle for the duration stored in the device (`MBF_PAR_FILTVALVE_INTERVAL`).
+- When switching **from manual filtration mode to backwash** on a device with a Besgo valve, the pump is intentionally **not** stopped before the mode change - this ensures the valve opens correctly under pressure.
+- On devices **without** a Besgo valve (manual multi-way valve), the pump IS stopped first so the user can safely rotate the valve before the backwash cycle begins.
+
+> **⚠️ WARNING:**
+> Always verify that your filtration system is correctly set up before triggering a backwash remotely.
+> **Improper use may damage your filtration system!**
 
 ---
 
@@ -205,7 +217,8 @@ Entities are lowercased and prefixed by your custom name, e.g. `sensor.pool1_fil
   `select.<name>_cell_boost` _(if supported)_,
   `select.<name>_relay_activation_delay`
 - **Buttons**:
-  `button.<name>_sync_time`, `button.<name>_escape`
+  `button.<name>_sync_time`, `button.<name>_escape`,
+  `button.<name>_backwash` _(if Besgo automatic filter valve is configured)_
 
 ---
 
@@ -215,7 +228,8 @@ Entities are lowercased and prefixed by your custom name, e.g. `sensor.pool1_fil
 - **Winter Mode:** Suspends all Modbus polling while keeping entities registered in Home Assistant (control entities become unavailable, sensors show unknown values). See [Winter Mode](#winter-mode) above.
 - **Timer resolution:** Can be set (in minutes) in integration Options.
 - **Entities cache last value** if there is a Modbus communication problem.
-- **Backwash and advanced options:** See above for details.
+- **Backwash (filtration mode select):** Hidden by default; unlock via advanced options. See above for details.
+- **Backwash button:** Automatically available when a Besgo automatic filter valve is configured on the device. See above for details.
 - **Reload on options change:** Integration is reloaded automatically on option changes.
 - **Filtration speed sensor/control:** Only available for variable-speed pump models.
 - **Boost control (select):** Only if Hydro/Electrolysis module is present.

--- a/custom_components/vistapool/button.py
+++ b/custom_components/vistapool/button.py
@@ -43,6 +43,11 @@ async def async_setup_entry(
         return
 
     for key, props in BUTTON_DEFINITIONS.items():
+        # BACKWASH button is only available when a Besgo filter valve is configured
+        if key == "BACKWASH" and not bool(
+            coordinator.data.get("MBF_PAR_FILTVALVE_ENABLE")
+        ):
+            continue
         entities.append(VistaPoolButton(coordinator, entry_id, key, props))
     async_add_entities(entities)
 
@@ -84,6 +89,24 @@ class VistaPoolButton(VistaPoolEntity, ButtonEntity):
             client = self.coordinator.client
             _LOGGER.debug("Clearing all possible errors...")
             await client.async_write_register(0x0297, 1)
+            await self.coordinator.async_request_refresh()
+        elif self._key == "BACKWASH":
+            filtvalve_enable = self.coordinator.data.get("MBF_PAR_FILTVALVE_ENABLE", 0)
+            if not filtvalve_enable:
+                _LOGGER.warning(
+                    "Backwash valve not configured (MBF_PAR_FILTVALVE_ENABLE=0) "
+                    "- ignoring backwash command for %s",
+                    self.coordinator.device_name,
+                )
+                return
+            client = self.coordinator.client
+            _LOGGER.info(
+                "Starting backwash on device '%s'", self.coordinator.device_name
+            )
+            # Set filtration mode to backwash (13 = MBV_PAR_FILT_BACKWASH).
+            # The device opens the configured Besgo valve and runs the filter
+            # cleaning cycle for the duration stored in MBF_PAR_FILTVALVE_INTERVAL.
+            await client.async_write_register(0x0411, 13)
             await self.coordinator.async_request_refresh()
 
     async def async_added_to_hass(self) -> None:  # pragma: no cover

--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -630,7 +630,7 @@ SELECT_DEFINITIONS = {
             2: "heating",
             3: "smart",
             4: "intelligent",
-            # 13: "backwash",
+            13: "backwash",
         },
         "register": 0x0411,  # FILTRATION_MODE_REGISTER
     },

--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -120,6 +120,7 @@ SENSOR_DEFINITIONS = {
         "unit": "%",
         "device_class": SensorDeviceClass.POWER_FACTOR,
         "state_class": SensorStateClass.MEASUREMENT,
+        "display_precision": 0,
     },
     "MBF_MEASURE_PH": {
         "name": "pH Level",
@@ -146,6 +147,7 @@ SENSOR_DEFINITIONS = {
         "unit": "%",
         "device_class": SensorDeviceClass.POWER_FACTOR,
         "state_class": SensorStateClass.MEASUREMENT,
+        "display_precision": 0,
     },
     "MBF_MEASURE_TEMPERATURE": {
         "name": "Water Temperature",
@@ -210,6 +212,7 @@ SENSOR_DEFINITIONS = {
         "device_class": SensorDeviceClass.DURATION,
         "state_class": SensorStateClass.MEASUREMENT,
         "icon": "mdi:timer-sand",
+        "display_precision": 0,
     },
 }
 

--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -606,6 +606,10 @@ BUTTON_DEFINITIONS = {
         "icon": "mdi:reload-alert",
         "entity_category": EntityCategory.CONFIG,
     },
+    "BACKWASH": {
+        "name": "Start Backwash",
+        "icon": "mdi:waves-arrow-left",
+    },
 }
 
 SELECT_DEFINITIONS = {

--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -652,6 +652,23 @@ SELECT_DEFINITIONS = {
         },
         "register": 0x020C,
     },
+    "MBF_PAR_FILTVALVE_PERIOD_MINUTES": {
+        "name": "Backwash Repeat Interval",
+        "icon": "mdi:timer-refresh-outline",
+        "entity_category": EntityCategory.CONFIG,
+        "options_map": {
+            1440: "1_day",
+            2880: "2_days",
+            4320: "3_days",
+            5760: "4_days",
+            7200: "5_days",
+            10080: "1_week",
+            20160: "2_weeks",
+            30240: "3_weeks",
+            40320: "4_weeks",
+        },
+        "register": 0x04ED,
+    },
     "MBF_PAR_INTELLIGENT_FILT_MIN_TIME": {
         "name": "Intelligent Min Filtration Time",
         "icon": "mdi:timer-lock-outline",

--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -204,6 +204,13 @@ SENSOR_DEFINITIONS = {
         "icon": "mdi:timeline-clock-outline",
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
+    "MBF_PAR_FILTVALVE_REMAINING": {
+        "name": "Backwash Time Remaining",
+        "unit": "s",
+        "device_class": SensorDeviceClass.DURATION,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "icon": "mdi:timer-sand",
+    },
 }
 
 BINARY_SENSOR_DEFINITIONS = {

--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -669,6 +669,19 @@ SELECT_DEFINITIONS = {
         },
         "register": 0x04ED,
     },
+    "MBF_PAR_FILTVALVE_MODE": {
+        "name": "Backwash Valve Mode",
+        "icon": "mdi:valve",
+        "entity_category": EntityCategory.CONFIG,
+        "options_map": {
+            # 0: "disabled",     # valve disabled – hidden (covered by MBF_PAR_FILTVALVE_ENABLE)
+            1: "enabled",  # timer-controlled (MBV_PAR_CTIMER_ENABLED)
+            # 2: "auto_linked",  # linked to parent relay – not applicable for filtvalve
+            3: "always_on",  # MBV_PAR_CTIMER_ALWAYS_ON
+            4: "always_off",  # MBV_PAR_CTIMER_ALWAYS_OFF
+        },
+        "register": 0x04E9,
+    },
     "MBF_PAR_INTELLIGENT_FILT_MIN_TIME": {
         "name": "Intelligent Min Filtration Time",
         "icon": "mdi:timer-lock-outline",

--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -70,6 +70,7 @@ CAPABILITY_KEYS = (
     "MBF_PAR_HIDRO_COVER_ENABLE",
     "MBF_PAR_PH_ACID_RELAY_GPIO",
     "MBF_PAR_PH_BASE_RELAY_GPIO",
+    "MBF_PAR_FILTVALVE_ENABLE",
     "pH measurement module detected",
     "Redox measurement module detected",
     "Chlorine measurement module detected",

--- a/custom_components/vistapool/modbus.py
+++ b/custom_components/vistapool/modbus.py
@@ -849,7 +849,9 @@ class VistaPoolModbusClient:
                     "MBF_PAR_RELAY_ACTIVATION_DELAY": get_safe(reg04, 43, lambda v: v + 10),    # 0x0433         Delay time in seconds for the pH pump when the measured pH value is outside the allowable pH setpoints. The system internally adds an extra time of 10 seconds to the value stored here. The pump starts the dosing operation once the condition of pH out of valid interval is maintained during the time specified in this register.
                     # FILTVALVE / backwash registers (0x04E8–0x04EF) at reg04 indices 44–51
                     "MBF_PAR_FILTVALVE_ENABLE": get_safe(reg04, 44),                            # 0x04E8        Filter cleaning mode (0 = off, 1 = Besgo valve)
+                    "MBF_PAR_FILTVALVE_MODE": get_safe(reg04, 45),                              # 0x04E9        Filter cleaning valve timing mode (MBV_PAR_CTIMER_ENABLED/ALWAYS_ON/ALWAYS_OFF)
                     "MBF_PAR_FILTVALVE_GPIO": get_safe(reg04, 46),                              # 0x04EA        Relay assigned to the filter cleaning function
+                    "MBF_PAR_FILTVALVE_PERIOD_MINUTES": get_safe(reg04, 49),                    # 0x04ED        Period in minutes between cleaning actions
                     "MBF_PAR_FILTVALVE_INTERVAL": get_safe(reg04, 50),                          # 0x04EE        Cleaning action duration in seconds
                     "MBF_PAR_FILTVALVE_REMAINING": get_safe(reg04, 51),                         # 0x04EF        Remaining backwash time in seconds (> 0 = backwash active)
 

--- a/custom_components/vistapool/modbus.py
+++ b/custom_components/vistapool/modbus.py
@@ -750,12 +750,16 @@ class VistaPoolModbusClient:
                 For configuration registers, we have to use function 0x03 (Read Holding Registers)
                 """
 
-                # Read configuration registers (0x0408–0x04E0) in blocks of *31* due to device limits
+                # Read configuration registers in multiple blocks due to device limits.
+                # Blocks covered:
+                #   0x0408–0x0426  (31 registers) - general config (relay GPIOs, offsets, etc.)
+                #   0x0427–0x0433  (13 registers) - pH/redox/chlorine config
+                #   0x0434–0x04E7  - TIMER_BLOCKS, read separately via read_all_timers()
+                #   0x04E8–0x04EF  ( 8 registers) - FILTVALVE / backwash valve config
                 rr04_ranges = [
                     (0x0408, 31),  # 0x0408–0x0426
                     (0x0427, 13),  # 0x0427–0x0433
-                    # TIMER_BLOCKS starts at 0x0434, so we skip 0x0434-0x04E8
-                    # (0x04E8, 9),  # 0x04F0-0x04E8
+                    (0x04E8, 8),  # 0x04E8–0x04EF  FILTVALVE / backwash registers
                 ]
 
                 reg04 = []
@@ -838,6 +842,11 @@ class VistaPoolModbusClient:
                     "MBF_PAR_RELAY_MAX_TIME": get_safe(reg04, 41),                              # 0x0431         Maximum amount of time in seconds, that a dosing pump can operate before rising an alarm signal. The behavior of the system when the dosing time is exceeded is regulated by the type of action stored in the MBF_PAR_RELAY_MODE register.
                     "MBF_PAR_RELAY_MODE": get_safe(reg04, 42),                                  # 0x0432         Behavior of the system when the dosing time is exceeded (see MBMSK_PAR_RELAY_MODE_* and MBV_PAR_RELAY_MODE_*)
                     "MBF_PAR_RELAY_ACTIVATION_DELAY": get_safe(reg04, 43, lambda v: v + 10),    # 0x0433         Delay time in seconds for the pH pump when the measured pH value is outside the allowable pH setpoints. The system internally adds an extra time of 10 seconds to the value stored here. The pump starts the dosing operation once the condition of pH out of valid interval is maintained during the time specified in this register.
+                    # FILTVALVE / backwash registers (0x04E8–0x04EF) at reg04 indices 44–51
+                    "MBF_PAR_FILTVALVE_ENABLE": get_safe(reg04, 44),                            # 0x04E8        Filter cleaning mode (0 = off, 1 = Besgo valve)
+                    "MBF_PAR_FILTVALVE_GPIO": get_safe(reg04, 46),                              # 0x04EA        Relay assigned to the filter cleaning function
+                    "MBF_PAR_FILTVALVE_INTERVAL": get_safe(reg04, 50),                          # 0x04EE        Cleaning action duration in seconds
+                    "MBF_PAR_FILTVALVE_REMAINING": get_safe(reg04, 51),                         # 0x04EF        Remaining backwash time in seconds (> 0 = backwash active)
 
                 })
                 # fmt: on
@@ -990,6 +999,7 @@ class VistaPoolModbusClient:
                     _LOGGER.debug(
                         "Could not clear MBF_NOTIFICATION (0x%04X)", notification
                     )
+
         except Exception as e:  # pragma: no cover
             self._failed_reads["unknown"] = self._failed_reads.get("unknown", 0) + 1
             raise ModbusException(f"Modbus TCP read error: {e}") from e

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -391,7 +391,11 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
                 "enable_backwash_option", False
             ) or bool(self.coordinator.data.get("MBF_PAR_FILTVALVE_ENABLE", 0))
             if not backwash_allowed:
-                option_keys = [k for k in option_keys if k != 13]
+                # Keep backwash (13) in the list if the device is currently in that
+                # mode, so current_option always matches one of the available options.
+                current_mode = self.coordinator.data.get("MBF_PAR_FILT_MODE")
+                if current_mode != 13:
+                    option_keys = [k for k in option_keys if k != 13]
 
         # Hide "Active (Redox control)" if no Redox module
         if self._key == "MBF_CELL_BOOST" and not bool(

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -517,6 +517,10 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
                 return None
             return self._options_map.get(value, f"{value}m")
 
+        if self._key == "MBF_PAR_FILTVALVE_MODE":
+            value = self.coordinator.data.get(self._key)
+            return self._options_map.get(value)
+
         value = self.coordinator.data.get(self._key)
         if value is None:  # pragma: no cover
             return None

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -298,9 +298,18 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
             if self._key == "MBF_PAR_FILT_MODE":
                 current_mode = self.coordinator.data.get(self._key)
                 current_name = self._options_map.get(current_mode)
+                has_auto_valve = bool(
+                    self.coordinator.data.get("MBF_PAR_FILTVALVE_ENABLE", 0)
+                )
+                # When leaving manual mode, stop the pump first - EXCEPT when
+                # switching to backwash on a device WITH an automatic valve (Besgo).
+                # In that case the pump must keep running so the valve opens correctly.
+                # For manual valve users the pump must stop so the user can safely
+                # rotate the multi-way valve before the backwash cycle begins.
                 if current_name == "manual" and option != "manual":
-                    await client.async_write_register(MANUAL_FILTRATION_REGISTER, 0)
-                    await asyncio.sleep(0.1)
+                    if not (option == "backwash" and has_auto_valve):
+                        await client.async_write_register(MANUAL_FILTRATION_REGISTER, 0)
+                        await asyncio.sleep(0.1)
             # Set the new mode
             await client.async_write_register(self._register, value)
             await asyncio.sleep(0.2)

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -70,6 +70,12 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                 coordinator.data.get("MBF_PAR_TEMPERATURE_ACTIVE")
             ):
                 continue
+        # Besgo-valve selects: only when MBF_PAR_FILTVALVE_ENABLE=1
+        if key in (
+            "MBF_PAR_FILTVALVE_PERIOD_MINUTES",
+            "MBF_PAR_FILTVALVE_MODE",
+        ) and not bool(coordinator.data.get("MBF_PAR_FILTVALVE_ENABLE")):
+            continue
 
         option_key = props.get("option")
         if option_key and not entry.options.get(option_key, False):
@@ -440,6 +446,14 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
                 return [f"{value}m"] + options
             return options
 
+        # Backwash repeat interval: same pattern as INTELLIGENT_FILT_MIN_TIME
+        if self._key == "MBF_PAR_FILTVALVE_PERIOD_MINUTES":
+            options = [self._options_map[k] for k in option_keys]
+            value = self.coordinator.data.get(self._key)
+            if isinstance(value, int) and value not in self._options_map:
+                return [f"{value}m"] + options
+            return options
+
         return [self._options_map[k] for k in option_keys]
 
     @property
@@ -495,6 +509,12 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
             if value is None:  # pragma: no cover
                 return None
             # Return mapped label or the raw minutes as string when unknown
+            return self._options_map.get(value, f"{value}m")
+
+        if self._key == "MBF_PAR_FILTVALVE_PERIOD_MINUTES":
+            value = self.coordinator.data.get(self._key)
+            if value is None:  # pragma: no cover
+                return None
             return self._options_map.get(value, f"{value}m")
 
         value = self.coordinator.data.get(self._key)

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -149,6 +149,24 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
             await self.coordinator.async_request_refresh()
             self.async_write_ha_state()
             return
+
+        # Backwash repeat interval: accept mapped labels (e.g. "1_day") or raw "Xm" strings
+        if self._key == "MBF_PAR_FILTVALVE_PERIOD_MINUTES":
+            reverse_map = {v: k for k, v in self._options_map.items()}
+            minutes = reverse_map.get(option)
+            if minutes is None:
+                try:
+                    if isinstance(option, str) and option.endswith("m"):
+                        minutes = int(option[:-1])
+                    else:  # pragma: no cover
+                        minutes = int(option)
+                except Exception:  # pragma: no cover
+                    return
+            await client.async_write_register(self._register or 0x04ED, minutes)
+            await asyncio.sleep(0.2)
+            await self.coordinator.async_request_refresh()
+            self.async_write_ha_state()
+            return
         if self._select_type == "timer_time":
             timer_name, field = self._key.rsplit("_", 1)
             entry_id = (
@@ -362,20 +380,17 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
             # Remove key for "smart"
             option_keys = [k for k in option_keys if k != 3]
 
-        # Add backwash option if:
+        # Show backwash option only if:
         # - explicitly enabled in advanced config options, OR
         # - a Besgo automatic filter valve is configured (MBF_PAR_FILTVALVE_ENABLE=1)
+        # The mapping (13 -> "backwash") is always present in options_map so that
+        # current_option and async_select_option work correctly regardless of
+        # whether options() has been evaluated first.
         if self._key == "MBF_PAR_FILT_MODE":
             backwash_allowed = self.coordinator.config_entry.options.get(
                 "enable_backwash_option", False
             ) or bool(self.coordinator.data.get("MBF_PAR_FILTVALVE_ENABLE", 0))
-            if backwash_allowed:
-                # Add backwash as the last option (key 13)
-                if 13 not in option_keys:  # pragma: no cover
-                    option_keys.append(13)
-                    self._options_map[13] = "backwash"
-            else:
-                # Remove key for "backwash" if it exists and not enabled
+            if not backwash_allowed:
                 option_keys = [k for k in option_keys if k != 13]
 
         # Hide "Active (Redox control)" if no Redox module

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -356,20 +356,21 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
             # Remove key for "smart"
             option_keys = [k for k in option_keys if k != 3]
 
-        # Add backwash option if enabled in config
-        if (
-            self._key == "MBF_PAR_FILT_MODE"
-            and self.coordinator.config_entry.options.get(
+        # Add backwash option if:
+        # - explicitly enabled in advanced config options, OR
+        # - a Besgo automatic filter valve is configured (MBF_PAR_FILTVALVE_ENABLE=1)
+        if self._key == "MBF_PAR_FILT_MODE":
+            backwash_allowed = self.coordinator.config_entry.options.get(
                 "enable_backwash_option", False
-            )
-        ):
-            # Add backwash as the last option (key 13)
-            if 13 not in option_keys:  # pragma: no cover
-                option_keys.append(13)
-                self._options_map[13] = "backwash"
-        else:
-            # Remove key for "backwash" if it exists and not enabled
-            option_keys = [k for k in option_keys if k != 13]
+            ) or bool(self.coordinator.data.get("MBF_PAR_FILTVALVE_ENABLE", 0))
+            if backwash_allowed:
+                # Add backwash as the last option (key 13)
+                if 13 not in option_keys:  # pragma: no cover
+                    option_keys.append(13)
+                    self._options_map[13] = "backwash"
+            else:
+                # Remove key for "backwash" if it exists and not enabled
+                option_keys = [k for k in option_keys if k != 13]
 
         # Hide "Active (Redox control)" if no Redox module
         if self._key == "MBF_CELL_BOOST" and not bool(

--- a/custom_components/vistapool/sensor.py
+++ b/custom_components/vistapool/sensor.py
@@ -118,6 +118,10 @@ async def async_setup_entry(
                 coordinator.data.get("MBF_PAR_TEMPERATURE_ACTIVE")
             ):
                 continue
+        if key == "MBF_PAR_FILTVALVE_REMAINING" and not bool(
+            coordinator.data.get("MBF_PAR_FILTVALVE_ENABLE")
+        ):
+            continue
 
         entities.append(
             VistaPoolSensor(

--- a/custom_components/vistapool/sensor.py
+++ b/custom_components/vistapool/sensor.py
@@ -153,6 +153,7 @@ class VistaPoolSensor(VistaPoolEntity, SensorEntity):
         self._attr_state_class = props.get("state_class") or None
         self._attr_entity_category = props.get("entity_category") or None
         self._attr_icon = props.get("icon") or None
+        self._attr_suggested_display_precision = props.get("display_precision")
 
         # Disable some entities by default.
         if self._attr_suggested_object_id.endswith("_voltage"):  # pragma: no cover
@@ -205,19 +206,19 @@ class VistaPoolSensor(VistaPoolEntity, SensorEntity):
     @property
     def suggested_display_precision(self) -> int | None:
         """Return the suggested display precision for the sensor value."""
-        if self._key == "MBF_HIDRO_CURRENT":
-            # Use 0 decimals for percent mode, 1 decimal for g/h mode
-            return 0 if is_hydrolysis_in_percent(self.coordinator.data) else 1
-        if self._key == "MBF_MEASURE_CONDUCTIVITY":
-            return 0
-        return None
+        if self._key == "MBF_HIDRO_CURRENT" and not is_hydrolysis_in_percent(
+            self.coordinator.data
+        ):
+            return 1
+        return self._attr_suggested_display_precision
 
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement for the sensor value."""
-        if self._key == "MBF_HIDRO_CURRENT":
-            # Dynamically determine unit based on machine configuration
-            return "%" if is_hydrolysis_in_percent(self.coordinator.data) else "g/h"
+        if self._key == "MBF_HIDRO_CURRENT" and not is_hydrolysis_in_percent(
+            self.coordinator.data
+        ):
+            return "g/h"
         return self._attr_native_unit_of_measurement
 
     @property

--- a/custom_components/vistapool/translations/cs.json
+++ b/custom_components/vistapool/translations/cs.json
@@ -131,7 +131,7 @@
       "intelligent_tt_next_interval": {
         "name": "Inteligentní režim: začátek příštího intervalu"
       },
-      "mbf_par_filtvalve_remaining": {
+      "filtvalve_remaining": {
         "name": "Zbývající čas proplachování"
       }
     },

--- a/custom_components/vistapool/translations/cs.json
+++ b/custom_components/vistapool/translations/cs.json
@@ -451,7 +451,21 @@
         }
       },
       "relay_activation_delay": { "name": "Zpoždění aktivace pH pumpy (s)" },
-      "intelligent_filt_min_time": { "name": "Inteligentní: Minimální doba filtrace" }
+      "intelligent_filt_min_time": { "name": "Inteligentní: Minimální doba filtrace" },
+      "filtvalve_period_minutes": {
+        "name": "Interval automatického proplachování",
+        "state": {
+          "1_day": "1 den",
+          "2_days": "2 dny",
+          "3_days": "3 dny",
+          "4_days": "4 dny",
+          "5_days": "5 dní",
+          "1_week": "1 týden",
+          "2_weeks": "2 týdny",
+          "3_weeks": "3 týdny",
+          "4_weeks": "4 týdny"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/vistapool/translations/cs.json
+++ b/custom_components/vistapool/translations/cs.json
@@ -204,7 +204,8 @@
     },
     "button": {
       "sync_time": { "name": "Synchronizovat čas zařízení" },
-      "escape": { "name": "Vymazat chybová hlášení" }
+      "escape": { "name": "Vymazat chybová hlášení" },
+      "backwash": { "name": "Spustit proplach" }
     },
     "select": {
       "filtration1_start": { "name": "Timer 1 - Spuštění filtrace" },

--- a/custom_components/vistapool/translations/cs.json
+++ b/custom_components/vistapool/translations/cs.json
@@ -465,6 +465,14 @@
           "3_weeks": "3 týdny",
           "4_weeks": "4 týdny"
         }
+      },
+      "filtvalve_mode": {
+        "name": "Režim ventilu zpětného proplachování",
+        "state": {
+          "enabled": "Automatický",
+          "always_on": "Vždy zapnuto",
+          "always_off": "Vždy vypnuto"
+        }
       }
     }
   },

--- a/custom_components/vistapool/translations/cs.json
+++ b/custom_components/vistapool/translations/cs.json
@@ -130,6 +130,9 @@
       },
       "intelligent_tt_next_interval": {
         "name": "Inteligentní režim: začátek příštího intervalu"
+      },
+      "mbf_par_filtvalve_remaining": {
+        "name": "Zbývající čas proplachování"
       }
     },
     "binary_sensor": {

--- a/custom_components/vistapool/translations/de.json
+++ b/custom_components/vistapool/translations/de.json
@@ -465,6 +465,14 @@
           "3_weeks": "3 Wochen",
           "4_weeks": "4 Wochen"
         }
+      },
+      "filtvalve_mode": {
+        "name": "Rückspülventil-Modus",
+        "state": {
+          "enabled": "Automatisch",
+          "always_on": "Immer An",
+          "always_off": "Immer Aus"
+        }
       }
     }
   },

--- a/custom_components/vistapool/translations/de.json
+++ b/custom_components/vistapool/translations/de.json
@@ -451,7 +451,21 @@
         }
       },
       "relay_activation_delay": { "name": "pH-Pumpenstartverzögerung (s)" },
-      "intelligent_filt_min_time": { "name": "Intelligent: Minimale Filterzeit" }
+      "intelligent_filt_min_time": { "name": "Intelligent: Minimale Filterzeit" },
+      "filtvalve_period_minutes": {
+        "name": "Rückspülintervall",
+        "state": {
+          "1_day": "1 Tag",
+          "2_days": "2 Tage",
+          "3_days": "3 Tage",
+          "4_days": "4 Tage",
+          "5_days": "5 Tage",
+          "1_week": "1 Woche",
+          "2_weeks": "2 Wochen",
+          "3_weeks": "3 Wochen",
+          "4_weeks": "4 Wochen"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/vistapool/translations/de.json
+++ b/custom_components/vistapool/translations/de.json
@@ -131,7 +131,7 @@
       "intelligent_tt_next_interval": {
         "name": "Intelligenter Modus: Beginn des nächsten Intervalls"
       },
-      "mbf_par_filtvalve_remaining": {
+      "filtvalve_remaining": {
         "name": "Verbleibende Rückspülzeit"
       }
     },

--- a/custom_components/vistapool/translations/de.json
+++ b/custom_components/vistapool/translations/de.json
@@ -204,7 +204,8 @@
     },
     "button": {
       "sync_time": { "name": "Gerätezeit synchronisieren" },
-      "escape": { "name": "Fehlermeldungen löschen" }
+      "escape": { "name": "Fehlermeldungen löschen" },
+      "backwash": { "name": "Rückspülung starten" }
     },
     "select": {
       "filtration1_start": { "name": "Timer 1 - Filtration Start" },

--- a/custom_components/vistapool/translations/de.json
+++ b/custom_components/vistapool/translations/de.json
@@ -130,6 +130,9 @@
       },
       "intelligent_tt_next_interval": {
         "name": "Intelligenter Modus: Beginn des nächsten Intervalls"
+      },
+      "mbf_par_filtvalve_remaining": {
+        "name": "Verbleibende Rückspülzeit"
       }
     },
     "binary_sensor": {

--- a/custom_components/vistapool/translations/en.json
+++ b/custom_components/vistapool/translations/en.json
@@ -131,7 +131,7 @@
       "intelligent_tt_next_interval": {
         "name": "Intelligent Mode Next Interval Start"
       },
-      "mbf_par_filtvalve_remaining": {
+      "filtvalve_remaining": {
         "name": "Backwash Time Remaining"
       }
     },

--- a/custom_components/vistapool/translations/en.json
+++ b/custom_components/vistapool/translations/en.json
@@ -451,7 +451,21 @@
         }
       },
       "relay_activation_delay": { "name": "pH pump activation delay (s)" },
-      "intelligent_filt_min_time": { "name": "Intelligent: Minimum Filtration Time" }
+      "intelligent_filt_min_time": { "name": "Intelligent: Minimum Filtration Time" },
+      "filtvalve_period_minutes": {
+        "name": "Backwash Repeat Interval",
+        "state": {
+          "1_day": "1 day",
+          "2_days": "2 days",
+          "3_days": "3 days",
+          "4_days": "4 days",
+          "5_days": "5 days",
+          "1_week": "1 week",
+          "2_weeks": "2 weeks",
+          "3_weeks": "3 weeks",
+          "4_weeks": "4 weeks"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/vistapool/translations/en.json
+++ b/custom_components/vistapool/translations/en.json
@@ -465,6 +465,14 @@
           "3_weeks": "3 weeks",
           "4_weeks": "4 weeks"
         }
+      },
+      "filtvalve_mode": {
+        "name": "Backwash Valve Mode",
+        "state": {
+          "enabled": "Automatic",
+          "always_on": "Always On",
+          "always_off": "Always Off"
+        }
       }
     }
   },

--- a/custom_components/vistapool/translations/en.json
+++ b/custom_components/vistapool/translations/en.json
@@ -204,7 +204,8 @@
     },
     "button": {
       "sync_time": { "name": "Synchronize Device Time" },
-      "escape": { "name": "Clear Error Messages" }
+      "escape": { "name": "Clear Error Messages" },
+      "backwash": { "name": "Start Backwash" }
     },
     "select": {
       "filtration1_start": { "name": "Timer 1 - Filtration Start" },

--- a/custom_components/vistapool/translations/en.json
+++ b/custom_components/vistapool/translations/en.json
@@ -130,6 +130,9 @@
       },
       "intelligent_tt_next_interval": {
         "name": "Intelligent Mode Next Interval Start"
+      },
+      "mbf_par_filtvalve_remaining": {
+        "name": "Backwash Time Remaining"
       }
     },
     "binary_sensor": {

--- a/custom_components/vistapool/translations/es.json
+++ b/custom_components/vistapool/translations/es.json
@@ -204,7 +204,8 @@
     },
     "button": {
       "sync_time": { "name": "Sincronizar hora del dispositivo" },
-      "escape": { "name": "Borrar mensajes de error" }
+      "escape": { "name": "Borrar mensajes de error" },
+      "backwash": { "name": "Iniciar retrolavado" }
     },
     "select": {
       "filtration1_start": { "name": "Temporizador 1 - Inicio de filtración" },

--- a/custom_components/vistapool/translations/es.json
+++ b/custom_components/vistapool/translations/es.json
@@ -131,7 +131,7 @@
       "intelligent_tt_next_interval": {
         "name": "Modo inteligente: inicio del próximo intervalo"
       },
-      "mbf_par_filtvalve_remaining": {
+      "filtvalve_remaining": {
         "name": "Tiempo restante de retrolavado"
       }
     },

--- a/custom_components/vistapool/translations/es.json
+++ b/custom_components/vistapool/translations/es.json
@@ -465,6 +465,14 @@
           "3_weeks": "3 semanas",
           "4_weeks": "4 semanas"
         }
+      },
+      "filtvalve_mode": {
+        "name": "Modo de válvula de retrolavado",
+        "state": {
+          "enabled": "Automático",
+          "always_on": "Siempre Activo",
+          "always_off": "Siempre Inactivo"
+        }
       }
     }
   },

--- a/custom_components/vistapool/translations/es.json
+++ b/custom_components/vistapool/translations/es.json
@@ -451,7 +451,21 @@
         }
       },
       "relay_activation_delay": { "name": "Retardo de activación de la bomba de pH (s)" },
-      "intelligent_filt_min_time": { "name": "Inteligente: Tiempo mínimo de filtración" }
+      "intelligent_filt_min_time": { "name": "Inteligente: Tiempo mínimo de filtración" },
+      "filtvalve_period_minutes": {
+        "name": "Intervalo de retrolavado automático",
+        "state": {
+          "1_day": "1 día",
+          "2_days": "2 días",
+          "3_days": "3 días",
+          "4_days": "4 días",
+          "5_days": "5 días",
+          "1_week": "1 semana",
+          "2_weeks": "2 semanas",
+          "3_weeks": "3 semanas",
+          "4_weeks": "4 semanas"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/vistapool/translations/es.json
+++ b/custom_components/vistapool/translations/es.json
@@ -130,6 +130,9 @@
       },
       "intelligent_tt_next_interval": {
         "name": "Modo inteligente: inicio del próximo intervalo"
+      },
+      "mbf_par_filtvalve_remaining": {
+        "name": "Tiempo restante de retrolavado"
       }
     },
     "binary_sensor": {

--- a/custom_components/vistapool/translations/fr.json
+++ b/custom_components/vistapool/translations/fr.json
@@ -451,7 +451,21 @@
         }
       },
       "relay_activation_delay": { "name": "Délai d'activation de la pompe pH (s)" },
-      "intelligent_filt_min_time": { "name": "Intelligent: Temps minimum de filtration" }
+      "intelligent_filt_min_time": { "name": "Intelligent: Temps minimum de filtration" },
+      "filtvalve_period_minutes": {
+        "name": "Intervalle de rétrolavage automatique",
+        "state": {
+          "1_day": "1 jour",
+          "2_days": "2 jours",
+          "3_days": "3 jours",
+          "4_days": "4 jours",
+          "5_days": "5 jours",
+          "1_week": "1 semaine",
+          "2_weeks": "2 semaines",
+          "3_weeks": "3 semaines",
+          "4_weeks": "4 semaines"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/vistapool/translations/fr.json
+++ b/custom_components/vistapool/translations/fr.json
@@ -465,6 +465,14 @@
           "3_weeks": "3 semaines",
           "4_weeks": "4 semaines"
         }
+      },
+      "filtvalve_mode": {
+        "name": "Mode de la vanne de rétrolavage",
+        "state": {
+          "enabled": "Automatique",
+          "always_on": "Toujours Activé",
+          "always_off": "Toujours Désactivé"
+        }
       }
     }
   },

--- a/custom_components/vistapool/translations/fr.json
+++ b/custom_components/vistapool/translations/fr.json
@@ -131,7 +131,7 @@
       "intelligent_tt_next_interval": {
         "name": "Mode intelligent : début du prochain intervalle"
       },
-      "mbf_par_filtvalve_remaining": {
+      "filtvalve_remaining": {
         "name": "Temps restant du rétrolavage"
       }
     },

--- a/custom_components/vistapool/translations/fr.json
+++ b/custom_components/vistapool/translations/fr.json
@@ -130,6 +130,9 @@
       },
       "intelligent_tt_next_interval": {
         "name": "Mode intelligent : début du prochain intervalle"
+      },
+      "mbf_par_filtvalve_remaining": {
+        "name": "Temps restant du rétrolavage"
       }
     },
     "binary_sensor": {

--- a/custom_components/vistapool/translations/fr.json
+++ b/custom_components/vistapool/translations/fr.json
@@ -204,7 +204,8 @@
     },
     "button": {
       "sync_time": { "name": "Synchroniser l’heure de l’appareil" },
-      "escape": { "name": "Effacer les messages d’erreur" }
+      "escape": { "name": "Effacer les messages d'erreur" },
+      "backwash": { "name": "Démarrer le contre-lavage" }
     },
     "select": {
       "filtration1_start": { "name": "Minuteur 1 - Début de filtration" },

--- a/custom_components/vistapool/translations/it.json
+++ b/custom_components/vistapool/translations/it.json
@@ -451,7 +451,21 @@
         }
       },
       "relay_activation_delay": { "name": "Ritardo di attivazione pompa pH (s)" },
-      "intelligent_filt_min_time": { "name": "Intelligente: Tempo minimo di filtrazione" }
+      "intelligent_filt_min_time": { "name": "Intelligente: Tempo minimo di filtrazione" },
+      "filtvalve_period_minutes": {
+        "name": "Intervallo di controlavaggio automatico",
+        "state": {
+          "1_day": "1 giorno",
+          "2_days": "2 giorni",
+          "3_days": "3 giorni",
+          "4_days": "4 giorni",
+          "5_days": "5 giorni",
+          "1_week": "1 settimana",
+          "2_weeks": "2 settimane",
+          "3_weeks": "3 settimane",
+          "4_weeks": "4 settimane"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/vistapool/translations/it.json
+++ b/custom_components/vistapool/translations/it.json
@@ -204,7 +204,8 @@
     },
     "button": {
       "sync_time": { "name": "Sincronizza orario dispositivo" },
-      "escape": { "name": "Cancella messaggi di errore" }
+      "escape": { "name": "Cancella messaggi di errore" },
+      "backwash": { "name": "Avvia controlavaggio" }
     },
     "select": {
       "filtration1_start": { "name": "Timer 1 - Inizio filtrazione" },

--- a/custom_components/vistapool/translations/it.json
+++ b/custom_components/vistapool/translations/it.json
@@ -465,6 +465,14 @@
           "3_weeks": "3 settimane",
           "4_weeks": "4 settimane"
         }
+      },
+      "filtvalve_mode": {
+        "name": "Modalità valvola di controlavaggio",
+        "state": {
+          "enabled": "Automatico",
+          "always_on": "Sempre Attivo",
+          "always_off": "Sempre Disattivo"
+        }
       }
     }
   },

--- a/custom_components/vistapool/translations/it.json
+++ b/custom_components/vistapool/translations/it.json
@@ -131,7 +131,7 @@
       "intelligent_tt_next_interval": {
         "name": "Modalità intelligente: inizio del prossimo intervallo"
       },
-      "mbf_par_filtvalve_remaining": {
+      "filtvalve_remaining": {
         "name": "Tempo rimanente di controlavaggio"
       }
     },

--- a/custom_components/vistapool/translations/it.json
+++ b/custom_components/vistapool/translations/it.json
@@ -130,6 +130,9 @@
       },
       "intelligent_tt_next_interval": {
         "name": "Modalità intelligente: inizio del prossimo intervallo"
+      },
+      "mbf_par_filtvalve_remaining": {
+        "name": "Tempo rimanente di controlavaggio"
       }
     },
     "binary_sensor": {

--- a/custom_components/vistapool/translations/pl.json
+++ b/custom_components/vistapool/translations/pl.json
@@ -451,7 +451,21 @@
         }
       },
       "relay_activation_delay": { "name": "Opóźnienie uruchomienia pompy pH (s)" },
-      "intelligent_filt_min_time": { "name": "Inteligentny: Minimalny czas filtracji" }
+      "intelligent_filt_min_time": { "name": "Inteligentny: Minimalny czas filtracji" },
+      "filtvalve_period_minutes": {
+        "name": "Interwał automatycznego płukania wstecznego",
+        "state": {
+          "1_day": "1 dzień",
+          "2_days": "2 dni",
+          "3_days": "3 dni",
+          "4_days": "4 dni",
+          "5_days": "5 dni",
+          "1_week": "1 tydzień",
+          "2_weeks": "2 tygodnie",
+          "3_weeks": "3 tygodnie",
+          "4_weeks": "4 tygodnie"
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/vistapool/translations/pl.json
+++ b/custom_components/vistapool/translations/pl.json
@@ -465,6 +465,14 @@
           "3_weeks": "3 tygodnie",
           "4_weeks": "4 tygodnie"
         }
+      },
+      "filtvalve_mode": {
+        "name": "Tryb zaworu płukania wstecznego",
+        "state": {
+          "enabled": "Automatyczny",
+          "always_on": "Zawsze Włączony",
+          "always_off": "Zawsze Wyłączony"
+        }
       }
     }
   },

--- a/custom_components/vistapool/translations/pl.json
+++ b/custom_components/vistapool/translations/pl.json
@@ -204,7 +204,8 @@
     },
     "button": {
       "sync_time": { "name": "Synchronizuj czas urządzenia" },
-      "escape": { "name": "Wyczyść komunikaty o błędach" }
+      "escape": { "name": "Wyczyść komunikaty o błędach" },
+      "backwash": { "name": "Uruchom płukanie wsteczne" }
     },
     "select": {
       "filtration1_start": { "name": "Timer 1 - Start filtracji" },

--- a/custom_components/vistapool/translations/pl.json
+++ b/custom_components/vistapool/translations/pl.json
@@ -131,7 +131,7 @@
       "intelligent_tt_next_interval": {
         "name": "Tryb inteligentny: początek następnego interwału"
       },
-      "mbf_par_filtvalve_remaining": {
+      "filtvalve_remaining": {
         "name": "Pozostały czas płukania wstecznego"
       }
     },

--- a/custom_components/vistapool/translations/pl.json
+++ b/custom_components/vistapool/translations/pl.json
@@ -130,6 +130,9 @@
       },
       "intelligent_tt_next_interval": {
         "name": "Tryb inteligentny: początek następnego interwału"
+      },
+      "mbf_par_filtvalve_remaining": {
+        "name": "Pozostały czas płukania wstecznego"
       }
     },
     "binary_sensor": {

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -134,3 +134,30 @@ def test_available_false_during_winter_mode(mock_coordinator):
     props = {"name": "Sync Time", "icon": "mdi:clock"}
     ent = VistaPoolButton(mock_coordinator, "test_entry", "SYNC_TIME", props)
     assert ent.available is False
+
+
+@pytest.mark.asyncio
+async def test_button_press_backwash_with_valve(mock_coordinator, caplog):
+    """async_press for BACKWASH writes mode 13 when filtvalve is configured."""
+    mock_coordinator.data = {"MBF_PAR_FILTVALVE_ENABLE": 1}
+    mock_coordinator.device_name = "Test Pool"
+    props = {"name": "Start Backwash", "icon": "mdi:waves-arrow-left"}
+    ent = VistaPoolButton(mock_coordinator, "test_entry", "BACKWASH", props)
+    ent.hass = MagicMock()
+    await ent.async_press()
+    mock_coordinator.client.async_write_register.assert_awaited_once_with(0x0411, 13)
+    mock_coordinator.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_button_press_backwash_no_valve(mock_coordinator, caplog):
+    """async_press for BACKWASH logs warning and does nothing when valve not configured."""
+    mock_coordinator.data = {"MBF_PAR_FILTVALVE_ENABLE": 0}
+    mock_coordinator.device_name = "Test Pool"
+    props = {"name": "Start Backwash", "icon": "mdi:waves-arrow-left"}
+    ent = VistaPoolButton(mock_coordinator, "test_entry", "BACKWASH", props)
+    ent.hass = MagicMock()
+    with caplog.at_level("WARNING"):
+        await ent.async_press()
+    mock_coordinator.client.async_write_register.assert_not_called()
+    assert "MBF_PAR_FILTVALVE_ENABLE=0" in caplog.text

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -330,7 +330,7 @@ async def test_perform_read_all_happy_path(config, monkeypatch):
 
     # Setup values for all reads in the order used in _perform_read_all:
     # rr00 (holding), rr01 (input), rr02 (holding), rr02_hidro (holding),
-    # rr03 (2x holding), rr04 (2x holding), rr05 (holding), rr06 (holding)
+    # rr03 (2x holding), rr04 (3x holding), rr05 (holding), rr06 (holding)
     fake_modbus.read_holding_registers = AsyncMock(
         side_effect=[
             DummyResp(
@@ -382,6 +382,7 @@ async def test_perform_read_all_happy_path(config, monkeypatch):
             DummyResp(list(range(14, 18))),  # factory block 2 (0x0322, 4)
             DummyResp(list(range(1, 32))),  # installer block 1 (0x0408, 31)
             DummyResp(list(range(32, 45))),  # installer block 2 (0x0427, 13)
+            DummyResp([0] * 8),  # installer block 3 (0x04E8, 8) FILTVALVE
             DummyResp([650, 0, 750, 700, 0, 0, 700, 0, 100, 0, 0, 0, 5000, 0]),  # rr05
             DummyResp([9, 6, 25604, 5, 0, 2240, 545, 1281, 0, 0, 0, 0, 0]),  # rr06
         ]
@@ -428,7 +429,7 @@ async def test_perform_read_all_happy_path(config, monkeypatch):
     assert "FILTRATION_SPEED" in result
 
     # Verify that all Modbus calls were made as expected
-    assert fake_modbus.read_holding_registers.await_count == 9
+    assert fake_modbus.read_holding_registers.await_count == 10
     assert fake_modbus.read_input_registers.await_count == 1
 
 
@@ -445,6 +446,7 @@ async def test_perform_read_all_happy_path(config, monkeypatch):
         ("rr03-2", "read_holding_registers", "0x0322", "iserror"),
         ("rr04-1", "read_holding_registers", "0x0408", "exception"),
         ("rr04-2", "read_holding_registers", "0x0427", "exception"),
+        ("rr04-3", "read_holding_registers", "0x04E8", "exception"),
         ("rr05", "read_holding_registers", "0x0502", "iserror"),
         ("rr06", "read_holding_registers", "0x0600", "iserror"),
     ],
@@ -475,6 +477,7 @@ async def test_perform_read_all_raises_on_block(
         "rr03-2",
         "rr04-1",
         "rr04-2",
+        "rr04-3",
         "rr05",
         "rr06",
     ]
@@ -489,6 +492,7 @@ async def test_perform_read_all_raises_on_block(
         "rr03-2": DummyResp([0] * 4),
         "rr04-1": DummyResp([0] * 31),
         "rr04-2": DummyResp([0] * 13),
+        "rr04-3": DummyResp([0] * 8),
         "rr05": DummyResp([0] * 14),
         "rr06": DummyResp([0] * 13),
     }
@@ -547,6 +551,7 @@ async def test_perform_read_all_raises_on_block(
         ("rr03-2", 0x0322),
         ("rr04-1", 0x0408),
         ("rr04-2", 0x0427),
+        ("rr04-3", 0x04E8),
         ("rr05", 0x0502),
         ("rr06", 0x0600),
     ],
@@ -579,6 +584,7 @@ async def test_perform_read_all_block_exception(
         ("rr03-2", DummyResp([0] * 4)),
         ("rr04-1", DummyResp([0] * 31)),
         ("rr04-2", DummyResp([0] * 13)),
+        ("rr04-3", DummyResp([0] * 8)),
         ("rr05", DummyResp([0] * 14)),
         ("rr06", DummyResp([0] * 13)),
     ]
@@ -591,7 +597,7 @@ async def test_perform_read_all_block_exception(
         else:
             rh_side_effect.append(resp)
 
-    # holding: rr00, rr02, rr02_hidro, rr03-01, rr03-02, rr04-1, rr04-2, rr05, rr06 (total 9 calls)
+    # holding: rr00, rr02, rr02_hidro, rr03-01, rr03-02, rr04-1, rr04-2, rr04-3, rr05, rr06 (total 10 calls)
     # input: rr01 (only one call)
     fake_modbus.read_holding_registers = AsyncMock(
         side_effect=[
@@ -602,8 +608,9 @@ async def test_perform_read_all_block_exception(
             rh_side_effect[5],  # rr03-2 (0x0322)
             rh_side_effect[6],  # rr04-1 (0x0408)
             rh_side_effect[7],  # rr04-2 (0x0427)
-            rh_side_effect[8],  # rr05 (0x0502)
-            rh_side_effect[9],  # rr06 (0x0600)
+            rh_side_effect[8],  # rr04-3 (0x04E8)
+            rh_side_effect[9],  # rr05 (0x0502)
+            rh_side_effect[10],  # rr06 (0x0600)
         ]
     )
     fake_modbus.read_input_registers = AsyncMock(

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -1514,7 +1514,7 @@ async def test_perform_read_all_force_full_after_interval(config, monkeypatch):
             _measure_regs(notification=0)
         )  # no notification bits set
     )
-    # Full read: rr00(1) + rr02(1) + rr02_hidro(1) + rr03(2) + rr04(2) + rr05(1) + rr06(1) = 9 calls
+    # Full read: rr00(1) + rr02(1) + rr02_hidro(1) + rr03(2) + rr04(3) + rr05(1) + rr06(1) = 10 calls
     fake_modbus.read_holding_registers = AsyncMock(
         side_effect=[
             _DummyResp([0] * 16),  # rr00
@@ -1524,6 +1524,7 @@ async def test_perform_read_all_force_full_after_interval(config, monkeypatch):
             _DummyResp([0] * 4),  # rr03-2
             _DummyResp([0] * 31),  # rr04-1
             _DummyResp([0] * 13),  # rr04-2
+            _DummyResp([0] * 8),  # rr04-3 (FILTVALVE 0x04E8)
             _DummyResp([0] * 14),  # rr05
             _DummyResp([0] * 13),  # rr06
         ]
@@ -1533,7 +1534,7 @@ async def test_perform_read_all_force_full_after_interval(config, monkeypatch):
 
     result = await client._perform_read_all()
 
-    assert fake_modbus.read_holding_registers.await_count == 9
+    assert fake_modbus.read_holding_registers.await_count == 10
     assert client._polls_since_full_read == 0  # was reset after full read
     assert isinstance(result, dict)
 
@@ -1638,6 +1639,7 @@ async def test_perform_read_all_poll_counter_resets_on_full_read(config, monkeyp
             _DummyResp([0] * 4),  # rr03-2
             _DummyResp([0] * 31),  # rr04-1
             _DummyResp([0] * 13),  # rr04-2
+            _DummyResp([0] * 8),  # rr04-3 (FILTVALVE 0x04E8)
             _DummyResp([0] * 14),  # rr05
             _DummyResp([0] * 13),  # rr06
         ]
@@ -1730,11 +1732,12 @@ async def test_perform_read_all_reads_installer_and_user_when_both_notified(
     fake_modbus.read_input_registers = AsyncMock(
         return_value=_DummyResp(_measure_regs(notification=notification))
     )
-    # INSTALLER: 2 blocks (0x0408+0x0427), USER: 1 block (0x0502) = 3 holding calls total
+    # INSTALLER: 3 blocks (0x0408+0x0427+0x04E8), USER: 1 block (0x0502) = 4 holding calls total
     fake_modbus.read_holding_registers = AsyncMock(
         side_effect=[
             _DummyResp([0] * 31),  # rr04-1
             _DummyResp([0] * 13),  # rr04-2
+            _DummyResp([0] * 8),  # rr04-3 (FILTVALVE 0x04E8)
             _DummyResp([0] * 14),  # rr05
         ]
     )
@@ -1743,7 +1746,7 @@ async def test_perform_read_all_reads_installer_and_user_when_both_notified(
 
     result = await client._perform_read_all()
 
-    assert fake_modbus.read_holding_registers.await_count == 3
+    assert fake_modbus.read_holding_registers.await_count == 4
     assert isinstance(result, dict)
 
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -97,6 +97,27 @@ def test_options_add_backwash(mock_coordinator):
     assert "backwash" in opts
 
 
+def test_options_add_backwash_via_filtvalve(mock_coordinator):
+    """Backwash must appear automatically when MBF_PAR_FILTVALVE_ENABLE=1 (Besgo valve),
+    even without enable_backwash_option in config options."""
+    props = make_props(options_map={0: "auto", 1: "manual", 2: "off", 13: "backwash"})
+    ent = VistaPoolSelect(mock_coordinator, "test_entry", "MBF_PAR_FILT_MODE", props)
+    mock_coordinator.data = {"MBF_PAR_FILTVALVE_ENABLE": 1}
+    mock_coordinator.config_entry.options = {}
+    opts = ent.options
+    assert "backwash" in opts
+
+
+def test_options_no_backwash_without_valve_or_option(mock_coordinator):
+    """Backwash must be hidden when neither enable_backwash_option nor Besgo valve."""
+    props = make_props(options_map={0: "auto", 1: "manual", 2: "off", 13: "backwash"})
+    ent = VistaPoolSelect(mock_coordinator, "test_entry", "MBF_PAR_FILT_MODE", props)
+    mock_coordinator.data = {"MBF_PAR_FILTVALVE_ENABLE": 0}
+    mock_coordinator.config_entry.options = {}
+    opts = ent.options
+    assert "backwash" not in opts
+
+
 def test_options_timer_time(mock_coordinator):
     from custom_components.vistapool.helpers import (
         hhmm_to_seconds,

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -881,3 +881,110 @@ def test_select_filtvalve_period_minutes_options_prepend_unknown(mock_coordinato
     opts = ent.options
     assert opts[0] == "999m"
     assert "1_day" in opts
+
+
+def test_select_filtvalve_period_minutes_options_known_value(mock_coordinator):
+    """options returns standard list without prepend when device holds a known value."""
+    from custom_components.vistapool.const import SELECT_DEFINITIONS
+
+    props = SELECT_DEFINITIONS["MBF_PAR_FILTVALVE_PERIOD_MINUTES"]
+    ent = VistaPoolSelect(
+        mock_coordinator, "test_entry", "MBF_PAR_FILTVALVE_PERIOD_MINUTES", props
+    )
+    mock_coordinator.data = {"MBF_PAR_FILTVALVE_PERIOD_MINUTES": 1440}
+    opts = ent.options
+    assert opts[0] == "1_day"
+    assert "999m" not in opts
+
+
+# MBF_PAR_FILTVALVE_MODE select tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_select_filtvalve_mode_skipped_without_besgo(mock_coordinator):
+    """MBF_PAR_FILTVALVE_MODE select must be skipped when Besgo valve is not configured."""
+    from custom_components.vistapool.select import async_setup_entry
+
+    class DummyEntry:
+        entry_id = "test_entry"
+        options = {}
+
+    class DummyCoordinator:
+        config_entry = DummyEntry()
+        device_slug = "vistapool"
+        data = {"MBF_PAR_FILTVALVE_ENABLE": 0}
+
+    from unittest.mock import MagicMock
+
+    hass = MagicMock()
+    hass.data = {"vistapool": {"test_entry": DummyCoordinator()}}
+    entry = DummyEntry()
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(hass, entry, async_add_entities)
+
+    keys = [e._key for e in async_add_entities.call_args[0][0]]
+    assert "MBF_PAR_FILTVALVE_MODE" not in keys
+
+
+@pytest.mark.asyncio
+async def test_select_filtvalve_mode_created_with_besgo(mock_coordinator):
+    """MBF_PAR_FILTVALVE_MODE select must be created when Besgo valve is configured."""
+    from custom_components.vistapool.select import async_setup_entry
+
+    class DummyEntry:
+        entry_id = "test_entry"
+        options = {}
+
+    class DummyCoordinator:
+        config_entry = DummyEntry()
+        device_slug = "vistapool"
+        data = {"MBF_PAR_FILTVALVE_ENABLE": 1, "MBF_PAR_FILTVALVE_MODE": 1}
+
+    from unittest.mock import MagicMock
+
+    hass = MagicMock()
+    hass.data = {"vistapool": {"test_entry": DummyCoordinator()}}
+    entry = DummyEntry()
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(hass, entry, async_add_entities)
+
+    keys = [e._key for e in async_add_entities.call_args[0][0]]
+    assert "MBF_PAR_FILTVALVE_MODE" in keys
+
+
+@pytest.mark.parametrize(
+    "raw_value, expected_option",
+    [
+        (1, "enabled"),
+        (3, "always_on"),
+        (4, "always_off"),
+        (0, None),  # disabled – not in options_map, returns None
+    ],
+)
+def test_select_filtvalve_mode_current_option(
+    mock_coordinator, raw_value, expected_option
+):
+    """current_option maps CTIMER enum values to the correct option strings."""
+    from custom_components.vistapool.const import SELECT_DEFINITIONS
+
+    props = SELECT_DEFINITIONS["MBF_PAR_FILTVALVE_MODE"]
+    ent = VistaPoolSelect(
+        mock_coordinator, "test_entry", "MBF_PAR_FILTVALVE_MODE", props
+    )
+    mock_coordinator.data = {"MBF_PAR_FILTVALVE_MODE": raw_value}
+    assert ent.current_option == expected_option
+
+
+def test_select_filtvalve_mode_options(mock_coordinator):
+    """options returns the three valid CTIMER mode strings."""
+    from custom_components.vistapool.const import SELECT_DEFINITIONS
+
+    props = SELECT_DEFINITIONS["MBF_PAR_FILTVALVE_MODE"]
+    ent = VistaPoolSelect(
+        mock_coordinator, "test_entry", "MBF_PAR_FILTVALVE_MODE", props
+    )
+    mock_coordinator.data = {"MBF_PAR_FILTVALVE_MODE": 1}
+    assert ent.options == ["enabled", "always_on", "always_off"]

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -784,3 +784,100 @@ def test_available_false_during_winter_mode(mock_coordinator):
     props = {"register": 0x0412, "options_map": {1: "Manual", 2: "Auto"}}
     ent = VistaPoolSelect(mock_coordinator, "test_entry", "MBF_PAR_FILT_MODE", props)
     assert ent.available is False
+
+
+# ---------------------------------------------------------------------------
+# MBF_PAR_FILTVALVE_PERIOD_MINUTES select tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_select_filtvalve_period_minutes_skipped_without_besgo(mock_coordinator):
+    """MBF_PAR_FILTVALVE_PERIOD_MINUTES select must be skipped when Besgo valve is not configured."""
+    from custom_components.vistapool.select import async_setup_entry
+
+    class DummyEntry:
+        entry_id = "test_entry"
+        options = {}
+
+    class DummyCoordinator:
+        config_entry = DummyEntry()
+        device_slug = "vistapool"
+        data = {"MBF_PAR_FILTVALVE_ENABLE": 0}
+
+    from unittest.mock import MagicMock
+
+    hass = MagicMock()
+    hass.data = {"vistapool": {"test_entry": DummyCoordinator()}}
+    entry = DummyEntry()
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(hass, entry, async_add_entities)
+
+    keys = [e._key for e in async_add_entities.call_args[0][0]]
+    assert "MBF_PAR_FILTVALVE_PERIOD_MINUTES" not in keys
+
+
+@pytest.mark.asyncio
+async def test_select_filtvalve_period_minutes_created_with_besgo(mock_coordinator):
+    """MBF_PAR_FILTVALVE_PERIOD_MINUTES select must be created when Besgo valve is configured."""
+    from custom_components.vistapool.select import async_setup_entry
+
+    class DummyEntry:
+        entry_id = "test_entry"
+        options = {}
+
+    class DummyCoordinator:
+        config_entry = DummyEntry()
+        device_slug = "vistapool"
+        data = {"MBF_PAR_FILTVALVE_ENABLE": 1, "MBF_PAR_FILTVALVE_PERIOD_MINUTES": 1440}
+
+    from unittest.mock import MagicMock
+
+    hass = MagicMock()
+    hass.data = {"vistapool": {"test_entry": DummyCoordinator()}}
+    entry = DummyEntry()
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(hass, entry, async_add_entities)
+
+    keys = [e._key for e in async_add_entities.call_args[0][0]]
+    assert "MBF_PAR_FILTVALVE_PERIOD_MINUTES" in keys
+
+
+def test_select_filtvalve_period_minutes_current_option_known(mock_coordinator):
+    """current_option returns the mapped label for a known minute value."""
+    from custom_components.vistapool.const import SELECT_DEFINITIONS
+
+    props = SELECT_DEFINITIONS["MBF_PAR_FILTVALVE_PERIOD_MINUTES"]
+    ent = VistaPoolSelect(
+        mock_coordinator, "test_entry", "MBF_PAR_FILTVALVE_PERIOD_MINUTES", props
+    )
+    mock_coordinator.data = {"MBF_PAR_FILTVALVE_PERIOD_MINUTES": 1440}
+    assert ent.current_option == "1_day"
+
+
+def test_select_filtvalve_period_minutes_current_option_unknown(mock_coordinator):
+    """current_option returns raw minutes string for an unmapped value."""
+    from custom_components.vistapool.const import SELECT_DEFINITIONS
+
+    props = SELECT_DEFINITIONS["MBF_PAR_FILTVALVE_PERIOD_MINUTES"]
+    ent = VistaPoolSelect(
+        mock_coordinator, "test_entry", "MBF_PAR_FILTVALVE_PERIOD_MINUTES", props
+    )
+    mock_coordinator.data = {"MBF_PAR_FILTVALVE_PERIOD_MINUTES": 999}
+    assert ent.current_option == "999m"
+
+
+def test_select_filtvalve_period_minutes_options_prepend_unknown(mock_coordinator):
+    """options prepends raw value when device holds an unmapped minute count."""
+    from custom_components.vistapool.const import SELECT_DEFINITIONS
+
+    props = SELECT_DEFINITIONS["MBF_PAR_FILTVALVE_PERIOD_MINUTES"]
+    ent = VistaPoolSelect(
+        mock_coordinator, "test_entry", "MBF_PAR_FILTVALVE_PERIOD_MINUTES", props
+    )
+    mock_coordinator.data = {"MBF_PAR_FILTVALVE_PERIOD_MINUTES": 999}
+    opts = ent.options
+    assert opts[0] == "999m"
+    assert "1_day" in opts

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -897,6 +897,40 @@ def test_select_filtvalve_period_minutes_options_known_value(mock_coordinator):
     assert "999m" not in opts
 
 
+@pytest.mark.asyncio
+async def test_async_select_option_filtvalve_period_minutes_label(mock_coordinator):
+    """async_select_option writes the correct minute value for a mapped label."""
+    from custom_components.vistapool.const import SELECT_DEFINITIONS
+
+    props = SELECT_DEFINITIONS["MBF_PAR_FILTVALVE_PERIOD_MINUTES"]
+    ent = VistaPoolSelect(
+        mock_coordinator, "test_entry", "MBF_PAR_FILTVALVE_PERIOD_MINUTES", props
+    )
+    ent.hass = MagicMock()
+    ent.coordinator.client = AsyncMock()
+    ent.coordinator.async_request_refresh = AsyncMock()
+    ent.async_write_ha_state = Mock()
+    await ent.async_select_option("1_day")
+    ent.coordinator.client.async_write_register.assert_awaited_with(0x04ED, 1440)
+
+
+@pytest.mark.asyncio
+async def test_async_select_option_filtvalve_period_minutes_raw_m(mock_coordinator):
+    """async_select_option parses and writes a raw 'Xm' string."""
+    from custom_components.vistapool.const import SELECT_DEFINITIONS
+
+    props = SELECT_DEFINITIONS["MBF_PAR_FILTVALVE_PERIOD_MINUTES"]
+    ent = VistaPoolSelect(
+        mock_coordinator, "test_entry", "MBF_PAR_FILTVALVE_PERIOD_MINUTES", props
+    )
+    ent.hass = MagicMock()
+    ent.coordinator.client = AsyncMock()
+    ent.coordinator.async_request_refresh = AsyncMock()
+    ent.async_write_ha_state = Mock()
+    await ent.async_select_option("999m")
+    ent.coordinator.client.async_write_register.assert_awaited_with(0x04ED, 999)
+
+
 # MBF_PAR_FILTVALVE_MODE select tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -303,14 +303,17 @@ async def test_async_select_option_backwash(mock_coordinator):
 
 @pytest.mark.asyncio
 async def test_async_select_option_backwash_from_manual(mock_coordinator):
-    """Switching from manual to backwash must first zero out MANUAL_FILTRATION_REGISTER."""
+    """Switching from manual to backwash with a MANUAL valve must stop the pump first.
+    The user needs the pump stopped so they can safely rotate the multi-way valve.
+    """
     props = SELECT_DEFINITIONS["MBF_PAR_FILT_MODE"]
     ent = VistaPoolSelect(mock_coordinator, "test_entry", "MBF_PAR_FILT_MODE", props)
     ent.hass = MagicMock()
     ent.coordinator.data = {
-        "MBF_PAR_FILT_MODE": 0,  # current: manual (key 0 in SELECT_DEFINITIONS)
+        "MBF_PAR_FILT_MODE": 0,  # current: manual
         "MBF_PAR_HEATING_GPIO": 0,
         "MBF_PAR_TEMPERATURE_ACTIVE": 0,
+        # MBF_PAR_FILTVALVE_ENABLE absent / 0 => manual valve
     }
     ent.coordinator.device_name = "vistapool"
     ent.coordinator.config_entry.options = {"enable_backwash_option": True}
@@ -319,10 +322,36 @@ async def test_async_select_option_backwash_from_manual(mock_coordinator):
     assert "backwash" in ent.options
     await ent.async_select_option("backwash")
     calls = ent.coordinator.client.async_write_register.await_args_list
-    # First call: turn off manual filtration
+    # First call: stop manual filtration (safety - user must turn valve manually)
     assert calls[0].args == (0x0413, 0)
     # Second call: set backwash mode
     assert calls[1].args == (0x0411, 13)
+
+
+@pytest.mark.asyncio
+async def test_async_select_option_backwash_from_manual_auto_valve(mock_coordinator):
+    """Switching from manual to backwash with an AUTOMATIC valve (Besgo) must NOT
+    stop the pump - it must keep running so the valve opens correctly.
+    """
+    props = SELECT_DEFINITIONS["MBF_PAR_FILT_MODE"]
+    ent = VistaPoolSelect(mock_coordinator, "test_entry", "MBF_PAR_FILT_MODE", props)
+    ent.hass = MagicMock()
+    ent.coordinator.data = {
+        "MBF_PAR_FILT_MODE": 0,  # current: manual
+        "MBF_PAR_HEATING_GPIO": 0,
+        "MBF_PAR_TEMPERATURE_ACTIVE": 0,
+        "MBF_PAR_FILTVALVE_ENABLE": 1,  # Besgo auto valve present
+    }
+    ent.coordinator.device_name = "vistapool"
+    ent.coordinator.config_entry.options = {"enable_backwash_option": True}
+    ent.coordinator.client = AsyncMock()
+    ent.async_write_ha_state = MagicMock()
+    assert "backwash" in ent.options
+    await ent.async_select_option("backwash")
+    calls = ent.coordinator.client.async_write_register.await_args_list
+    # Only one write: set backwash mode - pump must NOT be stopped
+    assert len(calls) == 1
+    assert calls[0].args == (0x0411, 13)
 
 
 @pytest.mark.asyncio

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -118,6 +118,17 @@ def test_options_no_backwash_without_valve_or_option(mock_coordinator):
     assert "backwash" not in opts
 
 
+def test_options_backwash_kept_when_active(mock_coordinator):
+    """Backwash must stay in options if device is currently in mode 13,
+    even when backwash is not allowed — so current_option stays valid."""
+    props = make_props(options_map={0: "auto", 1: "manual", 2: "off", 13: "backwash"})
+    ent = VistaPoolSelect(mock_coordinator, "test_entry", "MBF_PAR_FILT_MODE", props)
+    mock_coordinator.data = {"MBF_PAR_FILTVALVE_ENABLE": 0, "MBF_PAR_FILT_MODE": 13}
+    mock_coordinator.config_entry.options = {}
+    opts = ent.options
+    assert "backwash" in opts
+
+
 def test_options_timer_time(mock_coordinator):
     from custom_components.vistapool.helpers import (
         hhmm_to_seconds,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -74,8 +74,15 @@ def test_icon_default(mock_coordinator):
 
 
 def test_suggested_display_precision(mock_coordinator):
+    from custom_components.vistapool.const import SENSOR_DEFINITIONS
+
     # Test for MBF_HIDRO_CURRENT with percent mode
-    ent = VistaPoolSensor(mock_coordinator, "test_entry", "MBF_HIDRO_CURRENT", {})
+    ent = VistaPoolSensor(
+        mock_coordinator,
+        "test_entry",
+        "MBF_HIDRO_CURRENT",
+        SENSOR_DEFINITIONS["MBF_HIDRO_CURRENT"],
+    )
     mock_coordinator.data = {
         "MBF_PAR_UICFG_MACH_VISUAL_STYLE": 0x4000,  # Force percentage
         "MBF_PAR_UICFG_MACHINE": 0,
@@ -91,7 +98,10 @@ def test_suggested_display_precision(mock_coordinator):
 
     # Test for conductivity
     ent = VistaPoolSensor(
-        mock_coordinator, "test_entry", "MBF_MEASURE_CONDUCTIVITY", {}
+        mock_coordinator,
+        "test_entry",
+        "MBF_MEASURE_CONDUCTIVITY",
+        SENSOR_DEFINITIONS["MBF_MEASURE_CONDUCTIVITY"],
     )
     assert ent.suggested_display_precision == 0
 
@@ -102,8 +112,13 @@ def test_suggested_display_precision(mock_coordinator):
 
 def test_native_unit_of_measurement_hidro_current(mock_coordinator):
     """Test native_unit_of_measurement for MBF_HIDRO_CURRENT with different configurations."""
+    from custom_components.vistapool.const import SENSOR_DEFINITIONS
+
     ent = VistaPoolSensor(
-        mock_coordinator, "test_entry", "MBF_HIDRO_CURRENT", {"unit": "%"}
+        mock_coordinator,
+        "test_entry",
+        "MBF_HIDRO_CURRENT",
+        SENSOR_DEFINITIONS["MBF_HIDRO_CURRENT"],
     )
 
     # Test percent mode

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -603,3 +603,69 @@ async def test_sensor_setup_with_capability_snapshot_only():
     assert "MBF_PAR_FILT_MODE" in keys
     assert "MBF_PH_STATUS_ALARM" in keys
     assert "HIDRO_POLARITY" in keys
+
+
+@pytest.mark.asyncio
+async def test_sensor_filtvalve_remaining_skipped_without_besgo():
+    """MBF_PAR_FILTVALVE_REMAINING sensor must be skipped when Besgo valve is not configured."""
+
+    class DummyEntry:
+        entry_id = "test_entry"
+
+    class DummyCoordinator:
+        config_entry = DummyEntry()
+        device_slug = "vistapool"
+
+    DummyCoordinator.data = {"MBF_PAR_FILTVALVE_ENABLE": 0}
+
+    hass = MagicMock()
+    hass.data = {"vistapool": {"test_entry": DummyCoordinator()}}
+    entry = DummyEntry()
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(hass, entry, async_add_entities)
+
+    keys = [e._key for e in async_add_entities.call_args[0][0]]
+    assert "MBF_PAR_FILTVALVE_REMAINING" not in keys
+
+
+@pytest.mark.asyncio
+async def test_sensor_filtvalve_remaining_created_with_besgo():
+    """MBF_PAR_FILTVALVE_REMAINING sensor must be created when Besgo valve is configured."""
+
+    class DummyEntry:
+        entry_id = "test_entry"
+
+    class DummyCoordinator:
+        config_entry = DummyEntry()
+        device_slug = "vistapool"
+
+    DummyCoordinator.data = {
+        "MBF_PAR_FILTVALVE_ENABLE": 1,
+        "MBF_PAR_FILTVALVE_REMAINING": 120,
+    }
+
+    hass = MagicMock()
+    hass.data = {"vistapool": {"test_entry": DummyCoordinator()}}
+    entry = DummyEntry()
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(hass, entry, async_add_entities)
+
+    keys = [e._key for e in async_add_entities.call_args[0][0]]
+    assert "MBF_PAR_FILTVALVE_REMAINING" in keys
+
+
+def test_sensor_filtvalve_remaining_native_value():
+    """MBF_PAR_FILTVALVE_REMAINING sensor returns raw seconds from coordinator data."""
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {"MBF_PAR_FILTVALVE_REMAINING": 90}
+    mock_coordinator.config_entry.entry_id = "test_entry"
+    mock_coordinator.device_slug = "vistapool"
+
+    from custom_components.vistapool.sensor import VistaPoolSensor
+
+    ent = VistaPoolSensor(
+        mock_coordinator, "test_entry", "MBF_PAR_FILTVALVE_REMAINING", {}
+    )
+    assert ent.native_value == 90


### PR DESCRIPTION
## feat(button): ✨ Add backwash button and full Besgo valve support

Related to discussion #93

### 🔍 Problem

When switching to backwash mode via the "Filtration Mode" select entity, the integration was
unconditionally stopping the pump before writing the new mode to `MBF_PAR_FILT_MODE` (0x0411).

For users with an **automatic motorized valve** (e.g. Besgo), this is incorrect - the pump must
keep running when backwash is initiated so that the valve can open under pressure. Stopping the pump
first prevents the valve from opening, and backwash never actually starts.

Additionally, the FILTVALVE registers (0x04E8–0x04EF) were not being read at all - they were
left as a TODO comment in `modbus.py`. Without this data, the integration had no way to detect
whether an automatic valve is configured, nor expose its configuration to the user.

### 🔧 Changes

**🐛 Bug fixes:**

- `modbus.py`: Added reading of the full FILTVALVE register block (0x04E8, 8 registers). New data
  keys: `MBF_PAR_FILTVALVE_ENABLE`, `MBF_PAR_FILTVALVE_MODE`, `MBF_PAR_FILTVALVE_GPIO`,
  `MBF_PAR_FILTVALVE_PERIOD_MINUTES`, `MBF_PAR_FILTVALVE_INTERVAL`, `MBF_PAR_FILTVALVE_REMAINING`
- `select.py`: Fixed pump-stop logic when leaving manual mode and switching to backwash.
  Behavior now depends on valve type:
  - ⚡ **Automatic valve** (`MBF_PAR_FILTVALVE_ENABLE != 0`): pump keeps running, mode is switched directly
  - 🖐️ **Manual valve** (`MBF_PAR_FILTVALVE_ENABLE == 0`): pump is stopped first so the user can
    safely rotate the multi-way valve manually before the backwash cycle begins

**✨ New entities (all shown only when `MBF_PAR_FILTVALVE_ENABLE=1`):**

- **"Start Backwash" button** (`button.py`): one-tap backwash trigger for automatic valve users
- **"Backwash" option in Filtration Mode select** (`select.py`): now auto-enabled when Besgo is
  configured, without requiring the advanced option `enable_backwash_option`
- **Backwash remaining time sensor** (`sensor.py`): exposes `MBF_PAR_FILTVALVE_REMAINING` (seconds)
  so users can see how much time is left in the current backwash cycle
- **Backwash Repeat Interval select** (`select.py`): configures `MBF_PAR_FILTVALVE_PERIOD_MINUTES`
  (0x04ED) — how often an automatic backwash cycle is triggered (1 day – 4 weeks)
- **Backwash Valve Mode select** (`select.py`): configures `MBF_PAR_FILTVALVE_MODE` (0x04E9) —
  controls the Besgo valve's timer mode:
  - `Automatic` (1) — valve operates on the configured schedule
  - `Always On` (3) — valve permanently in backwash position
  - `Always Off` (4) — valve permanently in filtration position

- `translations/`: All new entities translated to all 7 supported languages (en, cs, de, es, fr, it, pl)

**🧪 Tests:**

- `tests/test_modbus.py`: Updated for the new FILTVALVE register block (rr04-3 at 0x04E8)
- `tests/test_select.py`: Full coverage for all new/changed select behavior
- `tests/test_button.py`: BACKWASH button press (with and without valve configured)
- `tests/test_sensor.py`: `MBF_PAR_FILTVALVE_REMAINING` sensor skip/create tests
- Coverage: **100%** across all modified files

### 📖 Background

The VistaPool controller has two completely different backwash setups:

1. ⚡ **Automatic valve (Besgo or similar)** - a relay assigned to `MBF_PAR_FILTVALVE_GPIO` controls
   the valve electrically. The pump must keep running when mode 13 (`MBV_PAR_FILT_BACKWASH`) is
   written to 0x0411. The controller manages the full cycle automatically based on
   `MBF_PAR_FILTVALVE_PERIOD_MINUTES` and `MBF_PAR_FILTVALVE_INTERVAL`.

2. 🖐️ **Manual multi-way valve** - the user must physically rotate the valve. Stopping the pump first
   is required so the valve can be safely rotated. The backwash "mode" is mostly informational in
   this case - the user has to manage the full cycle manually.

> This matches the behavior of Tasmota's NeoPool driver (`CmndNeopoolFiltrationMode`), which writes
value 13 directly to 0x0411 without stopping the pump.