### PR TITLE
fix!(sensor): 💥 merge polarity binary sensors into enum sensors

### DIFF
--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -426,7 +426,6 @@ BINARY_SENSOR_DEFINITIONS = {
         "device_class": BinarySensorDeviceClass.PROBLEM,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
-    # Note: "ION in dead time" is merged into the ION_POLARITY enum sensor as "dead_time" state.
     # Hydrolysis status bits
     "HIDRO On Target": {
         "name": "Hydrolysis On Target",

--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -200,6 +200,13 @@ SENSOR_DEFINITIONS = {
         "state_class": None,
         "icon": "mdi:plus-minus-variant",
     },
+    "ION_POLARITY": {
+        "name": "Ionizer Polarity",
+        "unit": None,
+        "device_class": SensorDeviceClass.ENUM,
+        "state_class": None,
+        "icon": "mdi:plus-minus-variant",
+    },
     "FILTRATION_SPEED": {
         "name": "Filtration Current Speed",
         "unit": None,
@@ -419,21 +426,7 @@ BINARY_SENSOR_DEFINITIONS = {
         "device_class": BinarySensorDeviceClass.PROBLEM,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
-    "ION in dead time": {
-        "name": "Ionizer In Dead Time",
-        "device_class": BinarySensorDeviceClass.PROBLEM,
-        "entity_category": EntityCategory.DIAGNOSTIC,
-    },
-    "ION in Pol1": {
-        "name": "Ionizer Polarity 1",
-        "device_class": None,
-        "entity_category": EntityCategory.DIAGNOSTIC,
-    },
-    "ION in Pol2": {
-        "name": "Ionizer Polarity 2",
-        "device_class": None,
-        "entity_category": EntityCategory.DIAGNOSTIC,
-    },
+    # Note: "ION in dead time" is merged into the ION_POLARITY enum sensor as "dead_time" state.
     # Hydrolysis status bits
     "HIDRO On Target": {
         "name": "Hydrolysis On Target",
@@ -497,11 +490,10 @@ BINARY_SENSOR_DEFINITIONS = {
         "icon_on": "mdi:lightbulb-fluorescent-tube",
         "icon_off": "mdi:lightbulb-fluorescent-tube-outline",
     },
-    "HIDRO in dead time": {
-        "name": "Hydrolysis In Dead Time",
-        "device_class": BinarySensorDeviceClass.PROBLEM,
-        "entity_category": EntityCategory.DIAGNOSTIC,
-    },
+    # Note: "HIDRO in dead time", "HIDRO in Pol1" and "HIDRO in Pol2" are merged
+    # into the HIDRO_POLARITY enum sensor.
+    # Similarly, "ION in dead time", "ION in Pol1" and "ION in Pol2" are merged
+    # into the ION_POLARITY enum sensor.
 }
 
 NUMBER_DEFINITIONS = {

--- a/custom_components/vistapool/sensor.py
+++ b/custom_components/vistapool/sensor.py
@@ -114,6 +114,10 @@ async def async_setup_entry(
             "HIDRO_POLARITY",
         ) and not coordinator.data.get("Hydrolysis module detected"):
             continue
+        if key == "ION_POLARITY" and not bool(
+            (coordinator.data.get("MBF_PAR_MODEL") or 0) & 0x0001
+        ):
+            continue
         if key == "FILTRATION_SPEED" and not get_filtration_pump_type(
             coordinator.data.get("MBF_PAR_FILTRATION_CONF", 0)
         ):
@@ -266,15 +270,31 @@ class VistaPoolSensor(VistaPoolEntity, SensorEntity):
             if filtration_state is not None and filtration_state is False:
                 return None
 
-        # Polarity sensor created from two binary sensors
+        # Polarity sensors created from status register bits (Pol1, Pol2, dead time)
         if self._key == "HIDRO_POLARITY":
             pol1 = self.coordinator.data.get("HIDRO in Pol1")
             pol2 = self.coordinator.data.get("HIDRO in Pol2")
-            if pol1 is None and pol2 is None:
+            dead = self.coordinator.data.get("HIDRO in dead time")
+            if pol1 is None and pol2 is None and dead is None:
                 return None
+            if dead:
+                return "dead_time"
             if pol1:
                 return "pol1"
-            elif pol2:
+            if pol2:
+                return "pol2"
+            return "off"
+        if self._key == "ION_POLARITY":
+            pol1 = self.coordinator.data.get("ION in Pol1")
+            pol2 = self.coordinator.data.get("ION in Pol2")
+            dead = self.coordinator.data.get("ION in dead time")
+            if pol1 is None and pol2 is None and dead is None:
+                return None
+            if dead:
+                return "dead_time"
+            if pol1:
+                return "pol1"
+            if pol2:
                 return "pol2"
             return "off"
         if self._key == "MBF_PAR_FILT_MODE":
@@ -302,5 +322,7 @@ class VistaPoolSensor(VistaPoolEntity, SensorEntity):
         if self._key == "MBF_PH_STATUS_ALARM":
             return list(PH_STATUS_ALARM_MAP.values())
         if self._key == "HIDRO_POLARITY":
-            return ["pol1", "pol2", "off"]
+            return ["pol1", "pol2", "dead_time", "off"]
+        if self._key == "ION_POLARITY":
+            return ["pol1", "pol2", "dead_time", "off"]
         return None  # pragma: no cover

--- a/custom_components/vistapool/translations/cs.json
+++ b/custom_components/vistapool/translations/cs.json
@@ -102,6 +102,16 @@
         "state": {
           "pol1": "Polarita 1",
           "pol2": "Polarita 2",
+          "dead_time": "Mrtvý čas",
+          "off": "Vypnuto"
+        }
+      },
+      "ion_polarity": {
+        "name": "Polarita ionizátoru",
+        "state": {
+          "pol1": "Polarita 1",
+          "pol2": "Polarita 2",
+          "dead_time": "Mrtvý čas",
           "off": "Vypnuto"
         }
       },
@@ -156,9 +166,6 @@
       "ion_on_target": { "name": "Ionizátor na cíli" },
       "ion_low_flow": { "name": "Nízký průtok ionizátoru" },
       "ion_program_time_exceeded": { "name": "Překročen čas programu ionizátoru" },
-      "ion_in_dead_time": { "name": "Ionizátor v době mrtvého času" },
-      "ion_in_pol1": { "name": "Ionizátor polarita 1" },
-      "ion_in_pol2": { "name": "Ionizátor polarita 2" },
       "hidro_on_target": { "name": "Hydrolýza na cíli" },
       "hidro_low_flow": { "name": "Nízký průtok hydrolýzy" },
       "hidro_cell_flow_fl1": { "name": "Proudění článkem hydrolýzy FL1" },
@@ -169,10 +176,7 @@
       "hidro_chlorine_shock_mode": { "name": "Hydrolýza šokový režim chloru (Boost)" },
       "hidro_chlorine_flow_indicator_fl2": { "name": "Průtokový indikátor chloru hydrolýzy FL2" },
       "hidro_activated_by_the_cl_module": { "name": "Hydrolýza aktivována CL modulem" },
-      "hidro_in_dead_time": { "name": "Hydrolýza v době mrtvého času" },
       "uv_lamp": { "name": "UV lampa" },
-      "hidro_in_pol1": { "name": "Hydrolýza polarita 1" },
-      "hidro_in_pol2": { "name": "Hydrolýza polarita 2" },
       "device_time_out_of_sync": { "name": "Čas v zařízení" },
       "aux1": { "name": "Pomocné relé Aux1" },
       "aux2": { "name": "Pomocné relé Aux2" },

--- a/custom_components/vistapool/translations/de.json
+++ b/custom_components/vistapool/translations/de.json
@@ -102,6 +102,16 @@
         "state": {
           "pol1": "Polarität 1",
           "pol2": "Polarität 2",
+          "dead_time": "Totzeit",
+          "off": "Aus"
+        }
+      },
+      "ion_polarity": {
+        "name": "Ionisator-Polarität",
+        "state": {
+          "pol1": "Polarität 1",
+          "pol2": "Polarität 2",
+          "dead_time": "Totzeit",
           "off": "Aus"
         }
       },
@@ -156,9 +166,6 @@
       "ion_on_target": { "name": "Ionisator am Ziel" },
       "ion_low_flow": { "name": "Ionisator Niedriger Durchfluss" },
       "ion_program_time_exceeded": { "name": "Ionisator Programmlaufzeit überschritten" },
-      "ion_in_dead_time": { "name": "Ionisator in Totzeit" },
-      "ion_in_pol1": { "name": "Ionisator Polarität 1" },
-      "ion_in_pol2": { "name": "Ionisator Polarität 2" },
       "hidro_on_target": { "name": "Hydrolyse am Ziel" },
       "hidro_low_flow": { "name": "Hydrolyse Niedriger Durchfluss" },
       "hidro_cell_flow_fl1": { "name": "Hydrolyse-Zelldurchfluss FL1" },
@@ -169,10 +176,7 @@
       "hidro_chlorine_shock_mode": { "name": "Hydrolyse Chlor-Schock-Modus (Boost)" },
       "hidro_chlorine_flow_indicator_fl2": { "name": "Hydrolyse Chlor-Durchflussanzeige FL2" },
       "hidro_activated_by_the_cl_module": { "name": "Hydrolyse aktiviert durch Chlor-Modul" },
-      "hidro_in_dead_time": { "name": "Hydrolyse in Totzeit" },
       "uv_lamp": { "name": "UV-Lampe" },
-      "hidro_in_pol1": { "name": "Hydrolyse Polarität 1" },
-      "hidro_in_pol2": { "name": "Hydrolyse Polarität 2" },
       "device_time_out_of_sync": { "name": "Gerätezeitsynchronisierung" },
       "aux1": { "name": "Relais Aux1" },
       "aux2": { "name": "Relais Aux2" },

--- a/custom_components/vistapool/translations/en.json
+++ b/custom_components/vistapool/translations/en.json
@@ -102,6 +102,16 @@
         "state": {
           "pol1": "Polarity 1",
           "pol2": "Polarity 2",
+          "dead_time": "Dead Time",
+          "off": "Off"
+        }
+      },
+      "ion_polarity": {
+        "name": "Ionizer Polarity",
+        "state": {
+          "pol1": "Polarity 1",
+          "pol2": "Polarity 2",
+          "dead_time": "Dead Time",
           "off": "Off"
         }
       },
@@ -156,9 +166,6 @@
       "ion_on_target": { "name": "Ionizer On Target" },
       "ion_low_flow": { "name": "Ionizer Low Flow" },
       "ion_program_time_exceeded": { "name": "Ionizer Program Time Exceeded" },
-      "ion_in_dead_time": { "name": "Ionizer In Dead Time" },
-      "ion_in_pol1": { "name": "Ionizer Polarity 1" },
-      "ion_in_pol2": { "name": "Ionizer Polarity 2" },
       "hidro_on_target": { "name": "Hydrolysis On Target" },
       "hidro_low_flow": { "name": "Hydrolysis Low Flow" },
       "hidro_cell_flow_fl1": { "name": "Hydrolysis Cell Flow FL1" },
@@ -169,10 +176,7 @@
       "hidro_chlorine_shock_mode": { "name": "Hydrolysis Chlorine Shock Mode (Boost)" },
       "hidro_chlorine_flow_indicator_fl2": { "name": "Hydrolysis Chlorine Flow Indicator FL2" },
       "hidro_activated_by_the_cl_module": { "name": "Hydrolysis Activated by Chlorine Module" },
-      "hidro_in_dead_time": { "name": "Hydrolysis In Dead Time" },
       "uv_lamp": { "name": "UV Lamp" },
-      "hidro_in_pol1": { "name": "Hydrolysis Polarity 1" },
-      "hidro_in_pol2": { "name": "Hydrolysis Polarity 2" },
       "device_time_out_of_sync": { "name": "Device Time Sync" },
       "aux1": { "name": "Relay Aux1" },
       "aux2": { "name": "Relay Aux2" },

--- a/custom_components/vistapool/translations/es.json
+++ b/custom_components/vistapool/translations/es.json
@@ -102,6 +102,16 @@
         "state": {
           "pol1": "Polaridad 1",
           "pol2": "Polaridad 2",
+          "dead_time": "Tiempo muerto",
+          "off": "Apagado"
+        }
+      },
+      "ion_polarity": {
+        "name": "Polaridad del ionizador",
+        "state": {
+          "pol1": "Polaridad 1",
+          "pol2": "Polaridad 2",
+          "dead_time": "Tiempo muerto",
           "off": "Apagado"
         }
       },
@@ -156,9 +166,6 @@
       "ion_on_target": { "name": "Ionizador en objetivo" },
       "ion_low_flow": { "name": "Bajo flujo del ionizador" },
       "ion_program_time_exceeded": { "name": "Tiempo de programa de ionizador excedido" },
-      "ion_in_dead_time": { "name": "Ionizador en tiempo muerto" },
-      "ion_in_pol1": { "name": "Ionizador Polaridad 1" },
-      "ion_in_pol2": { "name": "Ionizador Polaridad 2" },
       "hidro_on_target": { "name": "Hidrólisis en objetivo" },
       "hidro_low_flow": { "name": "Hidrólisis bajo flujo" },
       "hidro_cell_flow_fl1": { "name": "Flujo de celda de hidrólisis FL1" },
@@ -169,10 +176,7 @@
       "hidro_chlorine_shock_mode": { "name": "Modo de choque de cloro de hidrólisis (Boost)" },
       "hidro_chlorine_flow_indicator_fl2": { "name": "Indicador de flujo de cloro de hidrólisis FL2" },
       "hidro_activated_by_the_cl_module": { "name": "Hidrólisis activada por el módulo de cloro" },
-      "hidro_in_dead_time": { "name": "Hidrólisis en tiempo muerto" },
       "uv_lamp": { "name": "Lámpara UV" },
-      "hidro_in_pol1": { "name": "Hidrólisis Polaridad 1" },
-      "hidro_in_pol2": { "name": "Hidrólisis Polaridad 2" },
       "device_time_out_of_sync": { "name": "Sincronización de hora del dispositivo" },
       "aux1": { "name": "Relé Aux1" },
       "aux2": { "name": "Relé Aux2" },

--- a/custom_components/vistapool/translations/fr.json
+++ b/custom_components/vistapool/translations/fr.json
@@ -102,7 +102,17 @@
         "state": {
           "pol1": "Polarité 1",
           "pol2": "Polarité 2",
-          "off": "Arrêté"
+          "dead_time": "Temps mort",
+          "off": "Éteint"
+        }
+      },
+      "ion_polarity": {
+        "name": "Polarité de l'ioniseur",
+        "state": {
+          "pol1": "Polarité 1",
+          "pol2": "Polarité 2",
+          "dead_time": "Temps mort",
+          "off": "Éteint"
         }
       },
       "filt_mode": {
@@ -156,9 +166,7 @@
       "ion_on_target": { "name": "Ioniseur sur cible" },
       "ion_low_flow": { "name": "Faible débit de l’ioniseur" },
       "ion_program_time_exceeded": { "name": "Temps de programme de l’ioniseur dépassé" },
-      "ion_in_dead_time": { "name": "Ioniseur en temps mort" },
-      "ion_in_pol1": { "name": "Ioniseur polarité 1" },
-      "ion_in_pol2": { "name": "Ioniseur polarité 2" },
+
       "hidro_on_target": { "name": "Hydrolyse sur cible" },
       "hidro_low_flow": { "name": "Hydrolyse faible débit" },
       "hidro_cell_flow_fl1": { "name": "Débit cellule hydrolyse FL1" },
@@ -169,10 +177,7 @@
       "hidro_chlorine_shock_mode": { "name": "Mode choc chlore hydrolyse (Boost)" },
       "hidro_chlorine_flow_indicator_fl2": { "name": "Indicateur de débit de chlore hydrolyse FL2" },
       "hidro_activated_by_the_cl_module": { "name": "Hydrolyse activée par le module chlore" },
-      "hidro_in_dead_time": { "name": "Hydrolyse en temps mort" },
       "uv_lamp": { "name": "Lampe UV" },
-      "hidro_in_pol1": { "name": "Hydrolyse polarité 1" },
-      "hidro_in_pol2": { "name": "Hydrolyse polarité 2" },
       "device_time_out_of_sync": { "name": "Synchronisation de l’heure de l’appareil" },
       "aux1": { "name": "Relais Aux1" },
       "aux2": { "name": "Relais Aux2" },

--- a/custom_components/vistapool/translations/it.json
+++ b/custom_components/vistapool/translations/it.json
@@ -102,6 +102,16 @@
         "state": {
           "pol1": "Polarità 1",
           "pol2": "Polarità 2",
+          "dead_time": "Tempo morto",
+          "off": "Spento"
+        }
+      },
+      "ion_polarity": {
+        "name": "Polarità dell'ionizzatore",
+        "state": {
+          "pol1": "Polarità 1",
+          "pol2": "Polarità 2",
+          "dead_time": "Tempo morto",
           "off": "Spento"
         }
       },
