### PR TITLE
feat: ✨ add optimistic state updates with follow-up refresh for IO entities

### DIFF
--- a/custom_components/vistapool/__init__.py
+++ b/custom_components/vistapool/__init__.py
@@ -132,6 +132,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
             _LOGGER.debug("Setting timer %s with data: %s", timer_name, timer_data)
             await coordinator.client.write_timer(timer_name, timer_data)
+            coordinator.request_refresh_with_followup()
         except ServiceValidationError:
             raise
         except Exception as e:

--- a/custom_components/vistapool/__init__.py
+++ b/custom_components/vistapool/__init__.py
@@ -132,7 +132,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
             _LOGGER.debug("Setting timer %s with data: %s", timer_name, timer_data)
             await coordinator.client.write_timer(timer_name, timer_data)
-            await coordinator.async_request_refresh()
         except ServiceValidationError:
             raise
         except Exception as e:

--- a/custom_components/vistapool/__init__.py
+++ b/custom_components/vistapool/__init__.py
@@ -67,8 +67,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a VistaPool config entry."""
     coordinator = hass.data[DOMAIN].get(entry.entry_id)
-    if coordinator and getattr(coordinator, "client", None):
-        await coordinator.client.close()
+    if coordinator:
+        coordinator.cancel_follow_up_refresh()
+        if getattr(coordinator, "client", None):
+            await coordinator.client.close()
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)

--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -51,7 +51,7 @@ LOGGER = logging.getLogger(__name__)
 DEFAULT_TIMER_RESOLUTION = 15  # in minutes
 DEFAULT_SCAN_INTERVAL = 30  # in seconds
 FOLLOW_UP_REFRESH_DELAY = (
-    2.0  # seconds — delay before a second refresh after switch toggle
+    2.0  # seconds — delay before a second refresh after IO entity actions
 )
 DEFAULT_PORT = 502
 DEFAULT_SLAVE_ID = 1

--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -50,6 +50,9 @@ LOGGER = logging.getLogger(__name__)
 
 DEFAULT_TIMER_RESOLUTION = 15  # in minutes
 DEFAULT_SCAN_INTERVAL = 30  # in seconds
+FOLLOW_UP_REFRESH_DELAY = (
+    2.0  # seconds — delay before a second refresh after switch toggle
+)
 DEFAULT_PORT = 502
 DEFAULT_SLAVE_ID = 1
 DEFAULT_MODBUS_FRAMER = "tcp"  # "tcp" = standard Modbus TCP (MBAP header), "rtu" = RTU over TCP (no MBAP, CRC)

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -16,11 +16,13 @@
 
 import json
 import logging
+from collections.abc import Callable
 from datetime import timedelta
 
 from homeassistant.const import CONF_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import slugify
 
@@ -28,6 +30,7 @@ from .const import (
     CAPABILITY_KEYS,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    FOLLOW_UP_REFRESH_DELAY,
     HEATING_SETPOINT_REGISTER,
     INTELLIGENT_SETPOINT_REGISTER,
     TIMER_BLOCKS,
@@ -70,6 +73,32 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
         self._capability_snapshot: dict = dict(entry.options.get("_capabilities", {}))
         self._firmware = "?"
         self._model = "Unknown"
+        self._follow_up_unsub: Callable | None = None
+
+    async def async_request_refresh_with_followup(
+        self, delay: float = FOLLOW_UP_REFRESH_DELAY
+    ) -> None:
+        """Perform an immediate refresh and schedule a follow-up refresh.
+
+        The follow-up catches delayed device state changes that may not
+        be visible in Modbus registers immediately after a write.
+        If called again before the previous follow-up fires, the old one
+        is cancelled to avoid stacking.
+        """
+        await self.async_request_refresh()
+        self._schedule_follow_up_refresh(delay)
+
+    def _schedule_follow_up_refresh(self, delay: float) -> None:
+        """Schedule a delayed follow-up refresh."""
+        if self._follow_up_unsub:
+            self._follow_up_unsub()
+
+        @callback
+        def _do_refresh(_now) -> None:
+            self._follow_up_unsub = None
+            self.hass.async_create_task(self.async_request_refresh())
+
+        self._follow_up_unsub = async_call_later(self.hass, delay, _do_refresh)
 
     async def _async_update_data(self):
         # Winter mode: skip all Modbus communication; entities remain but show unknown values

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -75,7 +75,7 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
         self._model = "Unknown"
         self._follow_up_unsub: Callable | None = None
 
-    async def async_request_refresh_with_followup(
+    def request_refresh_with_followup(
         self, delay: float = FOLLOW_UP_REFRESH_DELAY
     ) -> None:
         """Schedule a follow-up refresh after a delay.
@@ -99,6 +99,7 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
         """Schedule a delayed follow-up refresh."""
         if self._follow_up_unsub:
             self._follow_up_unsub()
+            self._follow_up_unsub = None
 
         @callback
         def _do_refresh(_now) -> None:

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -78,14 +78,15 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
     async def async_request_refresh_with_followup(
         self, delay: float = FOLLOW_UP_REFRESH_DELAY
     ) -> None:
-        """Perform an immediate refresh and schedule a follow-up refresh.
+        """Schedule a follow-up refresh after a delay.
 
         The follow-up catches delayed device state changes that may not
         be visible in Modbus registers immediately after a write.
+        No immediate refresh is performed — callers should apply optimistic
+        state updates before calling this method.
         If called again before the previous follow-up fires, the old one
         is cancelled to avoid stacking.
         """
-        await self.async_request_refresh()
         self._schedule_follow_up_refresh(delay)
 
     def cancel_follow_up_refresh(self) -> None:

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -16,11 +16,10 @@
 
 import json
 import logging
-from collections.abc import Callable
 from datetime import timedelta
 
 from homeassistant.const import CONF_NAME
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -73,7 +72,7 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
         self._capability_snapshot: dict = dict(entry.options.get("_capabilities", {}))
         self._firmware = "?"
         self._model = "Unknown"
-        self._follow_up_unsub: Callable | None = None
+        self._follow_up_unsub: CALLBACK_TYPE | None = None
 
     def request_refresh_with_followup(
         self, delay: float = FOLLOW_UP_REFRESH_DELAY

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -88,6 +88,12 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
         await self.async_request_refresh()
         self._schedule_follow_up_refresh(delay)
 
+    def cancel_follow_up_refresh(self) -> None:
+        """Cancel any pending follow-up refresh (e.g. on config entry unload)."""
+        if self._follow_up_unsub:
+            self._follow_up_unsub()
+            self._follow_up_unsub = None
+
     def _schedule_follow_up_refresh(self, delay: float) -> None:
         """Schedule a delayed follow-up refresh."""
         if self._follow_up_unsub:

--- a/custom_components/vistapool/light.py
+++ b/custom_components/vistapool/light.py
@@ -111,7 +111,7 @@ class VistaPoolLight(VistaPoolEntity, LightEntity):
 
         # Run a refresh to update the state
         await asyncio.sleep(2.0)
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_request_refresh_with_followup()
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
@@ -136,7 +136,7 @@ class VistaPoolLight(VistaPoolEntity, LightEntity):
 
         # Run a refresh to update the state
         await asyncio.sleep(2.0)
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_request_refresh_with_followup()
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/vistapool/light.py
+++ b/custom_components/vistapool/light.py
@@ -110,7 +110,7 @@ class VistaPoolLight(VistaPoolEntity, LightEntity):
 
         # Optimistic update + schedule follow-up
         self._optimistic_update(True)
-        self.async_write_ha_state()
+        self.coordinator.async_set_updated_data(self.coordinator.data)
         await self.coordinator.async_request_refresh_with_followup()
 
     async def async_turn_off(self, **kwargs) -> None:
@@ -135,7 +135,7 @@ class VistaPoolLight(VistaPoolEntity, LightEntity):
 
         # Optimistic update + schedule follow-up
         self._optimistic_update(False)
-        self.async_write_ha_state()
+        self.coordinator.async_set_updated_data(self.coordinator.data)
         await self.coordinator.async_request_refresh_with_followup()
 
     def _optimistic_update(self, state: bool) -> None:

--- a/custom_components/vistapool/light.py
+++ b/custom_components/vistapool/light.py
@@ -111,7 +111,7 @@ class VistaPoolLight(VistaPoolEntity, LightEntity):
         # Optimistic update + schedule follow-up
         self._optimistic_update(True)
         self.coordinator.async_set_updated_data(self.coordinator.data)
-        await self.coordinator.async_request_refresh_with_followup()
+        self.coordinator.request_refresh_with_followup()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the light OFF."""
@@ -136,7 +136,7 @@ class VistaPoolLight(VistaPoolEntity, LightEntity):
         # Optimistic update + schedule follow-up
         self._optimistic_update(False)
         self.coordinator.async_set_updated_data(self.coordinator.data)
