### PR TITLE
fix: sensor for actual current filtration speed

### DIFF
--- a/custom_components/vistapool/helpers.py
+++ b/custom_components/vistapool/helpers.py
@@ -233,7 +233,7 @@ def get_filtration_speed(data) -> int:
         return 0  # Filtration is off
 
     par_filtration_conf = data.get("MBF_PAR_FILTRATION_CONF", 0)
-    relay_speed = (relay_state & 0x00E0) >> 5
+    relay_speed = (relay_state & 0x0700) >> 8
     if relay_speed == 1:
         return 1  # Low
     elif relay_speed == 2:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -58,7 +58,7 @@ def test_build_timer_block():
     assert isinstance(regs, list) and len(regs) == 15
 
 
-def test_get_filtration_speed_low():
+def test_get_filtration_speed_mid():
     d = {"MBF_RELAY_STATE": 0x0202, "MBF_PAR_FILTRATION_CONF": 0x0000}
     # relay_speed == 2 → Mid
     assert get_filtration_speed(d) == 2

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -59,13 +59,13 @@ def test_build_timer_block():
 
 
 def test_get_filtration_speed_low():
-    d = {"MBF_RELAY_STATE": 0x0042, "MBF_PAR_FILTRATION_CONF": 0x0000}
+    d = {"MBF_RELAY_STATE": 0x0202, "MBF_PAR_FILTRATION_CONF": 0x0000}
     # relay_speed == 2 → Mid
     assert get_filtration_speed(d) == 2
 
 
 def test_get_filtration_speed_high():
-    d = {"MBF_RELAY_STATE": 0x0082, "MBF_PAR_FILTRATION_CONF": 0x0000}
+    d = {"MBF_RELAY_STATE": 0x0402, "MBF_PAR_FILTRATION_CONF": 0x0000}
     # relay_speed == 4 → High
     assert get_filtration_speed(d) == 3
 
@@ -86,7 +86,7 @@ def test_get_filtration_speed_conf_speed_2():
 
 
 def test_get_filtration_speed_relay_speed_1():
-    d = {"MBF_RELAY_STATE": 0x0022, "MBF_PAR_FILTRATION_CONF": 0x0000}
+    d = {"MBF_RELAY_STATE": 0x0102, "MBF_PAR_FILTRATION_CONF": 0x0000}
     # relay_speed == 1, should return 1 (Low)
     assert get_filtration_speed(d) == 1
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -91,6 +91,13 @@ def test_get_filtration_speed_relay_speed_1():
     assert get_filtration_speed(d) == 1
 
 
+@pytest.mark.parametrize("aux_bit", [0x0010, 0x0020, 0x0040])
+def test_get_filtration_speed_aux_bits_do_not_affect_speed(aux_bit):
+    # filtration ON (0x0002), speed MID (0x0200), plus AUX relay bit set
+    d = {"MBF_RELAY_STATE": 0x0202 | aux_bit, "MBF_PAR_FILTRATION_CONF": 0x0000}
+    assert get_filtration_speed(d) == 2
+
+
 def test_get_filtration_speed_no_match():
     d = {"MBF_RELAY_STATE": 0x0002, "MBF_PAR_FILTRATION_CONF": 0x00F0}
     # relay_speed == 0, conf_speed == 15 (not 0,1,2) → default 0


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] An issue has been opened for this change as a [bug report or feature request](https://github.com/oncepassaway/homeassistant-vistapool-modbus/issues/new/choose)  
       → This allows us to discuss the idea, evaluate designs, and align on expectations.
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) standard.
- [x] Documentation has been updated if needed (e.g. `README.md`, docstrings). - not required

## Related Issue

Resolves #112
