### PR TITLE
fix(sensor): 🩹 derive ph alarm states from MBF_PH_STATUS register

### DIFF
--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -190,6 +190,7 @@ SENSOR_DEFINITIONS = {
         "device_class": SensorDeviceClass.ENUM,
         "state_class": None,
         "entity_category": EntityCategory.DIAGNOSTIC,
+        "icon": "mdi:ph",
     },
     "HIDRO_POLARITY": {
         "name": "Hydrolysis Polarity",

--- a/custom_components/vistapool/modbus.py
+++ b/custom_components/vistapool/modbus.py
@@ -517,11 +517,17 @@ class VistaPoolModbusClient:
             })
             # fmt: on
 
+            # Extract pH status enum from lower bits of MBF_PH_STATUS
+            _ph_status = get_safe(reg01, 7)
+            result["MBF_PH_STATUS_ALARM"] = (
+                (_ph_status & 0x000F) if _ph_status is not None else None
+            )
+
             # After loading reg01, update result with all decodings:
             # fmt: off
             result.update(
                 {
-                    **decode_ph_rx_cl_cd_status_bits(get_safe(reg01, 7), "pH"),
+                    **decode_ph_rx_cl_cd_status_bits(_ph_status, "pH"),
                     **decode_ph_rx_cl_cd_status_bits(get_safe(reg01, 8), "Redox"),
                     **decode_ph_rx_cl_cd_status_bits(get_safe(reg01, 9), "Chlorine"),
                     **decode_ph_rx_cl_cd_status_bits(get_safe(reg01, 10), "Conductivity"),
@@ -614,7 +620,6 @@ class VistaPoolModbusClient:
                     "MBF_POWER_MODULE_NODEID": reg00[4:10],             # 0x0004         ! Power module Node ID (6 register 0x0004 - 0x0009)
                     "MBF_POWER_MODULE_REGISTER": get_safe(reg00, 12),   # 0x000C         ! Writing an address in this register causes the power module register address to be read out into MBF_POWER_MODULE_DATA, see MBF_POWER_MODULE_REG_*
                     "MBF_POWER_MODULE_DATA": get_safe(reg00, 13),       # 0x000D         ! power module data as requested in MBF_POWER_MODULE_REGISTER
-                    "MBF_PH_STATUS_ALARM": get_safe(reg00, 15),         # 0x000F           PH alarm. The possible alarm values are depending on the regulation model
                     # Prepared for future use:
                     # "MBF_VOLT_24_36": get_safe(reg00, 16),            # 0x0022*        ! Current 24-36V line in mV
                     # "MBF_VOLT_12": get_safe(reg00, 17),               # 0x0023*        ! Current 12V line in mV

--- a/custom_components/vistapool/sensor.py
+++ b/custom_components/vistapool/sensor.py
@@ -53,10 +53,10 @@ FILTRATION_SPEED_MAP = {
 }
 
 PH_STATUS_ALARM_MAP = {
-    0: "no_alarm",
+    0: "ok",
     1: "ph_high",
     2: "ph_low",
-    3: "ph_stopped",
+    3: "pump_stopped",
     4: "ph_over",
     5: "ph_under",
     6: "tank_level",
@@ -84,7 +84,7 @@ async def async_setup_entry(
         ):
             continue
         if (
-            key == "MBF_MEASURE_PH"
+            key in ("MBF_MEASURE_PH", "MBF_PH_STATUS_ALARM")
             and coordinator.data.get("pH measurement module detected") is not True
         ):
             continue
@@ -201,10 +201,11 @@ class VistaPoolSensor(VistaPoolEntity, SensorEntity):
         # PH alarm icons
         if self._key == "MBF_PH_STATUS_ALARM":
             status = PH_STATUS_ALARM_MAP.get(raw)
-            if status == "no_alarm":
+            if status == "ok":
                 return "mdi:check-circle-outline"
-            else:
+            if status is not None:
                 return "mdi:alert"
+            return self._attr_icon or None
         if self._key == "MBF_HIDRO_CURRENT":
             return (
                 "mdi:air-humidifier"

--- a/custom_components/vistapool/translations/cs.json
+++ b/custom_components/vistapool/translations/cs.json
@@ -88,10 +88,10 @@
       "ph_status_alarm": {
         "name": "pH Alarm",
         "state": {
-          "no_alarm": "OK",
-          "ph_high": "pH je moc nízké",
-          "ph_low": "pH je moc vysoké",
-          "ph_stopped": "pH pumpa zastavena (překročený pracovní čas)",
+          "ok": "OK",
+          "ph_high": "pH je příliš vysoké",
+          "ph_low": "pH je příliš nízké",
+          "pump_stopped": "Čerpadlo zastaveno (překročena pracovní doba)",
           "ph_over": "pH je vyšší než nastavená hodnota",
           "ph_under": "pH je nižší než nastavená hodnota",
           "tank_level": "Alarm hladiny nádrže"

--- a/custom_components/vistapool/translations/de.json
+++ b/custom_components/vistapool/translations/de.json
@@ -88,10 +88,10 @@
       "ph_status_alarm": {
         "name": "pH-Alarm",
         "state": {
-          "no_alarm": "OK",
+          "ok": "OK",
           "ph_high": "pH zu hoch",
           "ph_low": "pH zu niedrig",
-          "ph_stopped": "pH-Pumpe gestoppt (Arbeitszeit überschritten)",
+          "pump_stopped": "Pumpe gestoppt (Arbeitszeit überschritten)",
           "ph_over": "pH über dem Sollwert",
           "ph_under": "pH unter dem Sollwert",
           "tank_level": "Tankfüllstandsalarm"

--- a/custom_components/vistapool/translations/en.json
+++ b/custom_components/vistapool/translations/en.json
@@ -88,10 +88,10 @@
       "ph_status_alarm": {
         "name": "pH Alarm",
         "state": {
-          "no_alarm": "OK",
+          "ok": "OK",
           "ph_high": "pH too high",
           "ph_low": "pH too low",
-          "ph_stopped": "pH Pump Stopped (exceeded working time)",
+          "pump_stopped": "Pump stopped (exceeded working time)",
           "ph_over": "pH higher than the set point",
           "ph_under": "pH lower than the set point",
           "tank_level": "Tank level alarm"

--- a/custom_components/vistapool/translations/es.json
+++ b/custom_components/vistapool/translations/es.json
@@ -88,10 +88,10 @@
       "ph_status_alarm": {
         "name": "Alarma de pH",
         "state": {
-          "no_alarm": "OK",
-          "ph_high": "pH alto",
-          "ph_low": "pH bajo",
-          "ph_stopped": "Bomba de pH detenida (tiempo excedido)",
+          "ok": "OK",
+          "ph_high": "pH demasiado alto",
+          "ph_low": "pH demasiado bajo",
+          "pump_stopped": "Bomba detenida (tiempo excedido)",
           "ph_over": "pH por encima del objetivo",
           "ph_under": "pH por debajo del objetivo",
           "tank_level": "Alarma de nivel de tanque"

--- a/custom_components/vistapool/translations/fr.json
+++ b/custom_components/vistapool/translations/fr.json
@@ -88,10 +88,10 @@
       "ph_status_alarm": {
         "name": "Alarme pH",
         "state": {
-          "no_alarm": "OK",
+          "ok": "OK",
           "ph_high": "pH trop élevé",
           "ph_low": "pH trop bas",
-          "ph_stopped": "Pompe pH arrêtée (temps de fonctionnement dépassé)",
+          "pump_stopped": "Pompe arrêtée (temps de fonctionnement dépassé)",
           "ph_over": "pH au-dessus de la cible",
           "ph_under": "pH en dessous de la cible",
           "tank_level": "Alarme de niveau de cuve"

--- a/custom_components/vistapool/translations/it.json
+++ b/custom_components/vistapool/translations/it.json
@@ -88,10 +88,10 @@
       "ph_status_alarm": {
         "name": "Allarme pH",
         "state": {
-          "no_alarm": "OK",
-          "ph_high": "pH alto",
-          "ph_low": "pH basso",
-          "ph_stopped": "Pompa pH fermata (tempo di lavoro superato)",
+          "ok": "OK",
+          "ph_high": "pH troppo alto",
+          "ph_low": "pH troppo basso",
+          "pump_stopped": "Pompa fermata (tempo di lavoro superato)",
           "ph_over": "pH sopra il target",
           "ph_under": "pH sotto il target",
           "tank_level": "Allarme livello serbatoio"

--- a/custom_components/vistapool/translations/pl.json
+++ b/custom_components/vistapool/translations/pl.json
@@ -88,10 +88,10 @@
       "ph_status_alarm": {
         "name": "Alarm pH",
         "state": {
-          "no_alarm": "OK",
+          "ok": "OK",
           "ph_high": "pH za wysokie",
           "ph_low": "pH za niskie",
-          "ph_stopped": "Pompa pH zatrzymana (przekroczony czas pracy)",
+          "pump_stopped": "Pompa zatrzymana (przekroczony czas pracy)",
           "ph_over": "pH powyżej celu",
           "ph_under": "pH poniżej celu",
           "tank_level": "Alarm poziomu zbiornika"

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -354,7 +354,7 @@ async def test_perform_read_all_happy_path(config, monkeypatch):
                     0,
                     22069,
                     0,
-                    0,  # 0x000F MBF_PH_STATUS_ALARM
+                    0,  # 0x000F (unused)
                 ]
             ),  # rr00
             DummyResp(
@@ -433,6 +433,9 @@ async def test_perform_read_all_happy_path(config, monkeypatch):
     assert "MBF_PAR_PH1" in result
     assert result["MBF_PAR_PH1"] == 7.5
     assert "FILTRATION_SPEED" in result
+    # MBF_PH_STATUS_ALARM derived from MBF_PH_STATUS (reg01[7]=50560=0xC580)
+    # lower 4 bits: 0xC580 & 0x000F = 0
+    assert result["MBF_PH_STATUS_ALARM"] == 0
 
     # Verify that all Modbus calls were made as expected
     assert fake_modbus.read_holding_registers.await_count == 10

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -173,6 +173,12 @@ def test_native_value_special_keys(mock_coordinator):
     ent = VistaPoolSensor(mock_coordinator, "test_entry", "MBF_PH_STATUS_ALARM", {})
     mock_coordinator.data = {"MBF_PH_STATUS_ALARM": 2}
     assert ent.native_value == "ph_low"
+    mock_coordinator.data = {"MBF_PH_STATUS_ALARM": 0}
+    assert ent.native_value == "ok"
+    mock_coordinator.data = {"MBF_PH_STATUS_ALARM": 3}
+    assert ent.native_value == "pump_stopped"
+    mock_coordinator.data = {"MBF_PH_STATUS_ALARM": 6}
+    assert ent.native_value == "tank_level"
 
 
 def test_native_value_default(mock_coordinator):
@@ -294,6 +300,8 @@ async def test_sensor_async_setup_entry_detected_flags(monkeypatch):
     # MBF_MEASURE_PH and MBF_MEASURE_RX should be skipped
     assert "MBF_MEASURE_PH" not in keys
     assert "MBF_MEASURE_RX" not in keys
+    # MBF_PH_STATUS_ALARM is also gated by pH detection flag
+    assert "MBF_PH_STATUS_ALARM" not in keys
 
 
 @pytest.mark.asyncio
@@ -357,6 +365,17 @@ def test_icon_ph_alarm(mock_coordinator):
     # Alarm
     mock_coordinator.data = {"MBF_PH_STATUS_ALARM": 3}
     assert ent.icon == "mdi:alert"
+
+
+def test_icon_ph_status_alarm_default_icon(mock_coordinator):
+    props = make_props(icon="mdi:ph")
+    ent = VistaPoolSensor(mock_coordinator, "test_entry", "MBF_PH_STATUS_ALARM", props)
+    mock_coordinator.data = {"MBF_PH_STATUS_ALARM": 0}
+    assert ent.icon == "mdi:check-circle-outline"
+    mock_coordinator.data = {"MBF_PH_STATUS_ALARM": 1}
+    assert ent.icon == "mdi:alert"
+    mock_coordinator.data = {"MBF_PH_STATUS_ALARM": None}
+    assert ent.icon == "mdi:ph"
 
 
 def test_icon_hidro_current(mock_coordinator):
@@ -593,13 +612,13 @@ async def test_sensor_setup_with_capability_snapshot_only():
     assert "MBF_MEASURE_TEMPERATURE" in keys
     assert "MBF_ION_CURRENT" in keys
     assert "FILTRATION_SPEED" in keys
+    assert "MBF_PH_STATUS_ALARM" in keys
     assert "MBF_PAR_INTELLIGENT_INTERVALS" in keys
     assert "MBF_PAR_INTELLIGENT_TT_NEXT_INTERVAL" in keys
     # Unconditional sensors
     assert "MBF_HIDRO_CURRENT" in keys
     assert "MBF_HIDRO_VOLTAGE" in keys
     assert "MBF_PAR_FILT_MODE" in keys
-    assert "MBF_PH_STATUS_ALARM" in keys
     assert "HIDRO_POLARITY" in keys
 
 


### PR DESCRIPTION
## Fix pH Alarm State Source

### 📋 Description

This change fixes the existing `MBF_PH_STATUS_ALARM` sensor so it reads its state from `MBF_PH_STATUS` register `0x0107` low 4 bits instead of the MODBUS page register `0x000F`.

The entity key stays unchanged, but its enum values now reflect the actual pH module status exposed by the device:

- ✅ **ok** — pH within setpoint
- ⚠️ **ph_high** — pH too high
- ⚠️ **ph_low** — pH too low
- ⏹️ **pump_stopped** — dosing pump stopped after exceeding allowed working time
- 🔴 **ph_over** — pH above setpoint
- 🔴 **ph_under** — pH below setpoint
- 🚨 **tank_level** — tank level alarm

### 🔧 Changes

- **modbus.py** — derive `MBF_PH_STATUS_ALARM` from `MBF_PH_STATUS` (`0x0107 & 0x000F`) and stop reading the obsolete value from register `0x000F`
- **sensor.py** — update enum mapping, apply the same pH module detection gate as other pH sensors, and improve icon fallback for unknown values
- **const.py** — add the pH icon to the existing `MBF_PH_STATUS_ALARM` sensor definition
- **translations/** — keep the original alarm entity name while updating state keys and labels in all 7 supported languages
- **tests/** — update coverage for register extraction, enum mapping, icon behavior, and setup gating

### ✅ Testing

- `MBF_PH_STATUS_ALARM` is extracted from `MBF_PH_STATUS` bits 0-3
- Enum values are mapped to the updated state names
- Icon handling returns `check-circle-outline` for `ok`, `alert` for known alarm states, and falls back to the configured default icon for unknown values
- Sensor setup is skipped when the pH measurement module is not detected
- Focused test run passed: `tests/test_modbus.py` and `tests/test_sensor.py`

### 🌍 Localization

- English (en)
- Czech (cs)
- German (de)
- Spanish (es)
- French (fr)
- Italian (it)
- Polish (pl)