@@ -156,9 +166,6 @@
       "ion_on_target": { "name": "Ionizzatore a target" },
       "ion_low_flow": { "name": "Basso flusso ionizzatore" },
       "ion_program_time_exceeded": { "name": "Tempo programma ionizzatore superato" },
-      "ion_in_dead_time": { "name": "Ionizzatore in tempo morto" },
-      "ion_in_pol1": { "name": "Ionizzatore Polarità 1" },
-      "ion_in_pol2": { "name": "Ionizzatore Polarità 2" },
       "hidro_on_target": { "name": "Idrolisi a target" },
       "hidro_low_flow": { "name": "Idrolisi a basso flusso" },
       "hidro_cell_flow_fl1": { "name": "Flusso cella idrolisi FL1" },
@@ -169,10 +176,7 @@
       "hidro_chlorine_shock_mode": { "name": "Modalità shock cloro idrolisi (Boost)" },
       "hidro_chlorine_flow_indicator_fl2": { "name": "Indicatore flusso cloro idrolisi FL2" },
       "hidro_activated_by_the_cl_module": { "name": "Idrolisi attivata dal modulo cloro" },
-      "hidro_in_dead_time": { "name": "Idrolisi in tempo morto" },
       "uv_lamp": { "name": "Lampada UV" },