-        await self.coordinator.async_request_refresh_with_followup()
+        self.coordinator.request_refresh_with_followup()
 
     def _optimistic_update(self, state: bool) -> None:
         """Apply an optimistic state update to coordinator data."""

--- a/custom_components/vistapool/light.py
+++ b/custom_components/vistapool/light.py
@@ -14,7 +14,6 @@
 
 """VistaPool Integration for Home Assistant - Light Module"""
 
-import asyncio
 import logging
 
 from homeassistant.components.light import ColorMode, LightEntity
@@ -109,10 +108,10 @@ class VistaPoolLight(VistaPoolEntity, LightEntity):
             await client.async_write_register(self.timer_block_addr, 3)  # Always ON
             await client.async_write_register(EXEC_REGISTER, 1)  # Commit
 
-        # Run a refresh to update the state
-        await asyncio.sleep(2.0)
-        await self.coordinator.async_request_refresh_with_followup()
+        # Optimistic update + schedule follow-up
+        self._optimistic_update(True)
         self.async_write_ha_state()
+        await self.coordinator.async_request_refresh_with_followup()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the light OFF."""
@@ -134,10 +133,18 @@ class VistaPoolLight(VistaPoolEntity, LightEntity):
             await client.async_write_register(self.timer_block_addr, 4)  # Always OFF
             await client.async_write_register(EXEC_REGISTER, 1)  # Commit
 
-        # Run a refresh to update the state
-        await asyncio.sleep(2.0)
-        await self.coordinator.async_request_refresh_with_followup()
+        # Optimistic update + schedule follow-up
+        self._optimistic_update(False)
         self.async_write_ha_state()
+        await self.coordinator.async_request_refresh_with_followup()
+
+    def _optimistic_update(self, state: bool) -> None:
+        """Apply an optimistic state update to coordinator data."""
+        data = self.coordinator.data
+        if data is None:
+            return
+        if self._switch_type == "relay_timer":
+            data["relay_light_enable"] = 3 if state else 4
 
     async def async_added_to_hass(self) -> None:
         """Run when the entity is added to hass."""

--- a/custom_components/vistapool/light.py
+++ b/custom_components/vistapool/light.py
@@ -110,7 +110,8 @@ class VistaPoolLight(VistaPoolEntity, LightEntity):
 
         # Optimistic update + schedule follow-up
         self._optimistic_update(True)
-        self.coordinator.async_set_updated_data(self.coordinator.data)
+        if self.coordinator.data is not None:
+            self.coordinator.async_set_updated_data(self.coordinator.data)
         self.coordinator.request_refresh_with_followup()
 
     async def async_turn_off(self, **kwargs) -> None:
@@ -135,7 +136,8 @@ class VistaPoolLight(VistaPoolEntity, LightEntity):
 
         # Optimistic update + schedule follow-up
         self._optimistic_update(False)
-        self.coordinator.async_set_updated_data(self.coordinator.data)
+        if self.coordinator.data is not None:
+            self.coordinator.async_set_updated_data(self.coordinator.data)
         self.coordinator.request_refresh_with_followup()
 
     def _optimistic_update(self, state: bool) -> None:

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -241,7 +241,7 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
                 },
             )
             await asyncio.sleep(0.2)
-            await self.coordinator.async_request_refresh()
+            await self.coordinator.async_request_refresh_with_followup()
             self.async_write_ha_state()
             return
 
@@ -340,7 +340,7 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
 
         # Run a refresh to update the state
         await asyncio.sleep(0.5)
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_request_refresh_with_followup()
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -196,7 +196,6 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
                     "stop": stop,
                 },
             )
-            self.coordinator.request_refresh_with_followup()
             return
 
         if self._select_type == "timer_period":
@@ -220,7 +219,6 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
                     "period": period_value,
                 },
             )
-            self.coordinator.request_refresh_with_followup()
             return
 
         if self._select_type == "relay_mode":
@@ -242,7 +240,6 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
             )
             self._optimistic_update(value)
             self.coordinator.async_set_updated_data(self.coordinator.data)
-            self.coordinator.request_refresh_with_followup()
             return
 
         if self._key == "MBF_CELL_BOOST":

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -196,7 +196,7 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
                     "stop": stop,
                 },
             )
-            await asyncio.sleep(0.2)
+            await self.coordinator.async_request_refresh_with_followup()
             return
 
         if self._select_type == "timer_period":
@@ -220,7 +220,7 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
                     "period": period_value,
                 },
             )
-            await asyncio.sleep(0.2)
+            await self.coordinator.async_request_refresh_with_followup()
             return
 
         if self._select_type == "relay_mode":
@@ -240,9 +240,8 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
                     timer_field: value,
                 },
             )
-            await asyncio.sleep(0.2)
             self._optimistic_update(value)
-            self.async_write_ha_state()
+            self.coordinator.async_set_updated_data(self.coordinator.data)
             await self.coordinator.async_request_refresh_with_followup()
             return
 
@@ -341,7 +340,7 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
 
         # Optimistic update + schedule follow-up
         self._optimistic_update(value)
-        self.async_write_ha_state()
+        self.coordinator.async_set_updated_data(self.coordinator.data)
         await self.coordinator.async_request_refresh_with_followup()
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -330,17 +330,16 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
                         await asyncio.sleep(0.1)
             # Set the new mode
             await client.async_write_register(self._register, value)
-            await asyncio.sleep(0.2)
             if self._key == "MBF_PAR_FILT_MODE" and option == "backwash":
                 _LOGGER.info(
                     f'Your pool "{VistaPoolEntity.slugify(self.coordinator.device_name)}" has been switched to the BACKWASH mode!'
                 )
 
-        # Optimistic update + schedule follow-up
-        self._optimistic_update(value)
-        if self.coordinator.data is not None:
-            self.coordinator.async_set_updated_data(self.coordinator.data)
-        self.coordinator.request_refresh_with_followup()
+            # Optimistic update + schedule follow-up
+            self._optimistic_update(value)
+            if self.coordinator.data is not None:
+                self.coordinator.async_set_updated_data(self.coordinator.data)
+            self.coordinator.request_refresh_with_followup()
 
     async def async_added_to_hass(self) -> None:
         """Run when the entity is added to hass."""

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -239,7 +239,8 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
                 },
             )
             self._optimistic_update(value)
-            self.coordinator.async_set_updated_data(self.coordinator.data)
+            if self.coordinator.data is not None:
+                self.coordinator.async_set_updated_data(self.coordinator.data)
             return
 
         if self._key == "MBF_CELL_BOOST":
@@ -337,7 +338,8 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
 
         # Optimistic update + schedule follow-up
         self._optimistic_update(value)
-        self.coordinator.async_set_updated_data(self.coordinator.data)
+        if self.coordinator.data is not None:
+            self.coordinator.async_set_updated_data(self.coordinator.data)
         self.coordinator.request_refresh_with_followup()
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -338,10 +338,10 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
                     f'Your pool "{VistaPoolEntity.slugify(self.coordinator.device_name)}" has been switched to the BACKWASH mode!'
                 )
 
-        # Run a refresh to update the state
-        await asyncio.sleep(0.5)
-        await self.coordinator.async_request_refresh_with_followup()
+        # Optimistic update + schedule follow-up
+        self._optimistic_update(value)
         self.async_write_ha_state()
+        await self.coordinator.async_request_refresh_with_followup()
 
     async def async_added_to_hass(self) -> None:
         """Run when the entity is added to hass."""
@@ -473,6 +473,22 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
             return options
 
         return [self._options_map[k] for k in option_keys]
+
+    def _optimistic_update(self, value: int | None) -> None:
+        """Apply an optimistic state update to coordinator data."""
+        data = self.coordinator.data
+        if data is None or value is None:
+            return
+        if self._select_type == "relay_mode":
+            timer_name = self._key.rsplit("_", 1)[0]
+            data[f"{timer_name}_enable"] = value
+        elif self._key in (
+            "MBF_PAR_FILT_MODE",
+            "MBF_PAR_FILTVALVE_MODE",
+            "MBF_PAR_FILTVALVE_PERIOD_MINUTES",
+            "MBF_PAR_INTELLIGENT_FILT_MIN_TIME",
+        ):
+            data[self._key] = value
 
     @property
     def current_option(self) -> str | None:

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -241,8 +241,9 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
                 },
             )
             await asyncio.sleep(0.2)
-            await self.coordinator.async_request_refresh_with_followup()
+            self._optimistic_update(value)
             self.async_write_ha_state()
+            await self.coordinator.async_request_refresh_with_followup()
             return
 
         if self._key == "MBF_CELL_BOOST":

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -196,7 +196,7 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
                     "stop": stop,
                 },
             )
-            await self.coordinator.async_request_refresh_with_followup()
+            self.coordinator.request_refresh_with_followup()
             return
 
         if self._select_type == "timer_period":
@@ -220,7 +220,7 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
                     "period": period_value,
                 },
             )
-            await self.coordinator.async_request_refresh_with_followup()
+            self.coordinator.request_refresh_with_followup()
             return
 
         if self._select_type == "relay_mode":
@@ -242,7 +242,7 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
             )
             self._optimistic_update(value)
             self.coordinator.async_set_updated_data(self.coordinator.data)
-            await self.coordinator.async_request_refresh_with_followup()
+            self.coordinator.request_refresh_with_followup()
             return
 
         if self._key == "MBF_CELL_BOOST":
@@ -341,7 +341,7 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
         # Optimistic update + schedule follow-up
         self._optimistic_update(value)
         self.coordinator.async_set_updated_data(self.coordinator.data)
-        await self.coordinator.async_request_refresh_with_followup()
+        self.coordinator.request_refresh_with_followup()
 
     async def async_added_to_hass(self) -> None:
         """Run when the entity is added to hass."""
@@ -480,8 +480,9 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):
         if data is None or value is None:
             return
         if self._select_type == "relay_mode":
+            timer_field = self._props.get("timer_field", "enable")
             timer_name = self._key.rsplit("_", 1)[0]
-            data[f"{timer_name}_enable"] = value
+            data[f"{timer_name}_{timer_field}"] = value
         elif self._key in (
             "MBF_PAR_FILT_MODE",
             "MBF_PAR_FILTVALVE_MODE",

--- a/custom_components/vistapool/switch.py
+++ b/custom_components/vistapool/switch.py
@@ -283,6 +283,8 @@ class VistaPoolSwitch(VistaPoolEntity, SwitchEntity):
             return
         if self._switch_type == "manual_filtration":
             data["MBF_PAR_FILT_MANUAL_STATE"] = 1 if state else 0
+        elif self._switch_type == "aux":
+            data[self._key] = state
         elif self._switch_type == "relay_timer":
             data[f"relay_{self._key}_enable"] = 3 if state else 4
         elif self._switch_type == "climate_mode":

--- a/custom_components/vistapool/switch.py
+++ b/custom_components/vistapool/switch.py
@@ -192,7 +192,7 @@ class VistaPoolSwitch(VistaPoolEntity, SwitchEntity):
         # Optimistic update + schedule follow-up for IO switch types
         if self._switch_type not in ("auto_time_sync", "winter_mode"):
             self._optimistic_update(True)
-            self.async_write_ha_state()
+            self.coordinator.async_set_updated_data(self.coordinator.data)
             await self.coordinator.async_request_refresh_with_followup()
         else:
             await self.coordinator.async_request_refresh()
@@ -260,7 +260,7 @@ class VistaPoolSwitch(VistaPoolEntity, SwitchEntity):
         # Optimistic update + schedule follow-up for IO switch types
         if self._switch_type not in ("auto_time_sync", "winter_mode"):
             self._optimistic_update(False)
-            self.async_write_ha_state()
+            self.coordinator.async_set_updated_data(self.coordinator.data)
             await self.coordinator.async_request_refresh_with_followup()
         else:
             await self.coordinator.async_request_refresh()

--- a/custom_components/vistapool/switch.py
+++ b/custom_components/vistapool/switch.py
@@ -193,7 +193,7 @@ class VistaPoolSwitch(VistaPoolEntity, SwitchEntity):
         if self._switch_type not in ("auto_time_sync", "winter_mode"):
             self._optimistic_update(True)
             self.coordinator.async_set_updated_data(self.coordinator.data)
-            await self.coordinator.async_request_refresh_with_followup()
+            self.coordinator.request_refresh_with_followup()
         else:
             await self.coordinator.async_request_refresh()
             self.async_write_ha_state()
@@ -261,7 +261,7 @@ class VistaPoolSwitch(VistaPoolEntity, SwitchEntity):
         if self._switch_type not in ("auto_time_sync", "winter_mode"):
             self._optimistic_update(False)
             self.coordinator.async_set_updated_data(self.coordinator.data)
-            await self.coordinator.async_request_refresh_with_followup()
+            self.coordinator.request_refresh_with_followup()
         else:
             await self.coordinator.async_request_refresh()
             self.async_write_ha_state()

--- a/custom_components/vistapool/switch.py
+++ b/custom_components/vistapool/switch.py
@@ -14,7 +14,6 @@
 
 """VistaPool Integration for Home Assistant - Switch Module"""
 
-import asyncio
 import logging
 
 from homeassistant.components.switch import SwitchEntity
@@ -190,13 +189,14 @@ class VistaPoolSwitch(VistaPoolEntity, SwitchEntity):
             )
             await client.async_write_register(self.function_addr, new_value, apply=True)
 
-        # Run a refresh to update the state; skip delay for non-IO switch types
+        # Optimistic update + schedule follow-up for IO switch types
         if self._switch_type not in ("auto_time_sync", "winter_mode"):
-            await asyncio.sleep(1.0)
+            self._optimistic_update(True)
+            self.async_write_ha_state()
             await self.coordinator.async_request_refresh_with_followup()
         else:
             await self.coordinator.async_request_refresh()
-        self.async_write_ha_state()
+            self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the switch OFF."""
@@ -257,13 +257,14 @@ class VistaPoolSwitch(VistaPoolEntity, SwitchEntity):
             )
             await client.async_write_register(self.function_addr, new_value, apply=True)
 
