### PR TITLE
fix(modbus): 🐛 fix binary_sensor.filtration_active incorrect in some installations

### DIFF
--- a/custom_components/vistapool/modbus.py
+++ b/custom_components/vistapool/modbus.py
@@ -1060,7 +1060,6 @@ class VistaPoolModbusClient:
             self._polls_since_full_read += 1
         self._last_notification = notification
         self._last_was_full_read = force_full
-        self._cached_result.update(result)
 
         # Fixup: on some firmware versions (e.g. v8.07 on HIDRO-only variants),
         # MBF_RELAY_STATE bit 1 is not set even when the filtration pump is running.
@@ -1068,8 +1067,8 @@ class VistaPoolModbusClient:
         # When the two disagree, patch both the decoded key and the relay state bit so
         # that get_filtration_speed() also sees the correct on/off state.
         filtration_state = result.get("MBF_PAR_FILTRATION_STATE")
-        if filtration_state is not None:
-            authoritative = bool(filtration_state)
+        if filtration_state in (0, 1):
+            authoritative = filtration_state == 1
             if result.get("Filtration Pump") != authoritative:
                 _LOGGER.debug(
                     "MBF_RELAY_STATE bit 1 disagrees with MBF_PAR_FILTRATION_STATE (%d); "
@@ -1083,6 +1082,9 @@ class VistaPoolModbusClient:
                     result["MBF_RELAY_STATE"] = relay_state | 0x0002
                 else:
                     result["MBF_RELAY_STATE"] = relay_state & ~0x0002
+
+        # Update cache after fixup so partial reads start from consistent patched values
+        self._cached_result.update(result)
 
         # Add filtration speed and type
         result["FILTRATION_SPEED"] = get_filtration_speed(result)

--- a/custom_components/vistapool/modbus.py
+++ b/custom_components/vistapool/modbus.py
@@ -1062,6 +1062,28 @@ class VistaPoolModbusClient:
         self._last_was_full_read = force_full
         self._cached_result.update(result)
 
+        # Fixup: on some firmware versions (e.g. v8.07 on HIDRO-only variants),
+        # MBF_RELAY_STATE bit 1 is not set even when the filtration pump is running.
+        # MBF_PAR_FILTRATION_STATE (0x0421) is the authoritative source per vendor docs.
+        # When the two disagree, patch both the decoded key and the relay state bit so
+        # that get_filtration_speed() also sees the correct on/off state.
+        filtration_state = result.get("MBF_PAR_FILTRATION_STATE")
+        if filtration_state is not None:
+            authoritative = bool(filtration_state)
+            if result.get("Filtration Pump") != authoritative:
+                _LOGGER.debug(
+                    "MBF_RELAY_STATE bit 1 disagrees with MBF_PAR_FILTRATION_STATE (%d); "
+                    "patching Filtration Pump state to %s",
+                    filtration_state,
+                    authoritative,
+                )
+                result["Filtration Pump"] = authoritative
+                relay_state = result.get("MBF_RELAY_STATE", 0) or 0
+                if authoritative:
+                    result["MBF_RELAY_STATE"] = relay_state | 0x0002
+                else:
+                    result["MBF_RELAY_STATE"] = relay_state & ~0x0002
+
         # Add filtration speed and type
         result["FILTRATION_SPEED"] = get_filtration_speed(result)
 

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -1971,3 +1971,54 @@ async def test_filtration_state_fixup_pump_off_agrees(config, monkeypatch):
 
     assert result["Filtration Pump"] is False
     assert not (result["MBF_RELAY_STATE"] & 0x0002)
+
+
+@pytest.mark.asyncio
+async def test_filtration_state_fixup_relay_on_but_state_off(config, monkeypatch):
+    """Test fixup when MBF_RELAY_STATE bit 1 is set but MBF_PAR_FILTRATION_STATE says off.
+
+    Edge case: relay state claims pump is running but authoritative register says it's off.
+    Fixup must clear bit 1 from MBF_RELAY_STATE and set Filtration Pump to False.
+    """
+    client = vistapool_modbus.VistaPoolModbusClient(config)
+
+    class DummyResp:
+        def __init__(self, regs, is_error=False):
+            self.registers = regs
+            self.isError = lambda: is_error
+
+    fake_modbus = AsyncMock()
+    fake_modbus.connected = True
+
+    reg01 = [0] * 18
+    reg01[14] = 0x0002  # MBF_RELAY_STATE — bit 1 set (relay claims pump on)
+
+    installer_block1 = [0] * 31
+    installer_block1[25] = 0  # MBF_PAR_FILTRATION_STATE = 0 (authoritative: pump off)
+
+    fake_modbus.read_holding_registers = AsyncMock(
+        side_effect=[
+            DummyResp([1, 3, 1280, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            DummyResp([0] * 20),
+            DummyResp([0, 0]),
+            DummyResp([0] * 13),
+            DummyResp([0] * 4),
+            DummyResp(installer_block1),
+            DummyResp([0] * 13),
+            DummyResp([0] * 8),
+            DummyResp([0] * 14),
+            DummyResp([0] * 13),
+        ]
+    )
+    fake_modbus.read_input_registers = AsyncMock(return_value=DummyResp(reg01))
+
+    monkeypatch.setattr(client, "get_client", AsyncMock(return_value=fake_modbus))
+
+    result = await client._perform_read_all()
+
+    assert result["Filtration Pump"] is False, (
+        "Filtration Pump should be False based on MBF_PAR_FILTRATION_STATE=0"
+    )
+    assert not (result["MBF_RELAY_STATE"] & 0x0002), (
+        "MBF_RELAY_STATE bit 1 should be cleared to match the authoritative register"
+    )

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -1871,3 +1871,103 @@ async def test_perform_read_all_timers_reads_on_full_read_even_without_notificat
 
     fake_modbus.read_holding_registers.assert_called_once()
     assert "filtration1" in result
+
+
+@pytest.mark.asyncio
+async def test_filtration_state_fixup_v8_07_firmware(config, monkeypatch):
+    """Test that MBF_PAR_FILTRATION_STATE overrides MBF_RELAY_STATE bit 1 when they disagree.
+
+    On firmware v8.07 (HIDRO-only, e.g. Oxilife), MBF_RELAY_STATE = 0x0700 with bit 1
+    not set even when the pump runs. MBF_PAR_FILTRATION_STATE (0x0421) is authoritative.
+    """
+    client = vistapool_modbus.VistaPoolModbusClient(config)
+
+    class DummyResp:
+        def __init__(self, regs, is_error=False):
+            self.registers = regs
+            self.isError = lambda: is_error
+
+    fake_modbus = AsyncMock()
+    fake_modbus.connected = True
+
+    # reg01 (input registers from 0x0100): MBF_RELAY_STATE at index 14 = 0x0700
+    # (firmware v8.07 quirk: bits 8-10 set, bit 1 not set)
+    reg01 = [0] * 18
+    reg01[14] = 0x0700  # MBF_RELAY_STATE
+
+    # installer block 1 (0x0408, 31 registers): MBF_PAR_FILTRATION_STATE at index 25 = 1
+    installer_block1 = [0] * 31
+    installer_block1[25] = 1  # MBF_PAR_FILTRATION_STATE = 1 (pump running)
+
+    fake_modbus.read_holding_registers = AsyncMock(
+        side_effect=[
+            DummyResp([1, 3, 1280, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),  # rr00
+            DummyResp([0] * 20),  # rr02
+            DummyResp([0, 0]),  # rr02_hidro
+            DummyResp([0] * 13),  # factory block 1 (0x0300)
+            DummyResp([0] * 4),  # factory block 2 (0x0322)
+            DummyResp(
+                installer_block1
+            ),  # installer block 1 (0x0408, 31) — has MBF_PAR_FILTRATION_STATE
+            DummyResp([0] * 13),  # installer block 2 (0x0427)
+            DummyResp([0] * 8),  # installer block 3 (0x04E8, FILTVALVE)
+            DummyResp([0] * 14),  # rr05
+            DummyResp([0] * 13),  # rr06
+        ]
+    )
+    fake_modbus.read_input_registers = AsyncMock(return_value=DummyResp(reg01))
+
+    monkeypatch.setattr(client, "get_client", AsyncMock(return_value=fake_modbus))
+
+    result = await client._perform_read_all()
+
+    # Fixup must have overridden MBF_RELAY_STATE bit 1 with the authoritative value
+    assert result["Filtration Pump"] is True, (
+        "Filtration Pump should be True based on MBF_PAR_FILTRATION_STATE=1"
+    )
+    assert result["MBF_RELAY_STATE"] & 0x0002, (
+        "MBF_RELAY_STATE bit 1 should be patched so get_filtration_speed sees pump as running"
+    )
+
+
+@pytest.mark.asyncio
+async def test_filtration_state_fixup_pump_off_agrees(config, monkeypatch):
+    """Test that when MBF_RELAY_STATE and MBF_PAR_FILTRATION_STATE agree (both off), no fixup fires."""
+    client = vistapool_modbus.VistaPoolModbusClient(config)
+
+    class DummyResp:
+        def __init__(self, regs, is_error=False):
+            self.registers = regs
+            self.isError = lambda: is_error
+
+    fake_modbus = AsyncMock()
+    fake_modbus.connected = True
+
+    reg01 = [0] * 18
+    reg01[14] = 0x0000  # MBF_RELAY_STATE — bit 1 not set (pump off)
+
+    installer_block1 = [0] * 31
+    installer_block1[25] = 0  # MBF_PAR_FILTRATION_STATE = 0 (pump off — agrees)
+
+    fake_modbus.read_holding_registers = AsyncMock(
+        side_effect=[
+            DummyResp([1, 3, 1280, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            DummyResp([0] * 20),
+            DummyResp([0, 0]),
+            DummyResp([0] * 13),
+            DummyResp([0] * 4),
+            DummyResp(installer_block1),
+            DummyResp([0] * 13),
+            DummyResp([0] * 8),
+            DummyResp([0] * 14),
+            DummyResp([0] * 13),
+        ]
+    )
+    fake_modbus.read_input_registers = AsyncMock(return_value=DummyResp(reg01))
+
+    monkeypatch.setattr(client, "get_client", AsyncMock(return_value=fake_modbus))
+
+    result = await client._perform_read_all()
+
+    assert result["Filtration Pump"] is False
+    assert not (result["MBF_RELAY_STATE"] & 0x0002)


### PR DESCRIPTION
# fix: 🐛 `binary_sensor.filtration_active` incorrect in some installations

## 🔍 Problem

On some devices, `binary_sensor.filtration_active` always reported `off` even when the pump
was clearly running. This could be caused by wrong configuration made by vendor or installer.
Additionally, `sensor.current_filtration_speed` showed `unknown`.

The root cause: `MBF_RELAY_STATE (0x010E)` bit 1 is **not set** on affected devices when the
pump runs. The integration relied solely on this bit for both the filtration binary sensor and
the speed sensor.

## 🛠️ Fix

After decoding all registers, a post-processing fixup in `modbus.py` compares `MBF_RELAY_STATE`
bit 1 against `MBF_PAR_FILTRATION_STATE (0x0421)` — the authoritative register per vendor docs.
When they disagree:

- `Filtration Pump` is overridden with the authoritative value
- `MBF_RELAY_STATE` bit 1 is patched in `result` so that `get_filtration_speed()` also sees the
  correct on/off state → fixes `sensor.current_filtration_speed` as well

On devices where `MBF_RELAY_STATE` is populated correctly, the two values always agree and the
fixup is **never triggered** — no impact on existing installations.

## ✅ Tests

Three new tests added to `tests/test_modbus.py`:

- `test_filtration_state_fixup_v8_07_firmware` — simulates the affected case
  (`MBF_RELAY_STATE = 0x0700`, `MBF_PAR_FILTRATION_STATE = 1`)
- `test_filtration_state_fixup_pump_off_agrees` — verifies no fixup fires when both sources
  agree (pump off)
- `test_filtration_state_fixup_relay_on_but_state_off` — edge case where relay bit 1 is set
  but `MBF_PAR_FILTRATION_STATE = 0`; fixup must clear the relay bit

## 🔗 Related

Resolves #105