-      "hidro_in_pol1": { "name": "Idrolisi Polarità 1" },
-      "hidro_in_pol2": { "name": "Idrolisi Polarità 2" },
       "device_time_out_of_sync": { "name": "Sincronizzazione orario dispositivo" },
       "aux1": { "name": "Relè Aux1" },
       "aux2": { "name": "Relè Aux2" },

--- a/custom_components/vistapool/translations/pl.json
+++ b/custom_components/vistapool/translations/pl.json
@@ -102,7 +102,17 @@
         "state": {
           "pol1": "Polaryzacja 1",
           "pol2": "Polaryzacja 2",
+          "dead_time": "Martwy czas",
           "off": "Wyłączone"
+        }
+      },
+      "ion_polarity": {
+        "name": "Polaryzacja jonizatora",
+        "state": {
+          "pol1": "Polaryzacja 1",
+          "pol2": "Polaryzacja 2",
+          "dead_time": "Martwy czas",
+          "off": "Wyłączony"
         }
       },
       "filt_mode": {
@@ -156,9 +166,6 @@
       "ion_on_target": { "name": "Jonizator na celu" },
       "ion_low_flow": { "name": "Niski przepływ jonizatora" },
       "ion_program_time_exceeded": { "name": "Przekroczony czas programu jonizatora" },
-      "ion_in_dead_time": { "name": "Jonizator w martwym czasie" },
-      "ion_in_pol1": { "name": "Jonizator polaryzacja 1" },
-      "ion_in_pol2": { "name": "Jonizator polaryzacja 2" },
       "hidro_on_target": { "name": "Elektroliza na celu" },
       "hidro_low_flow": { "name": "Niski przepływ elektrolizy" },
       "hidro_cell_flow_fl1": { "name": "Przepływ komórki elektrolizy FL1" },
@@ -169,10 +176,7 @@
       "hidro_chlorine_shock_mode": { "name": "Tryb szoku chloru elektrolizy (Boost)" },
       "hidro_chlorine_flow_indicator_fl2": { "name": "Wskaźnik przepływu chloru elektrolizy FL2" },
       "hidro_activated_by_the_cl_module": { "name": "Elektroliza aktywowana przez moduł chloru" },
-      "hidro_in_dead_time": { "name": "Elektroliza w martwym czasie" },
       "uv_lamp": { "name": "Lampa UV" },
-      "hidro_in_pol1": { "name": "Elektroliza polaryzacja 1" },
-      "hidro_in_pol2": { "name": "Elektroliza polaryzacja 2" },
       "device_time_out_of_sync": { "name": "Synchronizacja czasu urządzenia" },
       "aux1": { "name": "Przekaźnik pomocniczy Aux1" },
       "aux2": { "name": "Przekaźnik pomocniczy Aux2" },

--- a/custom_components/vistapool/translations/pl.json
+++ b/custom_components/vistapool/translations/pl.json
@@ -112,7 +112,7 @@
           "pol1": "Polaryzacja 1",
           "pol2": "Polaryzacja 2",
           "dead_time": "Martwy czas",
-          "off": "Wyłączony"
+          "off": "Wyłączone"
         }
       },
       "filt_mode": {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -155,13 +155,59 @@ def test_native_value_filtration_pump_off(mock_coordinator):
 
 def test_native_value_special_keys(mock_coordinator):
     ent = VistaPoolSensor(mock_coordinator, "test_entry", "HIDRO_POLARITY", {})
-    mock_coordinator.data = {"HIDRO in Pol1": True, "HIDRO in Pol2": False}
+    mock_coordinator.data = {
+        "HIDRO in Pol1": True,
+        "HIDRO in Pol2": False,
+        "HIDRO in dead time": False,
+    }
     assert ent.native_value == "pol1"
-    mock_coordinator.data = {"HIDRO in Pol1": False, "HIDRO in Pol2": True}
+    mock_coordinator.data = {
+        "HIDRO in Pol1": False,
+        "HIDRO in Pol2": True,
+        "HIDRO in dead time": False,
+    }
     assert ent.native_value == "pol2"
-    mock_coordinator.data = {"HIDRO in Pol1": False, "HIDRO in Pol2": False}
+    mock_coordinator.data = {
+        "HIDRO in Pol1": False,
+        "HIDRO in Pol2": False,
+        "HIDRO in dead time": True,
+    }
+    assert ent.native_value == "dead_time"
+    mock_coordinator.data = {
+        "HIDRO in Pol1": False,
+        "HIDRO in Pol2": False,
+        "HIDRO in dead time": False,
+    }
     assert ent.native_value == "off"
-    # Both keys absent (e.g. winter mode with empty capability snapshot) → unknown
+    # All keys absent (e.g. winter mode with empty capability snapshot) → unknown
+    mock_coordinator.data = {}
+    assert ent.native_value is None
+    # ION_POLARITY enum sensor
+    ent = VistaPoolSensor(mock_coordinator, "test_entry", "ION_POLARITY", {})
+    mock_coordinator.data = {
+        "ION in Pol1": True,
+        "ION in Pol2": False,
+        "ION in dead time": False,
+    }
+    assert ent.native_value == "pol1"
+    mock_coordinator.data = {
+        "ION in Pol1": False,
+        "ION in Pol2": True,
+        "ION in dead time": False,
+    }
+    assert ent.native_value == "pol2"
+    mock_coordinator.data = {
+        "ION in Pol1": False,
+        "ION in Pol2": False,
+        "ION in dead time": True,
+    }
+    assert ent.native_value == "dead_time"
+    mock_coordinator.data = {
+        "ION in Pol1": False,
+        "ION in Pol2": False,
+        "ION in dead time": False,
+    }
+    assert ent.native_value == "off"
     mock_coordinator.data = {}
     assert ent.native_value is None
     ent = VistaPoolSensor(mock_coordinator, "test_entry", "MBF_PAR_FILT_MODE", {})
@@ -195,7 +241,9 @@ def test_options_property(mock_coordinator):
     ent = VistaPoolSensor(mock_coordinator, "test_entry", "MBF_PH_STATUS_ALARM", {})
     assert ent.options == list(PH_STATUS_ALARM_MAP.values())
     ent = VistaPoolSensor(mock_coordinator, "test_entry", "HIDRO_POLARITY", {})
-    assert ent.options == ["pol1", "pol2", "off"]
+    assert ent.options == ["pol1", "pol2", "dead_time", "off"]
+    ent = VistaPoolSensor(mock_coordinator, "test_entry", "ION_POLARITY", {})
+    assert ent.options == ["pol1", "pol2", "dead_time", "off"]
 
 
 def test_available_during_winter_mode(mock_coordinator):
@@ -265,6 +313,7 @@ async def test_sensor_async_setup_entry_adds_entities(monkeypatch):
     assert "MBF_MEASURE_CL" in keys
     assert "MBF_MEASURE_CONDUCTIVITY" in keys
     assert "MBF_ION_CURRENT" in keys
+    assert "ION_POLARITY" in keys
     assert "FILTRATION_SPEED" in keys
     assert "MBF_PAR_FILT_MODE" in keys
     assert "MBF_PH_STATUS_ALARM" in keys
@@ -328,6 +377,7 @@ async def test_sensor_async_setup_entry_model_mask(monkeypatch):
     entities = async_add_entities.call_args[0][0]
     keys = [e._key for e in entities]
     assert "MBF_ION_CURRENT" not in keys
+    assert "ION_POLARITY" not in keys
 
 
 @pytest.mark.asyncio
@@ -639,6 +689,7 @@ async def test_sensor_setup_with_capability_snapshot_only():
     assert "MBF_MEASURE_CONDUCTIVITY" in keys
     assert "MBF_MEASURE_TEMPERATURE" in keys
     assert "MBF_ION_CURRENT" in keys
+    assert "ION_POLARITY" in keys
     assert "FILTRATION_SPEED" in keys
     assert "MBF_PH_STATUS_ALARM" in keys
     assert "MBF_PAR_INTELLIGENT_INTERVALS" in keys


### PR DESCRIPTION
## 🎯 Summary

Merges mutually exclusive polarity and dead-time binary sensors into proper enum sensors for both the hydrolysis and ionization modules.

## 💥 Breaking Change

Binary sensors `ion_in_pol1`, `ion_in_pol2`, `ion_in_dead_time`, `hidro_in_pol1`, `hidro_in_pol2`, `hidro_in_dead_time` are removed and replaced by `ION_POLARITY` and `HIDRO_POLARITY` enum sensors with states `pol1` / `pol2` / `dead_time` / `off`.

> ⚠️ Users with automations referencing the removed binary sensor entities will need to update them to use state checks on the new enum sensors instead.

## ♻️ Changes

- **New `ION_POLARITY` enum sensor** — mirrors the existing `HIDRO_POLARITY`, gated on the ionizer model bit (`MBF_PAR_MODEL & 0x0001`)
- **New `dead_time` state** added to both `HIDRO_POLARITY` and `ION_POLARITY` — represents the `POLOFF` bit (polarity reversal transition)
- **6 binary sensors removed** — bits 12–14 of `MBF_ION_STATUS` / `MBF_HIDRO_STATUS` are mutually exclusive states, not independent flags:
  - `ION in Pol1`, `ION in Pol2`, `ION in dead time`
  - `HIDRO in Pol1`, `HIDRO in Pol2`, `HIDRO in dead time`

## 🌍 Translations

All 7 languages updated (en, cs, de, es, fr, it, pl):
- ➕ Added `ion_polarity` sensor with `pol1` / `pol2` / `dead_time` / `off` states
- ➕ Added `dead_time` state to `hidro_polarity`
- ➖ Removed `ion_in_pol1`, `ion_in_pol2`, `ion_in_dead_time`, `hidro_in_pol1`, `hidro_in_pol2`, `hidro_in_dead_time` from binary sensor translations

## ✅ Tests

- Updated `test_native_value_special_keys` — tests all states (`pol1`, `pol2`, `dead_time`, `off`, `None`) for both polarity sensors
- Updated `test_options_property` — verifies option lists include `dead_time`
- Updated setup entry tests — asserts `ION_POLARITY` is created/skipped based on model mask

## 📁 Changed Files

| File | Change |
|---|---|
| `custom_components/vistapool/const.py` | Remove 6 binary sensor defs, add `ION_POLARITY` sensor def |
| `custom_components/vistapool/sensor.py` | Add `ION_POLARITY` setup logic, `dead_time` state handling |
| `custom_components/vistapool/translations/*.json` | Add/remove translations (7 files) |
| `tests/test_sensor.py` | Add tests for new enum states and setup gating |