-        # Run a refresh to update the state; skip delay for non-IO switch types
+        # Optimistic update + schedule follow-up for IO switch types
         if self._switch_type not in ("auto_time_sync", "winter_mode"):
-            await asyncio.sleep(0.1)
+            self._optimistic_update(False)
+            self.async_write_ha_state()
             await self.coordinator.async_request_refresh_with_followup()
         else:
             await self.coordinator.async_request_refresh()
-        self.async_write_ha_state()
+            self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:  # pragma: no cover
         """Handle entity which will be added to hass."""
@@ -274,6 +275,28 @@ class VistaPoolSwitch(VistaPoolEntity, SwitchEntity):
             getattr(self, "has_entity_name", None),
         )
         await super().async_added_to_hass()
+
+    def _optimistic_update(self, state: bool) -> None:
+        """Apply an optimistic state update to coordinator data."""
+        data = self.coordinator.data
+        if data is None:
+            return
+        if self._switch_type == "manual_filtration":
+            data["MBF_PAR_FILT_MANUAL_STATE"] = 1 if state else 0
+        elif self._switch_type == "relay_timer":
+            data[f"relay_{self._key}_enable"] = 3 if state else 4
+        elif self._switch_type == "climate_mode":
+            data["MBF_PAR_CLIMA_ONOFF"] = 1 if state else 0
+        elif self._switch_type == "smart_anti_freeze":
+            data["MBF_PAR_SMART_ANTI_FREEZE"] = 1 if state else 0
+        elif self._switch_type == "uv_mode":
+            data["MBF_PAR_UV_MODE"] = 1 if state else 0
+        elif self._switch_type == "bitmask":
+            current = int(data.get(self._data_key, 0) or 0)
+            if state:
+                data[self._data_key] = current | self._mask_bit
+            else:
+                data[self._data_key] = current & ~self._mask_bit
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/vistapool/switch.py
+++ b/custom_components/vistapool/switch.py
@@ -193,7 +193,9 @@ class VistaPoolSwitch(VistaPoolEntity, SwitchEntity):
         # Run a refresh to update the state; skip delay for non-IO switch types
         if self._switch_type not in ("auto_time_sync", "winter_mode"):
             await asyncio.sleep(1.0)
