### PR TITLE
fix: 🐛 gate entities on hardware module presence

### DIFF
--- a/custom_components/vistapool/binary_sensor.py
+++ b/custom_components/vistapool/binary_sensor.py
@@ -71,6 +71,16 @@ async def async_setup_entry(
             (coordinator.data.get("MBF_PAR_MODEL") or 0) & 0x0001
         ):
             continue  # pragma: no cover
+        # Skip HIDRO entities if no hydrolysis module is installed
+        if key.startswith("HIDRO ") and not coordinator.data.get(
+            "Hydrolysis module detected"
+        ):
+            continue
+        # Skip pH Acid Pump relay if acid pump relay is not assigned
+        if key == "pH Acid Pump" and not bool(
+            coordinator.data.get("MBF_PAR_PH_ACID_RELAY_GPIO")
+        ):
+            continue
         # Skip UV Lamp if UV relay is not assigned
         if key == "UV Lamp":
             uv_gpio = coordinator.data.get("MBF_PAR_UV_RELAY_GPIO", 0) or 0

--- a/custom_components/vistapool/binary_sensor.py
+++ b/custom_components/vistapool/binary_sensor.py
@@ -77,8 +77,8 @@ async def async_setup_entry(
         ):
             continue
         # Skip pH Acid Pump relay if acid pump relay is not assigned