-        await self.coordinator.async_request_refresh()
+            await self.coordinator.async_request_refresh_with_followup()
+        else:
+            await self.coordinator.async_request_refresh()
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
@@ -258,7 +260,9 @@ class VistaPoolSwitch(VistaPoolEntity, SwitchEntity):
         # Run a refresh to update the state; skip delay for non-IO switch types
         if self._switch_type not in ("auto_time_sync", "winter_mode"):
             await asyncio.sleep(0.1)
-        await self.coordinator.async_request_refresh()
+            await self.coordinator.async_request_refresh_with_followup()
+        else:
+            await self.coordinator.async_request_refresh()
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:  # pragma: no cover

--- a/custom_components/vistapool/switch.py
+++ b/custom_components/vistapool/switch.py
@@ -192,7 +192,8 @@ class VistaPoolSwitch(VistaPoolEntity, SwitchEntity):
         # Optimistic update + schedule follow-up for IO switch types
         if self._switch_type not in ("auto_time_sync", "winter_mode"):
             self._optimistic_update(True)
-            self.coordinator.async_set_updated_data(self.coordinator.data)
+            if self.coordinator.data is not None:
+                self.coordinator.async_set_updated_data(self.coordinator.data)
             self.coordinator.request_refresh_with_followup()
         else:
             await self.coordinator.async_request_refresh()
@@ -260,7 +261,8 @@ class VistaPoolSwitch(VistaPoolEntity, SwitchEntity):
         # Optimistic update + schedule follow-up for IO switch types
         if self._switch_type not in ("auto_time_sync", "winter_mode"):
             self._optimistic_update(False)
-            self.coordinator.async_set_updated_data(self.coordinator.data)
+            if self.coordinator.data is not None:
+                self.coordinator.async_set_updated_data(self.coordinator.data)
             self.coordinator.request_refresh_with_followup()
         else:
             await self.coordinator.async_request_refresh()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -605,7 +605,7 @@ async def test_async_update_data_updates_capability_snapshot(mock_entry):
 
 @pytest.mark.asyncio
 async def test_request_refresh_with_followup(mock_entry, monkeypatch):
-    """async_request_refresh_with_followup calls immediate refresh and schedules follow-up."""
+    """async_request_refresh_with_followup schedules a follow-up without immediate refresh."""
     client = AsyncMock()
     hass = MagicMock()
     coordinator = VistaPoolCoordinator(hass, client, mock_entry, mock_entry.entry_id)
@@ -622,7 +622,7 @@ async def test_request_refresh_with_followup(mock_entry, monkeypatch):
     )
 
     await coordinator.async_request_refresh_with_followup()
-    coordinator.async_request_refresh.assert_awaited_once()
+    coordinator.async_request_refresh.assert_not_awaited()
     assert len(calls) == 1
     assert calls[0][0] == FOLLOW_UP_REFRESH_DELAY
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -18,6 +18,7 @@ import pytest
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
+from custom_components.vistapool.const import FOLLOW_UP_REFRESH_DELAY
 from custom_components.vistapool.coordinator import VistaPoolCoordinator
 
 
@@ -623,7 +624,7 @@ async def test_request_refresh_with_followup(mock_entry, monkeypatch):
     await coordinator.async_request_refresh_with_followup()
     coordinator.async_request_refresh.assert_awaited_once()
     assert len(calls) == 1
-    assert calls[0][0] == 2.0
+    assert calls[0][0] == FOLLOW_UP_REFRESH_DELAY
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -600,3 +600,73 @@ async def test_async_update_data_updates_capability_snapshot(mock_entry):
     saved_options = hass.config_entries.async_update_entry.call_args[1]["options"]
     assert saved_options["_capabilities"]["MBF_PAR_MODEL"] == 2
     assert saved_options["_capabilities"]["MBF_PAR_TEMPERATURE_ACTIVE"] == 1
+
+
+@pytest.mark.asyncio
+async def test_request_refresh_with_followup(mock_entry, monkeypatch):
+    """async_request_refresh_with_followup calls immediate refresh and schedules follow-up."""
+    client = AsyncMock()
+    hass = MagicMock()
+    coordinator = VistaPoolCoordinator(hass, client, mock_entry, mock_entry.entry_id)
+    coordinator.async_request_refresh = AsyncMock()
+
+    calls = []
+
+    def fake_call_later(hass, delay, action):
+        calls.append((delay, action))
+        return lambda: None
+
+    monkeypatch.setattr(
+        "custom_components.vistapool.coordinator.async_call_later", fake_call_later
+    )
+
+    await coordinator.async_request_refresh_with_followup()
+    coordinator.async_request_refresh.assert_awaited_once()
+    assert len(calls) == 1
+    assert calls[0][0] == 2.0
+
+
+@pytest.mark.asyncio
+async def test_request_refresh_with_followup_custom_delay(mock_entry, monkeypatch):
+    """Follow-up delay can be customized."""
+    client = AsyncMock()
+    hass = MagicMock()
+    coordinator = VistaPoolCoordinator(hass, client, mock_entry, mock_entry.entry_id)
+    coordinator.async_request_refresh = AsyncMock()
+
+    calls = []
+
+    def fake_call_later(hass, delay, action):
+        calls.append((delay, action))
+        return lambda: None
+
+    monkeypatch.setattr(
+        "custom_components.vistapool.coordinator.async_call_later", fake_call_later
+    )
+
+    await coordinator.async_request_refresh_with_followup(delay=5.0)
+    assert calls[0][0] == 5.0
+
+
+@pytest.mark.asyncio
+async def test_follow_up_cancels_previous(mock_entry, monkeypatch):
+    """A new follow-up refresh cancels any previously scheduled one."""
+    client = AsyncMock()
+    hass = MagicMock()
+    coordinator = VistaPoolCoordinator(hass, client, mock_entry, mock_entry.entry_id)
+    coordinator.async_request_refresh = AsyncMock()
+
+    unsub = MagicMock()
+
+    def fake_call_later(hass, delay, action):
+        return unsub
+
+    monkeypatch.setattr(
+        "custom_components.vistapool.coordinator.async_call_later", fake_call_later
+    )
+
+    await coordinator.async_request_refresh_with_followup()
+    assert unsub.call_count == 0  # first schedule, nothing to cancel
+
+    await coordinator.async_request_refresh_with_followup()
+    assert unsub.call_count == 1  # previous follow-up was cancelled

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -605,7 +605,7 @@ async def test_async_update_data_updates_capability_snapshot(mock_entry):
 
 @pytest.mark.asyncio
 async def test_request_refresh_with_followup(mock_entry, monkeypatch):
-    """async_request_refresh_with_followup schedules a follow-up without immediate refresh."""
+    """request_refresh_with_followup schedules a follow-up without immediate refresh."""
     client = AsyncMock()
     hass = MagicMock()
     coordinator = VistaPoolCoordinator(hass, client, mock_entry, mock_entry.entry_id)
@@ -621,7 +621,7 @@ async def test_request_refresh_with_followup(mock_entry, monkeypatch):
         "custom_components.vistapool.coordinator.async_call_later", fake_call_later
     )
 
-    await coordinator.async_request_refresh_with_followup()
+    coordinator.request_refresh_with_followup()
     coordinator.async_request_refresh.assert_not_awaited()
     assert len(calls) == 1
     assert calls[0][0] == FOLLOW_UP_REFRESH_DELAY
@@ -645,7 +645,7 @@ async def test_request_refresh_with_followup_custom_delay(mock_entry, monkeypatc
         "custom_components.vistapool.coordinator.async_call_later", fake_call_later
     )
 
-    await coordinator.async_request_refresh_with_followup(delay=5.0)
+    coordinator.request_refresh_with_followup(delay=5.0)
     assert calls[0][0] == 5.0
 
 
@@ -666,10 +666,10 @@ async def test_follow_up_cancels_previous(mock_entry, monkeypatch):
         "custom_components.vistapool.coordinator.async_call_later", fake_call_later
     )
 
-    await coordinator.async_request_refresh_with_followup()
+    coordinator.request_refresh_with_followup()
     assert unsub.call_count == 0  # first schedule, nothing to cancel
 
-    await coordinator.async_request_refresh_with_followup()
+    coordinator.request_refresh_with_followup()
     assert unsub.call_count == 1  # previous follow-up was cancelled
 
 
@@ -692,7 +692,7 @@ async def test_follow_up_callback_triggers_refresh(mock_entry, monkeypatch):
         "custom_components.vistapool.coordinator.async_call_later", fake_call_later
     )
 
-    await coordinator.async_request_refresh_with_followup()
+    coordinator.request_refresh_with_followup()
     assert captured_callback is not None
     assert coordinator._follow_up_unsub is not None
 
@@ -719,7 +719,7 @@ async def test_cancel_follow_up_refresh(mock_entry, monkeypatch):
         "custom_components.vistapool.coordinator.async_call_later", fake_call_later
     )
 
-    await coordinator.async_request_refresh_with_followup()
+    coordinator.request_refresh_with_followup()
     assert coordinator._follow_up_unsub is not None
 
     coordinator.cancel_follow_up_refresh()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -670,3 +670,32 @@ async def test_follow_up_cancels_previous(mock_entry, monkeypatch):
 
     await coordinator.async_request_refresh_with_followup()
     assert unsub.call_count == 1  # previous follow-up was cancelled
+
+
+@pytest.mark.asyncio
+async def test_follow_up_callback_triggers_refresh(mock_entry, monkeypatch):
+    """The scheduled follow-up callback clears unsub and creates a refresh task."""
+    client = AsyncMock()
+    hass = MagicMock()
+    coordinator = VistaPoolCoordinator(hass, client, mock_entry, mock_entry.entry_id)
+    coordinator.async_request_refresh = AsyncMock()
+
+    captured_callback = None
+
+    def fake_call_later(hass, delay, action):
+        nonlocal captured_callback
+        captured_callback = action
+        return MagicMock()
+
+    monkeypatch.setattr(
+        "custom_components.vistapool.coordinator.async_call_later", fake_call_later
+    )
+
+    await coordinator.async_request_refresh_with_followup()
+    assert captured_callback is not None
+    assert coordinator._follow_up_unsub is not None
+
+    # Simulate the timer firing
+    captured_callback(None)
+    assert coordinator._follow_up_unsub is None
+    hass.async_create_task.assert_called_once()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -699,3 +699,39 @@ async def test_follow_up_callback_triggers_refresh(mock_entry, monkeypatch):
     captured_callback(None)
     assert coordinator._follow_up_unsub is None
     hass.async_create_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cancel_follow_up_refresh(mock_entry, monkeypatch):