-        if key == "pH Acid Pump" and not bool(
-            coordinator.data.get("MBF_PAR_PH_ACID_RELAY_GPIO")
+        if key == "pH Acid Pump" and not is_valid_relay_gpio(
+            coordinator.data.get("MBF_PAR_PH_ACID_RELAY_GPIO", 0) or 0
         ):
             continue
         # Skip UV Lamp if UV relay is not assigned

--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -86,6 +86,7 @@ CAPABILITY_KEYS = (
     "MBF_PAR_UV_RELAY_GPIO",
     "MBF_PAR_FILTVALVE_ENABLE",
     "MBF_PAR_FILTVALVE_GPIO",
+    "Hydrolysis module detected",
     "pH measurement module detected",
     "Redox measurement module detected",
     "Chlorine measurement module detected",

--- a/custom_components/vistapool/modbus.py
+++ b/custom_components/vistapool/modbus.py
@@ -1091,6 +1091,12 @@ class VistaPoolModbusClient:
         # Update cache after fixup so partial reads start from consistent patched values
         self._cached_result.update(result)
 
+        # Derive hydrolysis module presence:
+        # MBF_PAR_MODEL bit 1 (MBMSK_MODEL_HIDRO) OR MBF_HIDRO_STATUS bit 6 (CTRL_ACTIVE)
+        result["Hydrolysis module detected"] = bool(
+            (result.get("MBF_PAR_MODEL") or 0) & 0x0002
+        ) or bool((result.get("MBF_HIDRO_STATUS") or 0) & 0x0040)
+
         # Add filtration speed and type
         result["FILTRATION_SPEED"] = get_filtration_speed(result)
 

--- a/custom_components/vistapool/modbus.py
+++ b/custom_components/vistapool/modbus.py
@@ -1088,9 +1088,6 @@ class VistaPoolModbusClient:
                 else:
                     result["MBF_RELAY_STATE"] = relay_state & ~0x0002
 
-        # Update cache after fixup so partial reads start from consistent patched values
-        self._cached_result.update(result)
-
         # Derive hydrolysis module presence:
         # MBF_PAR_MODEL bit 1 (MBMSK_MODEL_HIDRO) OR MBF_HIDRO_STATUS bit 6 (CTRL_ACTIVE)
         result["Hydrolysis module detected"] = bool(
@@ -1099,6 +1096,10 @@ class VistaPoolModbusClient:
 
         # Add filtration speed and type
         result["FILTRATION_SPEED"] = get_filtration_speed(result)
+
+        # Update cache after fixup and derived fields so partial reads
+        # start from consistent values including derived flags.
+        self._cached_result.update(result)
 
         # _LOGGER.debug("All Results: %s", result)
         return result

--- a/custom_components/vistapool/number.py
+++ b/custom_components/vistapool/number.py
@@ -79,14 +79,19 @@ async def async_setup_entry(
         if key == "MBF_PAR_CL1":
             if not bool(coordinator.data.get("Chlorine measurement module detected")):
                 continue
+        # Skip hydrolysis target if no hydrolysis module is installed
+        if key == "MBF_PAR_HIDRO" and not coordinator.data.get(
+            "Hydrolysis module detected"
+        ):
+            continue
         # Cover reduction numbers only visible when hydrolysis module present
         if key == "MBF_PAR_HIDRO_COVER_REDUCTION":
-            if not bool(coordinator.data.get("MBF_PAR_HIDRO_NOM")):
+            if not coordinator.data.get("Hydrolysis module detected"):
                 continue
         # Shutdown temperature needs hydrolysis and temperature sensor
         if key == "MBF_PAR_HIDRO_SHUTDOWN_TEMPERATURE":
             if (
-                not bool(coordinator.data.get("MBF_PAR_HIDRO_NOM"))
+                not coordinator.data.get("Hydrolysis module detected")
                 or coordinator.data.get("MBF_PAR_TEMPERATURE_ACTIVE", 0) == 0
             ):
                 continue

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -79,6 +79,12 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             "MBF_PAR_FILTVALVE_MODE",
         ) and not has_filtvalve(coordinator.data):
             continue
+        # Skip relay activation delay if no pH module is detected
+        if (
+            key == "MBF_PAR_RELAY_ACTIVATION_DELAY"
+            and coordinator.data.get("pH measurement module detected") is not True
+        ):
+            continue
 
         option_key = props.get("option")
         if option_key and not entry.options.get(option_key, False):

--- a/custom_components/vistapool/sensor.py
+++ b/custom_components/vistapool/sensor.py
@@ -108,6 +108,12 @@ async def async_setup_entry(
             (coordinator.data.get("MBF_PAR_MODEL") or 0) & 0x0001
         ):
             continue
+        if key in (
+            "MBF_HIDRO_CURRENT",
+            "MBF_HIDRO_VOLTAGE",
+            "HIDRO_POLARITY",
+        ) and not coordinator.data.get("Hydrolysis module detected"):
+            continue
         if key == "FILTRATION_SPEED" and not get_filtration_pump_type(
             coordinator.data.get("MBF_PAR_FILTRATION_CONF", 0)
         ):

--- a/custom_components/vistapool/switch.py
+++ b/custom_components/vistapool/switch.py
@@ -64,11 +64,13 @@ async def async_setup_entry(
                 continue
         # Hydro cover-reduction switch only when hydrolysis module present
         if key == "MBF_PAR_HIDRO_COVER_ENABLE":
-            if not bool(coordinator.data.get("MBF_PAR_HIDRO_NOM")):
+            if not coordinator.data.get("Hydrolysis module detected"):
                 continue
         # Hydro temp-shutdown switch needs hydrolysis and temperature sensor
         if key == "MBF_PAR_HIDRO_TEMP_SHUTDOWN":
-            if not bool(coordinator.data.get("MBF_PAR_HIDRO_NOM")) or not bool(
+            if not coordinator.data.get(
+                "Hydrolysis module detected"
+            ) or not bool(
                 coordinator.data.get("MBF_PAR_TEMPERATURE_ACTIVE")
             ):
                 continue

--- a/custom_components/vistapool/switch.py
+++ b/custom_components/vistapool/switch.py
@@ -68,9 +68,7 @@ async def async_setup_entry(
                 continue
         # Hydro temp-shutdown switch needs hydrolysis and temperature sensor
         if key == "MBF_PAR_HIDRO_TEMP_SHUTDOWN":
-            if not coordinator.data.get(
-                "Hydrolysis module detected"
-            ) or not bool(
+            if not coordinator.data.get("Hydrolysis module detected") or not bool(
                 coordinator.data.get("MBF_PAR_TEMPERATURE_ACTIVE")
             ):
                 continue

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -51,6 +51,7 @@ async def test_async_setup_entry_adds_entities(monkeypatch):
             "MBF_PAR_MODEL": 0x000F,  # All bits set (should allow all modules)
             "MBF_PAR_PH_BASE_RELAY_GPIO": True,
             "MBF_PAR_PH_ACID_RELAY_GPIO": True,
+            "Hydrolysis module detected": True,
             "Chlorine measurement module detected": True,
             "Redox measurement module detected": True,
         }
@@ -78,6 +79,11 @@ async def test_async_setup_entry_adds_entities(monkeypatch):
     # Should contain at least one expected sensor (by key from BINARY_SENSOR_DEFINITIONS)
     # For example, "pH acid pump active"
     assert any("acid" in k for k in entity_keys)
+    # HIDRO entities created when Hydrolysis module detected
+    hidro_keys = [k for k in entity_keys if k.startswith("HIDRO ")]
+    assert len(hidro_keys) > 0, "HIDRO entities should be created"
+    # pH Acid Pump created when relay is assigned
+    assert "pH Acid Pump" in entity_keys
 
 
 @pytest.mark.asyncio
@@ -136,6 +142,66 @@ async def test_async_setup_entry_skips_ph_acid_pump_without_relay(monkeypatch):
     entities = async_add_entities.call_args[0][0]
     entity_keys = [e._key for e in entities]
     assert "pH Acid Pump" not in entity_keys
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_cl_module_sensor_without_chlorine(monkeypatch):
+    """Test that CL module binary sensor is skipped when chlorine module is not detected."""
+
+    class DummyEntry:
+        entry_id = "test_entry"
+        options = {}
+
+    class DummyCoordinator:
+        data = {
+            "MBF_PAR_MODEL": 0x000F,
+            "Hydrolysis module detected": True,
+            "Chlorine measurement module detected": False,
+        }
+        config_entry = DummyEntry()
+        device_slug = "vistapool"
+
+    hass = MagicMock()
+    hass.data = {"vistapool": {"test_entry": DummyCoordinator()}}
+    entry = DummyEntry()
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(hass, entry, async_add_entities)
+
+    entities = async_add_entities.call_args[0][0]
+    entity_keys = [e._key for e in entities]
+    cl_keys = [k for k in entity_keys if k.endswith("Activated by the CL module")]
+    assert cl_keys == [], f"CL module entities should be skipped: {cl_keys}"
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_rx_module_sensor_without_redox(monkeypatch):
+    """Test that RX module binary sensor is skipped when redox module is not detected."""
+
+    class DummyEntry:
+        entry_id = "test_entry"
+        options = {}
+
+    class DummyCoordinator:
+        data = {
+            "MBF_PAR_MODEL": 0x000F,
+            "Hydrolysis module detected": True,
+            "Redox measurement module detected": False,
+        }
+        config_entry = DummyEntry()
+        device_slug = "vistapool"
+
+    hass = MagicMock()
+    hass.data = {"vistapool": {"test_entry": DummyCoordinator()}}
+    entry = DummyEntry()
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(hass, entry, async_add_entities)
+
+    entities = async_add_entities.call_args[0][0]
+    entity_keys = [e._key for e in entities]
+    rx_keys = [k for k in entity_keys if k.endswith("Activated by the RX module")]
+    assert rx_keys == [], f"RX module entities should be skipped: {rx_keys}"
 
 
 @pytest.mark.asyncio

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -49,8 +49,8 @@ async def test_async_setup_entry_adds_entities(monkeypatch):
     class DummyCoordinator:
         data = {
             "MBF_PAR_MODEL": 0x000F,  # All bits set (should allow all modules)
-            "MBF_PAR_PH_BASE_RELAY_GPIO": True,
-            "MBF_PAR_PH_ACID_RELAY_GPIO": True,
+            "MBF_PAR_PH_BASE_RELAY_GPIO": 1,
+            "MBF_PAR_PH_ACID_RELAY_GPIO": 1,
             "Hydrolysis module detected": True,
             "Chlorine measurement module detected": True,
             "Redox measurement module detected": True,
@@ -97,7 +97,7 @@ async def test_async_setup_entry_skips_hidro_without_hydrolysis(monkeypatch):
     class DummyCoordinator:
         data = {
             "MBF_PAR_MODEL": 0x000F,
-            "MBF_PAR_PH_ACID_RELAY_GPIO": True,
+            "MBF_PAR_PH_ACID_RELAY_GPIO": 1,
             "Hydrolysis module detected": False,  # No hydrolysis module
         }
         config_entry = DummyEntry()

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -81,6 +81,64 @@ async def test_async_setup_entry_adds_entities(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_skips_hidro_without_hydrolysis(monkeypatch):
+    """Test that HIDRO binary sensors are skipped when Hydrolysis module detected is False."""
+
+    class DummyEntry:
+        entry_id = "test_entry"
+        options = {}
+
+    class DummyCoordinator:
+        data = {
+            "MBF_PAR_MODEL": 0x000F,
+            "MBF_PAR_PH_ACID_RELAY_GPIO": True,
+            "Hydrolysis module detected": False,  # No hydrolysis module
+        }
+        config_entry = DummyEntry()
+        device_slug = "vistapool"
+
+    hass = MagicMock()
+    hass.data = {"vistapool": {"test_entry": DummyCoordinator()}}
+    entry = DummyEntry()
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(hass, entry, async_add_entities)
+
+    entities = async_add_entities.call_args[0][0]
+    entity_keys = [e._key for e in entities]
+    hidro_keys = [k for k in entity_keys if k.startswith("HIDRO ")]
+    assert hidro_keys == [], f"HIDRO entities should be skipped: {hidro_keys}"
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_ph_acid_pump_without_relay(monkeypatch):
+    """Test that pH Acid Pump binary sensor is skipped when relay is not assigned."""
+
+    class DummyEntry:
+        entry_id = "test_entry"
+        options = {}
+
+    class DummyCoordinator:
+        data = {
+            "MBF_PAR_MODEL": 0x000F,
+            "MBF_PAR_PH_ACID_RELAY_GPIO": 0,  # No acid relay
+        }
+        config_entry = DummyEntry()
+        device_slug = "vistapool"
+
+    hass = MagicMock()
+    hass.data = {"vistapool": {"test_entry": DummyCoordinator()}}
+    entry = DummyEntry()
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(hass, entry, async_add_entities)
+
+    entities = async_add_entities.call_args[0][0]
+    entity_keys = [e._key for e in entities]
+    assert "pH Acid Pump" not in entity_keys
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_no_data(monkeypatch, caplog):
     """Test async_setup_entry returns early if coordinator.data is None."""
 

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -2025,3 +2025,84 @@ async def test_filtration_state_fixup_relay_on_but_state_off(config, monkeypatch
     assert not (result["MBF_RELAY_STATE"] & 0x0002), (
         "MBF_RELAY_STATE bit 1 should be cleared to match the authoritative register"
     )
+
+
+@pytest.mark.asyncio
+async def test_hydrolysis_detected_via_model_bit(config, monkeypatch):
+    """Hydrolysis module detected is True when MBF_PAR_MODEL bit 1 (MBMSK_MODEL_HIDRO) is set."""
+    client = vistapool_modbus.VistaPoolModbusClient(config)
+
+    class DummyResp:
+        def __init__(self, regs, is_error=False):
+            self.registers = regs
+            self.isError = lambda: is_error
+
+    fake_modbus = AsyncMock()
+    fake_modbus.connected = True
+
+    reg01 = [0] * 18  # MBF_HIDRO_STATUS at index 13 = 0 (no CTRL_ACTIVE)
+
+    factory_block1 = [0] * 13
+    factory_block1[1] = 0x0002  # MBF_PAR_MODEL bit 1 set (MBMSK_MODEL_HIDRO)
+
+    fake_modbus.read_holding_registers = AsyncMock(
+        side_effect=[
+            DummyResp([0] * 16),  # rr00
+            DummyResp([0] * 20),  # rr02
+            DummyResp([0, 0]),  # rr02_hidro
+            DummyResp(factory_block1),  # factory block 1 (0x0300)
+            DummyResp([0] * 4),  # factory block 2 (0x0322)
+            DummyResp([0] * 31),  # installer block 1
+            DummyResp([0] * 13),  # installer block 2
+            DummyResp([0] * 8),  # installer block 3
+            DummyResp([0] * 14),  # rr05
+            DummyResp([0] * 16),  # rr06
+        ]
+    )
+    fake_modbus.read_input_registers = AsyncMock(return_value=DummyResp(reg01))
+    monkeypatch.setattr(client, "get_client", AsyncMock(return_value=fake_modbus))
+
+    result = await client._perform_read_all()
+
+    assert result["Hydrolysis module detected"] is True
+
+
+@pytest.mark.asyncio
+async def test_hydrolysis_detected_via_status_ctrl_active(config, monkeypatch):
+    """Hydrolysis module detected is True when MBF_HIDRO_STATUS bit 6 (CTRL_ACTIVE) is set."""
+    client = vistapool_modbus.VistaPoolModbusClient(config)
+
+    class DummyResp:
+        def __init__(self, regs, is_error=False):
+            self.registers = regs
+            self.isError = lambda: is_error
+
+    fake_modbus = AsyncMock()
+    fake_modbus.connected = True
+
+    reg01 = [0] * 18
+    reg01[13] = 0x0040  # MBF_HIDRO_STATUS bit 6 (CTRL_ACTIVE)
+
+    factory_block1 = [0] * 13
+    factory_block1[1] = 0x0000  # MBF_PAR_MODEL — no HIDRO bit
+
+    fake_modbus.read_holding_registers = AsyncMock(
+        side_effect=[
+            DummyResp([0] * 16),  # rr00
+            DummyResp([0] * 20),  # rr02
+            DummyResp([0, 0]),  # rr02_hidro
+            DummyResp(factory_block1),  # factory block 1 (0x0300)
+            DummyResp([0] * 4),  # factory block 2 (0x0322)
+            DummyResp([0] * 31),  # installer block 1
+            DummyResp([0] * 13),  # installer block 2
+            DummyResp([0] * 8),  # installer block 3
+            DummyResp([0] * 14),  # rr05
+            DummyResp([0] * 16),  # rr06
+        ]
+    )
+    fake_modbus.read_input_registers = AsyncMock(return_value=DummyResp(reg01))
+    monkeypatch.setattr(client, "get_client", AsyncMock(return_value=fake_modbus))
+
+    result = await client._perform_read_all()
+
+    assert result["Hydrolysis module detected"] is True

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -463,8 +463,7 @@ async def test_number_setup_skips_cover_without_cover_sensor(monkeypatch):
 
     class DummyCoordinator:
         data = {
-            "MBF_PAR_HIDRO_NOM": 80,  # hydro present
-            "MBF_PAR_TEMPERATURE_ACTIVE": 1,
+            "Hydrolysis module detected": True,
         }
         config_entry = DummyEntry()
         device_slug = "vistapool"
@@ -503,7 +502,7 @@ async def test_number_setup_creates_cover_with_cover_sensor(monkeypatch):
 
     class DummyCoordinator:
         data = {
-            "MBF_PAR_HIDRO_NOM": 80,  # hydro present
+            "Hydrolysis module detected": True,
             "MBF_PAR_TEMPERATURE_ACTIVE": 1,
         }
         config_entry = DummyEntry()
@@ -542,7 +541,7 @@ async def test_number_setup_skips_cover_without_hydro_module(monkeypatch):
         options = {"use_cover_sensor": True}
 
     class DummyCoordinator:
-        data = {"MBF_PAR_TEMPERATURE_ACTIVE": 1}  # no MBF_PAR_HIDRO_NOM
+        data = {"MBF_PAR_TEMPERATURE_ACTIVE": 1}  # Hydrolysis module not detected
         config_entry = DummyEntry()
         device_slug = "vistapool"
 
@@ -579,7 +578,7 @@ async def test_number_setup_skips_temp_shutdown_without_temp_sensor(monkeypatch)
         options = {"use_cover_sensor": True}
 
     class DummyCoordinator:
-        data = {"MBF_PAR_HIDRO_NOM": 80}  # hydro present, but no temp sensor
+        data = {"Hydrolysis module detected": True}  # hydro present, but no temp sensor
         config_entry = DummyEntry()
         device_slug = "vistapool"
 
@@ -762,3 +761,31 @@ async def test_async_setup_entry_no_data(caplog):
         await async_setup_entry(hass, entry, async_add_entities)
         assert "No data from Modbus" in caplog.text
     async_add_entities.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_hidro_without_hydrolysis(caplog):
+    """Test that MBF_PAR_HIDRO number is skipped when Hydrolysis module detected is False."""
+    from custom_components.vistapool.number import async_setup_entry
+
+    class DummyEntry:
+        entry_id = "test_entry"
+        options = {}
+
+    class DummyCoordinator:
+        data = {
+            "Hydrolysis module detected": False,  # No hydrolysis module
+        }
+        config_entry = DummyEntry()
+        device_slug = "vistapool"
+
+    hass = MagicMock()
+    hass.data = {"vistapool": {"test_entry": DummyCoordinator()}}
+    entry = DummyEntry()
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(hass, entry, async_add_entities)
+
+    entities = async_add_entities.call_args[0][0]
+    keys = [e._key for e in entities]
+    assert "MBF_PAR_HIDRO" not in keys

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1143,3 +1143,32 @@ def test_optimistic_update_noop_when_value_is_none(mock_coordinator):
     mock_coordinator.data = {"MBF_PAR_FILT_MODE": 0}
     ent._optimistic_update(None)
     assert mock_coordinator.data["MBF_PAR_FILT_MODE"] == 0
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_skips_relay_activation_delay_without_ph_module():
+    """MBF_PAR_RELAY_ACTIVATION_DELAY is skipped when pH module is not detected."""
+    from custom_components.vistapool.select import async_setup_entry
+
+    class DummyEntry:
+        entry_id = "test_entry"
+
+    class DummyCoordinator:
+        data = {
+            # pH module NOT detected
+            "pH measurement module detected": False,
+        }
+        config_entry = DummyEntry()
+        device_slug = "vistapool"
+
+    hass = MagicMock()
+    hass.data = {"vistapool": {"test_entry": DummyCoordinator()}}
+    entry = DummyEntry()
+    entry.options = {}
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(hass, entry, async_add_entities)
+
+    entities = async_add_entities.call_args[0][0]
+    keys = [e._key for e in entities]
+    assert "MBF_PAR_RELAY_ACTIVATION_DELAY" not in keys

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -247,6 +247,7 @@ async def test_sensor_async_setup_entry_adds_entities(monkeypatch):
             "FILTRATION_SPEED": 1,
             "MBF_PAR_FILT_MODE": 1,
             "MBF_PH_STATUS_ALARM": 0,
+            "Hydrolysis module detected": True,
         }
         config_entry = DummyEntry()
         device_slug = "vistapool"
@@ -267,7 +268,7 @@ async def test_sensor_async_setup_entry_adds_entities(monkeypatch):
     assert "FILTRATION_SPEED" in keys
     assert "MBF_PAR_FILT_MODE" in keys
     assert "MBF_PH_STATUS_ALARM" in keys
-    # These sensors have no capability gate — always created
+    # HIDRO sensors created when Hydrolysis module detected
     assert "MBF_HIDRO_CURRENT" in keys
     assert "MBF_HIDRO_VOLTAGE" in keys
     assert "HIDRO_POLARITY" in keys
@@ -327,6 +328,32 @@ async def test_sensor_async_setup_entry_model_mask(monkeypatch):
     entities = async_add_entities.call_args[0][0]
     keys = [e._key for e in entities]
     assert "MBF_ION_CURRENT" not in keys
+
+
+@pytest.mark.asyncio
+async def test_sensor_hidro_skipped_without_hydrolysis(monkeypatch):
+    """Test async_setup_entry skips HIDRO sensors when Hydrolysis module detected is False."""
+
+    class DummyEntry:
+        entry_id = "test_entry"
+
+    class DummyCoordinator:
+        data = {
+            "Hydrolysis module detected": False,  # No hydrolysis module
+        }
+        config_entry = DummyEntry()
+        device_slug = "vistapool"
+
+    hass = MagicMock()
+    hass.data = {"vistapool": {"test_entry": DummyCoordinator()}}
+    entry = DummyEntry()
+    async_add_entities = MagicMock()
+    await async_setup_entry(hass, entry, async_add_entities)
+    entities = async_add_entities.call_args[0][0]
+    keys = [e._key for e in entities]
+    assert "MBF_HIDRO_CURRENT" not in keys
+    assert "MBF_HIDRO_VOLTAGE" not in keys
+    assert "HIDRO_POLARITY" not in keys
 
 
 def make_sensor(props, key, data):
@@ -585,6 +612,7 @@ async def test_sensor_setup_with_capability_snapshot_only():
             "MBF_PAR_TEMPERATURE_ACTIVE": 1,
             "MBF_PAR_FILTRATION_CONF": 0x0001,  # variable-speed pump
             "MBF_PAR_HEATING_GPIO": 5,
+            "Hydrolysis module detected": True,
             "pH measurement module detected": True,
             "Redox measurement module detected": True,
             "Chlorine measurement module detected": True,
@@ -615,11 +643,12 @@ async def test_sensor_setup_with_capability_snapshot_only():
     assert "MBF_PH_STATUS_ALARM" in keys
     assert "MBF_PAR_INTELLIGENT_INTERVALS" in keys
     assert "MBF_PAR_INTELLIGENT_TT_NEXT_INTERVAL" in keys
-    # Unconditional sensors
+    # HIDRO sensors gated by Hydrolysis module detected
     assert "MBF_HIDRO_CURRENT" in keys
     assert "MBF_HIDRO_VOLTAGE" in keys
-    assert "MBF_PAR_FILT_MODE" in keys
     assert "HIDRO_POLARITY" in keys
+    # Unconditional sensors
+    assert "MBF_PAR_FILT_MODE" in keys
 
 
 @pytest.mark.asyncio

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -477,7 +477,7 @@ async def test_switch_setup_skips_hidro_cover_without_hydro_module():
         options = {"use_cover_sensor": True}  # cover sensor option enabled
 
     class DummyCoordinator:
-        data = {"MBF_PAR_HIDRO_NOM": 0}  # hydro module absent (falsy)
+        data = {"Hydrolysis module detected": False}  # hydro module absent
         config_entry = DummyEntry()
         device_slug = "vistapool"
 
@@ -502,7 +502,7 @@ async def test_switch_setup_creates_hidro_cover_with_hydro_module():
 
     class DummyCoordinator:
         data = {
-            "MBF_PAR_HIDRO_NOM": 80,  # hydro module present
+            "Hydrolysis module detected": True,
             "MBF_PAR_TEMPERATURE_ACTIVE": 1,
         }
         config_entry = DummyEntry()
@@ -529,7 +529,7 @@ async def test_switch_setup_skips_hidro_temp_shutdown_without_temp_sensor():
 
     class DummyCoordinator:
         data = {
-            "MBF_PAR_HIDRO_NOM": 80,  # hydro present
+            "Hydrolysis module detected": True,
             "MBF_PAR_TEMPERATURE_ACTIVE": 0,  # but temp sensor inactive
         }
         config_entry = DummyEntry()
@@ -558,7 +558,7 @@ async def test_switch_setup_skips_hidro_cover_without_cover_sensor():
 
     class DummyCoordinator:
         data = {
-            "MBF_PAR_HIDRO_NOM": 80,
+            "Hydrolysis module detected": True,
             "MBF_PAR_TEMPERATURE_ACTIVE": 1,
         }
         config_entry = DummyEntry()


### PR DESCRIPTION
## 🐛 Problem

Several entities were created unconditionally even when the
corresponding hardware module was not installed, resulting in ghost
entities with no meaningful data.

Affected entities:
- Hydrolysis sensors, binary sensors, and the production setpoint number
- pH Acid Pump binary sensor
- Relay activation delay select

Additionally, existing hydrolysis gating in switch and number platforms
used `MBF_PAR_HIDRO_NOM` (a factory register with max production level)
instead of actual module presence detection.

## ✅ Solution

### Hydrolysis detection

Derive a new `"Hydrolysis module detected"` flag using the same logic
as Tasmota's `NeoPoolIsHydrolysis()`:

- `MBF_PAR_MODEL` bit 1 (`MBMSK_MODEL_HIDRO`), **OR**
- `MBF_HIDRO_STATUS` bit 6 (`MBMSK_HIDRO_STATUS_CTRL_ACTIVE`)

This is consistent with how pH, Redox, Chlorine, and Conductivity
modules are detected from their respective `*_STATUS` registers.

### New entity gates

| Platform | Entity | Gate |
|---|---|---|
| 🔢 sensor | `MBF_HIDRO_CURRENT`, `MBF_HIDRO_VOLTAGE`, `HIDRO_POLARITY` | Hydrolysis module detected |
| 🔘 binary_sensor | `HIDRO *` (7 entities) | Hydrolysis module detected |
| 🔘 binary_sensor | `pH Acid Pump` | `MBF_PAR_PH_ACID_RELAY_GPIO` assigned |
| 🔢 number | `MBF_PAR_HIDRO` | Hydrolysis module detected |
| 🎛️ select | `MBF_PAR_RELAY_ACTIVATION_DELAY` | pH measurement module detected |

### Migrated gates

Existing hydrolysis gates in **switch** (`MBF_PAR_HIDRO_COVER_ENABLE`,
`MBF_PAR_HIDRO_TEMP_SHUTDOWN`) and **number**
(`MBF_PAR_HIDRO_COVER_REDUCTION`, `MBF_PAR_HIDRO_SHUTDOWN_TEMPERATURE`)
now use `"Hydrolysis module detected"` instead of `MBF_PAR_HIDRO_NOM`.

### Winter mode

`"Hydrolysis module detected"` added to `CAPABILITY_KEYS` so it is
persisted across HA restarts in winter mode.

## 🧪 Tests

- ✅ 592 tests passing
- ➕ New tests for all new gating conditions
- 🔄 Existing tests updated for the new detection key