+    """cancel_follow_up_refresh cancels a pending follow-up and clears the handle."""
+    client = AsyncMock()
+    hass = MagicMock()
+    coordinator = VistaPoolCoordinator(hass, client, mock_entry, mock_entry.entry_id)
+    coordinator.async_request_refresh = AsyncMock()
+
+    unsub = MagicMock()
+
+    def fake_call_later(hass, delay, action):
+        return unsub
+
+    monkeypatch.setattr(
+        "custom_components.vistapool.coordinator.async_call_later", fake_call_later
+    )
+
+    await coordinator.async_request_refresh_with_followup()
+    assert coordinator._follow_up_unsub is not None
+
+    coordinator.cancel_follow_up_refresh()
+    unsub.assert_called_once()
+    assert coordinator._follow_up_unsub is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_follow_up_refresh_noop_when_none(mock_entry):
+    """cancel_follow_up_refresh is safe to call when no follow-up is pending."""
+    client = AsyncMock()
+    hass = MagicMock()
+    coordinator = VistaPoolCoordinator(hass, client, mock_entry, mock_entry.entry_id)
+    assert coordinator._follow_up_unsub is None
+    coordinator.cancel_follow_up_refresh()  # should not raise
+    assert coordinator._follow_up_unsub is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -56,7 +56,7 @@ async def test_async_handle_set_timer_happy(monkeypatch):
         "filtration1",
         {"on": 30600, "interval": 6300, "period": 1234, "enable": 1},
     )
-    coordinator.async_request_refresh.assert_awaited_once()
+    coordinator.async_request_refresh.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -33,6 +33,7 @@ async def test_async_handle_set_timer_happy(monkeypatch):
     coordinator = hass.data["vistapool"]["entry1"]
     coordinator.client.write_timer = AsyncMock(return_value=True)
     coordinator.async_request_refresh = AsyncMock()
+    coordinator.request_refresh_with_followup = MagicMock()
 
     # Prepare call mock
     call = MagicMock()
@@ -57,6 +58,7 @@ async def test_async_handle_set_timer_happy(monkeypatch):
         {"on": 30600, "interval": 6300, "period": 1234, "enable": 1},
     )
     coordinator.async_request_refresh.assert_not_awaited()
+    coordinator.request_refresh_with_followup.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -68,6 +70,7 @@ async def test_async_handle_set_timer_entry_id_fallback(monkeypatch):
     coordinator = hass.data["vistapool"]["fallback"]
     coordinator.client.write_timer = AsyncMock(return_value=True)
     coordinator.async_request_refresh = AsyncMock()
+    coordinator.request_refresh_with_followup = MagicMock()
 
     call = MagicMock()
     call.data = {
@@ -117,6 +120,7 @@ async def test_async_handle_set_timer_write_timer_exception(monkeypatch):
     coordinator = hass.data["vistapool"]["entryX"]
     coordinator.client.write_timer = AsyncMock(side_effect=Exception("fail!"))
     coordinator.async_request_refresh = AsyncMock()
+    coordinator.request_refresh_with_followup = MagicMock()
 
     call = MagicMock()
     call.data = {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -203,7 +203,8 @@ async def test_async_unload_entry_success():
     hass.services.async_remove = MagicMock()
     result = await async_unload_entry(hass, config_entry)
     assert result is True
-    # Check that client.close() was called
+    # Check that follow-up refresh was cancelled and client closed
+    coordinator.cancel_follow_up_refresh.assert_called_once()
     assert coordinator.client.close.await_count == 1
 
 

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -34,7 +34,7 @@ def mock_coordinator():
     mock.winter_mode = False
     mock.client = AsyncMock()
     mock.async_request_refresh = AsyncMock()
-    mock.async_request_refresh_with_followup = AsyncMock()
+    mock.request_refresh_with_followup = MagicMock()
     config_entry = MagicMock()
     config_entry.entry_id = "test_entry"
     config_entry.unique_id = "test_slug"

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -327,3 +327,20 @@ def test_available_false_on_coordinator_failure(mock_coordinator, light_props):
     mock_coordinator.last_update_success = False
     ent = VistaPoolLight(mock_coordinator, "test_entry", "light", light_props)
     assert ent.available is False
+
+
+def test_optimistic_update_light(mock_coordinator, light_props):
+    """Optimistic update sets relay_light_enable correctly."""
+    mock_coordinator.data = {"relay_light_enable": 4}
+    ent = VistaPoolLight(mock_coordinator, "test_entry", "light", light_props)
+    ent._optimistic_update(True)
+    assert mock_coordinator.data["relay_light_enable"] == 3
+    ent._optimistic_update(False)
+    assert mock_coordinator.data["relay_light_enable"] == 4
+
+
+def test_optimistic_update_light_noop_when_data_is_none(mock_coordinator, light_props):
+    """Optimistic update is a no-op when coordinator data is None."""
+    mock_coordinator.data = None
+    ent = VistaPoolLight(mock_coordinator, "test_entry", "light", light_props)
+    ent._optimistic_update(True)  # Should not raise

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -34,6 +34,7 @@ def mock_coordinator():
     mock.winter_mode = False
     mock.client = AsyncMock()
     mock.async_request_refresh = AsyncMock()
+    mock.async_request_refresh_with_followup = AsyncMock()
     config_entry = MagicMock()
     config_entry.entry_id = "test_entry"
     config_entry.unique_id = "test_slug"

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -313,11 +313,9 @@ async def test_async_select_option_relay_mode(mock_coordinator):
     ent = VistaPoolSelect(mock_coordinator, "test_entry", "relay_aux1_enable", props)
     ent.hass = MagicMock()
     ent.hass.services.async_call = AsyncMock()
-    ent.coordinator.request_refresh_with_followup = MagicMock()
     ent.coordinator.async_set_updated_data = MagicMock()
     await ent.async_select_option("manual")
     ent.hass.services.async_call.assert_awaited()
-    ent.coordinator.request_refresh_with_followup.assert_called()
     ent.coordinator.async_set_updated_data.assert_called()
 
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1109,3 +1109,38 @@ def test_select_filtvalve_mode_options(mock_coordinator):
     )
     mock_coordinator.data = {"MBF_PAR_FILTVALVE_MODE": 1}
     assert ent.options == ["enabled", "always_on", "always_off"]
+
+
+def test_optimistic_update_relay_mode(mock_coordinator):
+    """Optimistic update sets relay enable value for relay_mode selects."""
+    props = SELECT_DEFINITIONS["relay_aux1_mode"]
+    ent = VistaPoolSelect(mock_coordinator, "test_entry", "relay_aux1_mode", props)
+    mock_coordinator.data = {"relay_aux1_enable": 4}
+    ent._optimistic_update(3)
+    assert mock_coordinator.data["relay_aux1_enable"] == 3
+
+
+def test_optimistic_update_filt_mode(mock_coordinator):
+    """Optimistic update sets MBF_PAR_FILT_MODE value."""
+    props = SELECT_DEFINITIONS["MBF_PAR_FILT_MODE"]
+    ent = VistaPoolSelect(mock_coordinator, "test_entry", "MBF_PAR_FILT_MODE", props)
+    mock_coordinator.data = {"MBF_PAR_FILT_MODE": 0}
+    ent._optimistic_update(1)
+    assert mock_coordinator.data["MBF_PAR_FILT_MODE"] == 1
+
+
+def test_optimistic_update_noop_when_data_is_none(mock_coordinator):
+    """Optimistic update is a no-op when coordinator data is None."""
+    props = SELECT_DEFINITIONS["MBF_PAR_FILT_MODE"]
+    ent = VistaPoolSelect(mock_coordinator, "test_entry", "MBF_PAR_FILT_MODE", props)
+    mock_coordinator.data = None
+    ent._optimistic_update(1)  # Should not raise
+
+
+def test_optimistic_update_noop_when_value_is_none(mock_coordinator):
+    """Optimistic update is a no-op when value is None."""
+    props = SELECT_DEFINITIONS["MBF_PAR_FILT_MODE"]
+    ent = VistaPoolSelect(mock_coordinator, "test_entry", "MBF_PAR_FILT_MODE", props)
+    mock_coordinator.data = {"MBF_PAR_FILT_MODE": 0}
+    ent._optimistic_update(None)
+    assert mock_coordinator.data["MBF_PAR_FILT_MODE"] == 0

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -314,11 +314,11 @@ async def test_async_select_option_relay_mode(mock_coordinator):
     ent.hass = MagicMock()
     ent.hass.services.async_call = AsyncMock()
     ent.coordinator.async_request_refresh_with_followup = AsyncMock()
-    ent.async_write_ha_state = MagicMock()
+    ent.coordinator.async_set_updated_data = MagicMock()
     await ent.async_select_option("manual")
     ent.hass.services.async_call.assert_awaited()
     ent.coordinator.async_request_refresh_with_followup.assert_awaited()
-    ent.async_write_ha_state.assert_called()
+    ent.coordinator.async_set_updated_data.assert_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -313,11 +313,11 @@ async def test_async_select_option_relay_mode(mock_coordinator):
     ent = VistaPoolSelect(mock_coordinator, "test_entry", "relay_aux1_enable", props)
     ent.hass = MagicMock()
     ent.hass.services.async_call = AsyncMock()
-    ent.coordinator.async_request_refresh = AsyncMock()
+    ent.coordinator.async_request_refresh_with_followup = AsyncMock()
     ent.async_write_ha_state = MagicMock()
     await ent.async_select_option("manual")
     ent.hass.services.async_call.assert_awaited()
-    ent.coordinator.async_request_refresh.assert_awaited()
+    ent.coordinator.async_request_refresh_with_followup.assert_awaited()
     ent.async_write_ha_state.assert_called()
 
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -313,11 +313,11 @@ async def test_async_select_option_relay_mode(mock_coordinator):
     ent = VistaPoolSelect(mock_coordinator, "test_entry", "relay_aux1_enable", props)
     ent.hass = MagicMock()
     ent.hass.services.async_call = AsyncMock()
-    ent.coordinator.async_request_refresh_with_followup = AsyncMock()
+    ent.coordinator.request_refresh_with_followup = MagicMock()
     ent.coordinator.async_set_updated_data = MagicMock()
     await ent.async_select_option("manual")
     ent.hass.services.async_call.assert_awaited()
-    ent.coordinator.async_request_refresh_with_followup.assert_awaited()
+    ent.coordinator.request_refresh_with_followup.assert_called()
     ent.coordinator.async_set_updated_data.assert_called()
 
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -39,6 +39,8 @@ def mock_coordinator():
     mock.data = {}
     mock.device_slug = "vistapool"
     mock.winter_mode = False
+    mock.async_set_updated_data = MagicMock()
+    mock.request_refresh_with_followup = MagicMock()
     config_entry = MagicMock()
     config_entry.entry_id = "test_entry"
     config_entry.unique_id = "test_slug"
@@ -313,7 +315,6 @@ async def test_async_select_option_relay_mode(mock_coordinator):
     ent = VistaPoolSelect(mock_coordinator, "test_entry", "relay_aux1_enable", props)
     ent.hass = MagicMock()
     ent.hass.services.async_call = AsyncMock()
-    ent.coordinator.async_set_updated_data = MagicMock()
     await ent.async_select_option("manual")
     ent.hass.services.async_call.assert_awaited()
     ent.coordinator.async_set_updated_data.assert_called()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -33,6 +33,7 @@ def mock_coordinator():
     mock.device_slug = "vistapool"
     mock.config_entry.entry_id = "test_entry"
     mock.winter_mode = False
+    mock.async_request_refresh_with_followup = AsyncMock()
     return mock
 
 
@@ -954,3 +955,38 @@ async def test_switch_setup_skips_uv_mode_when_gpio_out_of_range(monkeypatch):
     entities = async_add_entities.call_args[0][0]
     keys = [e._key for e in entities]
     assert "MBF_PAR_UV_MODE" not in keys
+
+
+@pytest.mark.asyncio
+async def test_follow_up_refresh_called_on_turn_on(mock_coordinator):
+    """Follow-up refresh is used after turn_on for IO switch types."""
+    props = make_props(switch_type="manual_filtration")
+    ent = VistaPoolSwitch(mock_coordinator, "test_entry", "manual", props)
+    ent.coordinator.client = AsyncMock()
+    ent.async_write_ha_state = MagicMock()
+    await ent.async_turn_on()
+    ent.coordinator.async_request_refresh_with_followup.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_follow_up_refresh_called_on_turn_off(mock_coordinator):
+    """Follow-up refresh is used after turn_off for IO switch types."""
+    props = make_props(switch_type="aux", relay_index=1)
+    ent = VistaPoolSwitch(mock_coordinator, "test_entry", "aux1", props)
+    ent.coordinator.client = AsyncMock()
+    ent.async_write_ha_state = MagicMock()
+    await ent.async_turn_off()
+    ent.coordinator.async_request_refresh_with_followup.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_follow_up_refresh_for_non_io_switch(mock_coordinator):
+    """Non-IO switches use plain refresh without follow-up."""
+    props = make_props(switch_type="auto_time_sync")
+    ent = VistaPoolSwitch(mock_coordinator, "test_entry", "sync", props)
+    ent.coordinator.set_auto_time_sync = AsyncMock()
+    ent.coordinator.async_request_refresh = AsyncMock()
+    ent.async_write_ha_state = MagicMock()
+    await ent.async_turn_on()
+    ent.coordinator.async_request_refresh.assert_awaited_once()
+    ent.coordinator.async_request_refresh_with_followup.assert_not_awaited()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -33,7 +33,7 @@ def mock_coordinator():
     mock.device_slug = "vistapool"
     mock.config_entry.entry_id = "test_entry"
     mock.winter_mode = False
-    mock.async_request_refresh_with_followup = AsyncMock()
+    mock.request_refresh_with_followup = MagicMock()
     return mock
 
 
@@ -965,7 +965,7 @@ async def test_follow_up_refresh_called_on_turn_on(mock_coordinator):
     ent.coordinator.client = AsyncMock()
     ent.async_write_ha_state = MagicMock()
     await ent.async_turn_on()
-    ent.coordinator.async_request_refresh_with_followup.assert_awaited_once()
+    ent.coordinator.request_refresh_with_followup.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -976,7 +976,7 @@ async def test_follow_up_refresh_called_on_turn_off(mock_coordinator):
     ent.coordinator.client = AsyncMock()
     ent.async_write_ha_state = MagicMock()
     await ent.async_turn_off()
-    ent.coordinator.async_request_refresh_with_followup.assert_awaited_once()
+    ent.coordinator.request_refresh_with_followup.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -989,7 +989,7 @@ async def test_no_follow_up_refresh_for_non_io_switch(mock_coordinator):
     ent.async_write_ha_state = MagicMock()
     await ent.async_turn_on()
     ent.coordinator.async_request_refresh.assert_awaited_once()
-    ent.coordinator.async_request_refresh_with_followup.assert_not_awaited()
+    ent.coordinator.request_refresh_with_followup.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1005,6 +1005,18 @@ async def test_optimistic_update_manual_filtration(mock_coordinator):
 
 
 @pytest.mark.asyncio
+async def test_optimistic_update_aux(mock_coordinator):
+    """Optimistic update sets data[key] for aux switches."""
+    mock_coordinator.data = {"aux1": False}
+    props = make_props(switch_type="aux", relay_index=1)
+    ent = VistaPoolSwitch(mock_coordinator, "test_entry", "aux1", props)
+    ent._optimistic_update(True)
+    assert mock_coordinator.data["aux1"] is True
+    ent._optimistic_update(False)
+    assert mock_coordinator.data["aux1"] is False
+
+
+@pytest.mark.asyncio
 async def test_optimistic_update_relay_timer(mock_coordinator):
     """Optimistic update sets relay enable value for relay_timer switches."""
     mock_coordinator.data = {"relay_aux1_enable": 4}

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -990,3 +990,57 @@ async def test_no_follow_up_refresh_for_non_io_switch(mock_coordinator):
     await ent.async_turn_on()
     ent.coordinator.async_request_refresh.assert_awaited_once()
     ent.coordinator.async_request_refresh_with_followup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_optimistic_update_manual_filtration(mock_coordinator):
+    """Optimistic update sets MBF_PAR_FILT_MANUAL_STATE correctly."""
+    mock_coordinator.data = {"MBF_PAR_FILT_MANUAL_STATE": 0}
+    props = make_props(switch_type="manual_filtration")
+    ent = VistaPoolSwitch(mock_coordinator, "test_entry", "manual", props)
+    ent._optimistic_update(True)
+    assert mock_coordinator.data["MBF_PAR_FILT_MANUAL_STATE"] == 1
+    ent._optimistic_update(False)
+    assert mock_coordinator.data["MBF_PAR_FILT_MANUAL_STATE"] == 0
+
+
+@pytest.mark.asyncio
+async def test_optimistic_update_relay_timer(mock_coordinator):
+    """Optimistic update sets relay enable value for relay_timer switches."""
+    mock_coordinator.data = {"relay_aux1_enable": 4}
+    props = make_props(
+        switch_type="relay_timer",
+        timer_block_addr=0x04AC,
+        function_addr=0x04B7,
+        function_code=0x0800,
+    )
+    ent = VistaPoolSwitch(mock_coordinator, "test_entry", "aux1", props)
+    ent._optimistic_update(True)
+    assert mock_coordinator.data["relay_aux1_enable"] == 3
+    ent._optimistic_update(False)
+    assert mock_coordinator.data["relay_aux1_enable"] == 4
+
+
+@pytest.mark.asyncio
+async def test_optimistic_update_bitmask(mock_coordinator):
+    """Optimistic update sets bitmask values correctly."""
+    mock_coordinator.data = {"MBF_PAR_HIDRO_COVER_ENABLE": 0}
+    props = make_props(
+        switch_type="bitmask",
+        function_addr=0x042C,
+        mask_bit=0x0001,
+        data_key="MBF_PAR_HIDRO_COVER_ENABLE",
+    )
+    ent = VistaPoolSwitch(mock_coordinator, "test_entry", "cover", props)
+    ent._optimistic_update(True)
+    assert mock_coordinator.data["MBF_PAR_HIDRO_COVER_ENABLE"] == 1
+    ent._optimistic_update(False)
+    assert mock_coordinator.data["MBF_PAR_HIDRO_COVER_ENABLE"] == 0
+
+
+def test_optimistic_update_noop_when_data_is_none(mock_coordinator):
+    """Optimistic update is a no-op when coordinator data is None."""
+    mock_coordinator.data = None
+    props = make_props(switch_type="manual_filtration")
+    ent = VistaPoolSwitch(mock_coordinator, "test_entry", "manual", props)
+    ent._optimistic_update(True)  # Should not raise


### PR DESCRIPTION
### 🎯 Problem

After toggling switches, lights, or selects that write to Modbus registers, the device needs time to process the write. The first poll reads stale register values, causing the UI to briefly bounce back to the old state before showing the correct value on the next polling cycle (30s).

### 🔧 Solution

**Optimistic state updates** — after a Modbus write, the integration immediately sets the expected value in `coordinator.data` and notifies all coordinator listeners via `async_set_updated_data()`, so the UI reflects the new state instantly without any bounce-back. A `None` guard prevents propagating unknown states if coordinator data is unavailable.

**Scheduled follow-up refresh** — a synchronous `request_refresh_with_followup()` schedules a non-blocking `async_call_later` callback that fires after 2 seconds to re-read registers and confirm the actual device state. If multiple actions occur in quick succession, previous follow-ups are cancelled (and the stale handle cleared immediately) to avoid stacking.

**Centralized refresh in `set_timer` handler** — the `set_timer` service handler schedules a follow-up refresh after each timer write, so external callers (automations, scripts) also get timely state updates. Entity-level callers that go through `set_timer` rely on this and do not schedule duplicate follow-ups.

**Cleanup on unload** — any pending follow-up timer is cancelled during `async_unload_entry` to prevent errors when the Modbus client is closed.

### 📦 Changes

#### Coordinator (`coordinator.py`)

- ✨ Add `request_refresh_with_followup()` — synchronous method that schedules a delayed follow-up refresh via `async_call_later`
- ✨ Add `cancel_follow_up_refresh()` — cancels pending follow-up on config entry unload
- 🏷️ Use `CALLBACK_TYPE` from `homeassistant.core` for `_follow_up_unsub` annotation
- 🩹 Clear stale `_follow_up_unsub` immediately after cancel in `_schedule_follow_up_refresh`
- 🔧 New constant `FOLLOW_UP_REFRESH_DELAY = 2.0` in `const.py`

#### Switch (`switch.py`)

- ✨ Add `_optimistic_update()` method for all IO switch types (manual_filtration, aux, relay_timer, climate_mode, smart_anti_freeze, uv_mode, bitmask)
- ♻️ Replace `asyncio.sleep` + immediate refresh with optimistic update + `async_set_updated_data` + follow-up
- 🐛 Guard `async_set_updated_data` against `None` coordinator data

#### Light (`light.py`)

- ✨ Add `_optimistic_update()` method for relay_timer light
- ♻️ Replace `asyncio.sleep(2.0)` + immediate refresh with optimistic update + `async_set_updated_data` + follow-up
- 🐛 Guard `async_set_updated_data` against `None` coordinator data

#### Select (`select.py`)

- ✨ Add `_optimistic_update()` method for relay_mode and filtration mode selects
- ♻️ Replace `asyncio.sleep` delays with optimistic update + `async_set_updated_data`
- ♻️ Respect configurable `timer_field` prop in `_optimistic_update` for relay_mode
- ♻️ Remove duplicate follow-up scheduling from `set_timer` callers (handler already schedules it)
- 🐛 Guard `async_set_updated_data` against `None` coordinator data

#### Init (`__init__.py`)

- ♻️ Replace `async_request_refresh()` with `request_refresh_with_followup()` in `set_timer` handler
- 🐛 Call `cancel_follow_up_refresh()` in `async_unload_entry` before closing Modbus client

### ✅ Tests

- 583 tests passing, 100% code coverage
- Tests for follow-up scheduling, cancellation, callback execution, custom delay
- Tests for optimistic updates across all entity types (switch, light, select)
- Tests for `None` data guard (no-op when coordinator data unavailable)
- Test for cleanup on config entry unload
