### PR TITLE
feat(sensor): ✨ add filtration time remaining sensor

### DIFF
--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -276,7 +276,7 @@ SENSOR_DEFINITIONS = {
         "name": "Filtration Time Remaining",
         "unit": "s",
         "device_class": SensorDeviceClass.DURATION,
-        "state_class": SensorStateClass.MEASUREMENT,
+        "state_class": None,
         "icon": "mdi:timer-sand",
         "display_precision": 0,
     },

--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -272,7 +272,7 @@ SENSOR_DEFINITIONS = {
         "icon": "mdi:timer-sand",
         "display_precision": 0,
     },
-    "filtration_remaining": {
+    "FILTRATION_REMAINING": {
         "name": "Filtration Time Remaining",
         "unit": "s",
         "device_class": SensorDeviceClass.DURATION,

--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -272,6 +272,14 @@ SENSOR_DEFINITIONS = {
         "icon": "mdi:timer-sand",
         "display_precision": 0,
     },
+    "filtration_remaining": {
+        "name": "Filtration Time Remaining",
+        "unit": "s",
+        "device_class": SensorDeviceClass.DURATION,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "icon": "mdi:timer-sand",
+        "display_precision": 0,
+    },
 }
 
 BINARY_SENSOR_DEFINITIONS = {

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -153,7 +153,14 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
 
             # Bypass the notification cache for filtration timers while
             # filtration is running so the countdown values stay fresh.
-            filtration_active = bool(data.get("Filtration Pump"))
+            # Use both the relay bit and the previous countdown to avoid
+            # missing cycles when the relay bit is unreliable.
+            prev_remaining = (
+                self.data.get("FILTRATION_REMAINING") if self.data else None
+            )
+            filtration_active = bool(data.get("Filtration Pump")) or bool(
+                prev_remaining and prev_remaining > 0
+            )
             timers = await self.client.read_all_timers(
                 enabled_timers=enabled_timers,
                 force_read=_FILT_TIMERS if filtration_active else None,

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -38,6 +38,8 @@ from .helpers import is_device_time_out_of_sync, parse_version, prepare_device_t
 
 MAX_SCAN_INTERVAL = timedelta(seconds=180)  # Maximum allowed scan interval (3 minutes)
 
+_FILT_TIMERS = ("filtration1", "filtration2", "filtration3")
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -145,7 +147,6 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
 
             # Always read filtration timer blocks for countdown aggregation,
             # even if the user hasn't enabled their configuration entities.
-            _FILT_TIMERS = ("filtration1", "filtration2", "filtration3")
             for ft in _FILT_TIMERS:
                 if ft not in enabled_timers:
                     enabled_timers.append(ft)

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -145,11 +145,18 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
 
             # Always read filtration timer blocks for countdown aggregation,
             # even if the user hasn't enabled their configuration entities.
-            for ft in ("filtration1", "filtration2", "filtration3"):
+            _FILT_TIMERS = ("filtration1", "filtration2", "filtration3")
+            for ft in _FILT_TIMERS:
                 if ft not in enabled_timers:
                     enabled_timers.append(ft)
 
-            timers = await self.client.read_all_timers(enabled_timers=enabled_timers)
+            # Bypass the notification cache for filtration timers while
+            # filtration is running so the countdown values stay fresh.
+            filtration_active = bool(data.get("Filtration Pump"))
+            timers = await self.client.read_all_timers(
+                enabled_timers=enabled_timers,
+                force_read=_FILT_TIMERS if filtration_active else None,
+            )
 
             for t_name, t in timers.items():
                 data[f"{t_name}_enable"] = t["enable"]

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -143,6 +143,12 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
                 if options.get(option_key, False):
                     enabled_timers.append(key)
 
+            # Always read filtration timer blocks for countdown aggregation,
+            # even if the user hasn't enabled their configuration entities.
+            for ft in ("filtration1", "filtration2", "filtration3"):
+                if ft not in enabled_timers:
+                    enabled_timers.append(ft)
+
             timers = await self.client.read_all_timers(enabled_timers=enabled_timers)
 
             for t_name, t in timers.items():
@@ -163,7 +169,7 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
                 cd = data.get(f"filtration{n}_countdown")
                 if cd is not None and cd > 0:
                     filt_remaining = max(filt_remaining or 0, cd)
-            data["filtration_remaining"] = filt_remaining
+            data["FILTRATION_REMAINING"] = filt_remaining
 
             if self.auto_time_sync:
                 if is_device_time_out_of_sync(data, self.hass):

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -150,11 +150,20 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
                 data[f"{t_name}_start"] = t["on"]  # saved as seconds since midnight
                 data[f"{t_name}_interval"] = t["interval"]
                 data[f"{t_name}_period"] = t["period"]
+                data[f"{t_name}_countdown"] = t["countdown"]
                 if t["on"] is not None and t["interval"] is not None:
                     stop = (t["on"] + t["interval"]) % 86400
                     data[f"{t_name}_stop"] = stop
                 else:
                     data[f"{t_name}_stop"] = None
+
+            # Aggregate filtration remaining time from active filtration timers
+            filt_remaining = None
+            for n in (1, 2, 3):
+                cd = data.get(f"filtration{n}_countdown")
+                if cd is not None and cd > 0:
+                    filt_remaining = max(filt_remaining or 0, cd)
+            data["filtration_remaining"] = filt_remaining
 
             if self.auto_time_sync:
                 if is_device_time_out_of_sync(data, self.hass):

--- a/custom_components/vistapool/modbus.py
+++ b/custom_components/vistapool/modbus.py
@@ -1142,10 +1142,10 @@ class VistaPoolModbusClient:
             end = time.monotonic()
             self._write_response_times.append(end - start)
 
-    async def read_all_timers(self, enabled_timers=None) -> dict:
+    async def read_all_timers(self, enabled_timers=None, force_read=None) -> dict:
         """Read timers with retry."""
         try:
-            result = await self._perform_read_all_timers(enabled_timers)
+            result = await self._perform_read_all_timers(enabled_timers, force_read)
             self._last_successful_operation = datetime.now()
             return result
         except Exception:
@@ -1155,29 +1155,32 @@ class VistaPoolModbusClient:
                 self._client = None
             raise
 
-    async def _perform_read_all_timers(self, enabled_timers=None) -> dict:
+    async def _perform_read_all_timers(
+        self, enabled_timers=None, force_read=None
+    ) -> dict:
         """Reads all timer blocks from the device.
         If enabled_timers is provided, only those timers will be read.
         If enabled_timers is None, all timers will be read.
+        If force_read is provided, those timers bypass the notification cache
+        and are always read fresh from the device.
         Returns a dictionary with timer names as keys and parsed timer data as values.
         """
         timers = {}
         start = time.monotonic()
+        force_read = set(force_read or ())
 
         # Skip timer reads if the INSTALLER page has not changed since the last poll
         # and this is not a forced full read.
-        if not self._last_was_full_read and not (
+        can_use_cache = not self._last_was_full_read and not (
             self._last_notification & _NOTIF_INSTALLER
-        ):
-            if self._cached_timers:
-                _LOGGER.debug("Skipping timer read (no INSTALLER change notification)")
-                if enabled_timers is not None:
-                    return {
-                        k: v
-                        for k, v in self._cached_timers.items()
-                        if k in enabled_timers
-                    }
-                return dict(self._cached_timers)
+        )
+        if can_use_cache and self._cached_timers and not force_read:
+            _LOGGER.debug("Skipping timer read (no INSTALLER change notification)")
+            if enabled_timers is not None:
+                return {
+                    k: v for k, v in self._cached_timers.items() if k in enabled_timers
+                }
+            return dict(self._cached_timers)
 
         client = await self.get_client()
         if client is None or not client.connected:
@@ -1190,6 +1193,10 @@ class VistaPoolModbusClient:
         for name, addr in TIMER_BLOCKS.items():
             # If enabled_timers is provided, limit to those timers only
             if enabled_timers is not None and name not in enabled_timers:
+                continue
+            # Use cache for non-forced timers when INSTALLER page hasn't changed
+            if can_use_cache and name not in force_read and name in self._cached_timers:
+                timers[name] = self._cached_timers[name]
                 continue
             try:
                 rr = await modbus_acall(

--- a/custom_components/vistapool/modbus.py
+++ b/custom_components/vistapool/modbus.py
@@ -1179,11 +1179,9 @@ class VistaPoolModbusClient:
         )
         if can_use_cache and self._cached_timers and not force_read:
             _LOGGER.debug("Skipping timer read (no INSTALLER change notification)")
-            if enabled_timers is not None:
-                return {
-                    k: v for k, v in self._cached_timers.items() if k in enabled_timers
-                }
-            return dict(self._cached_timers)
+            return {
+                k: v for k, v in self._cached_timers.items() if k in effective_timers
+            }
 
         client = await self.get_client()
         if client is None or not client.connected:
@@ -1194,8 +1192,7 @@ class VistaPoolModbusClient:
                 f"Modbus client connection failed to {self._host}:{self._port}"
             )
         for name, addr in TIMER_BLOCKS.items():
-            # If enabled_timers is provided, limit to those timers only
-            if enabled_timers is not None and name not in enabled_timers:
+            if name not in effective_timers:
                 continue
             # Use cache for non-forced timers when INSTALLER page hasn't changed
             if can_use_cache and name not in force_read and name in self._cached_timers:

--- a/custom_components/vistapool/modbus.py
+++ b/custom_components/vistapool/modbus.py
@@ -1167,7 +1167,10 @@ class VistaPoolModbusClient:
         """
         timers = {}
         start = time.monotonic()
-        force_read = set(force_read or ())
+        effective_timers = (
+            set(enabled_timers) if enabled_timers is not None else set(TIMER_BLOCKS)
+        )
+        force_read = set(force_read or ()) & effective_timers
 
         # Skip timer reads if the INSTALLER page has not changed since the last poll
         # and this is not a forced full read.

--- a/custom_components/vistapool/translations/cs.json
+++ b/custom_components/vistapool/translations/cs.json
@@ -154,6 +154,9 @@
       },
       "filtvalve_remaining": {
         "name": "Zbývající čas proplachování"
+      },
+      "filtration_remaining": {
+        "name": "Zbývající čas filtrace"
       }
     },
     "binary_sensor": {

--- a/custom_components/vistapool/translations/de.json
+++ b/custom_components/vistapool/translations/de.json
@@ -154,6 +154,9 @@
       },
       "filtvalve_remaining": {
         "name": "Verbleibende Rückspülzeit"
+      },
+      "filtration_remaining": {
+        "name": "Verbleibende Filtrationszeit"
       }
     },
     "binary_sensor": {

--- a/custom_components/vistapool/translations/en.json
+++ b/custom_components/vistapool/translations/en.json
@@ -154,6 +154,9 @@
       },
       "filtvalve_remaining": {
         "name": "Backwash Time Remaining"
+      },
+      "filtration_remaining": {
+        "name": "Filtration Time Remaining"
       }
     },
     "binary_sensor": {

--- a/custom_components/vistapool/translations/es.json
+++ b/custom_components/vistapool/translations/es.json
@@ -154,6 +154,9 @@
       },
       "filtvalve_remaining": {
         "name": "Tiempo restante de retrolavado"
+      },
+      "filtration_remaining": {
+        "name": "Tiempo restante de filtración"
       }
     },
     "binary_sensor": {

--- a/custom_components/vistapool/translations/fr.json
+++ b/custom_components/vistapool/translations/fr.json
@@ -154,6 +154,9 @@
       },
       "filtvalve_remaining": {
         "name": "Temps restant du rétrolavage"
+      },
+      "filtration_remaining": {
+        "name": "Temps restant de filtration"
       }
     },
     "binary_sensor": {

--- a/custom_components/vistapool/translations/it.json
+++ b/custom_components/vistapool/translations/it.json
@@ -154,6 +154,9 @@
       },
       "filtvalve_remaining": {
         "name": "Tempo rimanente di controlavaggio"
+      },
+      "filtration_remaining": {
+        "name": "Tempo rimanente di filtrazione"
       }
     },
     "binary_sensor": {

--- a/custom_components/vistapool/translations/pl.json
+++ b/custom_components/vistapool/translations/pl.json
@@ -154,6 +154,9 @@
       },
       "filtvalve_remaining": {
         "name": "Pozostały czas płukania wstecznego"
+      },
+      "filtration_remaining": {
+        "name": "Pozostały czas filtracji"
       }
     },
     "binary_sensor": {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -179,6 +179,14 @@ async def test_async_update_data_timer_processing(mock_entry):
     coordinator = VistaPoolCoordinator(MagicMock(), client, entry, entry.entry_id)
     data = await coordinator._async_update_data()
 
+    # Filtration timer blocks are always read regardless of use_filtration* options
+    call_args = client.read_all_timers.call_args
+    timers_requested = call_args[1].get("enabled_timers") or call_args[0][0]
+    for ft in ("filtration1", "filtration2", "filtration3"):
+        assert ft in timers_requested, (
+            f"{ft} must always be read for countdown aggregation"
+        )
+
     # Check that timer data keys are present and correctly computed
     assert data["filtration1_enable"] is True
     assert data["filtration1_start"] == 1000
@@ -196,7 +204,7 @@ async def test_async_update_data_timer_processing(mock_entry):
     assert data["filtration2_stop"] is None
 
     # Aggregated filtration remaining: max of non-zero countdowns (1200)
-    assert data["filtration_remaining"] == 1200
+    assert data["FILTRATION_REMAINING"] == 1200
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -149,7 +149,12 @@ def test_firmware_and_model_property(mock_entry):
 async def test_async_update_data_timer_processing(mock_entry):
     # Prepare a fake timer block with different value combinations
     client = AsyncMock()
-    client.async_read_all = AsyncMock(return_value={"MBF_POWER_MODULE_VERSION": 0x1234})
+    client.async_read_all = AsyncMock(
+        return_value={
+            "MBF_POWER_MODULE_VERSION": 0x1234,
+            "Filtration Pump": True,
+        }
+    )
     # Simulate two timers: one with both 'on' and 'interval', another with 'on' missing
     client.read_all_timers = AsyncMock(
         return_value={
@@ -181,11 +186,23 @@ async def test_async_update_data_timer_processing(mock_entry):
 
     # Filtration timer blocks are always read regardless of use_filtration* options
     call_args = client.read_all_timers.call_args
-    timers_requested = call_args[1].get("enabled_timers") or call_args[0][0]
+    timers_requested = (
+        call_args.kwargs.get("enabled_timers")
+        if "enabled_timers" in call_args.kwargs
+        else call_args.args[0]
+        if call_args.args
+        else None
+    )
     for ft in ("filtration1", "filtration2", "filtration3"):
         assert ft in timers_requested, (
             f"{ft} must always be read for countdown aggregation"
         )
+
+    # force_read must include filtration timers when filtration is active
+    force_read = call_args[1].get("force_read")
+    assert force_read is not None, "force_read must be set when filtration is running"
+    for ft in ("filtration1", "filtration2", "filtration3"):
+        assert ft in force_read, f"{ft} must bypass timer cache while filtration runs"
 
     # Check that timer data keys are present and correctly computed
     assert data["filtration1_enable"] is True

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -158,12 +158,14 @@ async def test_async_update_data_timer_processing(mock_entry):
                 "on": 1000,  # e.g. 1000 seconds since midnight
                 "interval": 3600,  # 1 hour
                 "period": 2,
+                "countdown": 1200,
             },
             "filtration2": {
                 "enable": False,
                 "on": None,
                 "interval": 1800,  # 30 minutes
                 "period": 1,
+                "countdown": 0,
             },
         }
     )
@@ -182,6 +184,7 @@ async def test_async_update_data_timer_processing(mock_entry):
     assert data["filtration1_start"] == 1000
     assert data["filtration1_interval"] == 3600
     assert data["filtration1_period"] == 2
+    assert data["filtration1_countdown"] == 1200
     # stop = (1000 + 3600) % 86400 = 4600
     assert data["filtration1_stop"] == 4600
 
@@ -189,7 +192,11 @@ async def test_async_update_data_timer_processing(mock_entry):
     assert data["filtration2_start"] is None
     assert data["filtration2_interval"] == 1800
     assert data["filtration2_period"] == 1
+    assert data["filtration2_countdown"] == 0
     assert data["filtration2_stop"] is None
+
+    # Aggregated filtration remaining: max of non-zero countdowns (1200)
+    assert data["filtration_remaining"] == 1200
 
 
 @pytest.mark.asyncio

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -1832,6 +1832,43 @@ async def test_perform_read_all_timers_skips_returns_all_cached_when_enabled_tim
 
 
 @pytest.mark.asyncio
+async def test_perform_read_all_timers_force_read_bypasses_cache(
+    config, monkeypatch
+):
+    """force_read timers are re-read from Modbus even when the cache would be used."""
+    client = vistapool_modbus.VistaPoolModbusClient(config)
+    client._last_was_full_read = False
+    client._last_notification = 0  # no notification — cache would normally be used
+    client._cached_timers = {
+        "filtration1": {
+            "enable": 1, "on": 3600, "interval": 7200,
+            "period": 1, "function": 1, "countdown": 999,
+        },
+        "filtration2": {
+            "enable": 0, "on": 0, "interval": 0,
+            "period": 1, "function": 1, "countdown": 0,
+        },
+    }
+
+    fake_modbus = AsyncMock()
+    fake_modbus.connected = True
+    fake_modbus.read_holding_registers = AsyncMock(return_value=_DummyResp([0] * 15))
+    monkeypatch.setattr(client, "get_client", AsyncMock(return_value=fake_modbus))
+
+    result = await client._perform_read_all_timers(
+        enabled_timers=["filtration1", "filtration2"],
+        force_read=["filtration1"],
+    )
+
+    # filtration1 must be read fresh (force_read), filtration2 served from cache
+    assert fake_modbus.read_holding_registers.await_count == 1
+    assert "filtration1" in result
+    assert "filtration2" in result
+    # filtration2 should retain cached countdown value
+    assert result["filtration2"]["countdown"] == 0
+
+
+@pytest.mark.asyncio
 async def test_perform_read_all_timers_reads_when_installer_notified(
     config, monkeypatch
 ):

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -1832,21 +1832,27 @@ async def test_perform_read_all_timers_skips_returns_all_cached_when_enabled_tim
 
 
 @pytest.mark.asyncio
-async def test_perform_read_all_timers_force_read_bypasses_cache(
-    config, monkeypatch
-):
+async def test_perform_read_all_timers_force_read_bypasses_cache(config, monkeypatch):
     """force_read timers are re-read from Modbus even when the cache would be used."""
     client = vistapool_modbus.VistaPoolModbusClient(config)
     client._last_was_full_read = False
     client._last_notification = 0  # no notification — cache would normally be used
     client._cached_timers = {
         "filtration1": {
-            "enable": 1, "on": 3600, "interval": 7200,
-            "period": 1, "function": 1, "countdown": 999,
+            "enable": 1,
+            "on": 3600,
+            "interval": 7200,
+            "period": 1,
+            "function": 1,
+            "countdown": 999,
         },
         "filtration2": {
-            "enable": 0, "on": 0, "interval": 0,
-            "period": 1, "function": 1, "countdown": 0,
+            "enable": 0,
+            "on": 0,
+            "interval": 0,
+            "period": 1,
+            "function": 1,
+            "countdown": 0,
         },
     }
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -403,6 +403,7 @@ async def test_sensor_async_setup_entry_adds_entities(monkeypatch):
 
     class DummyEntry:
         entry_id = "test_entry"
+        options = {}
 
     class DummyCoordinator:
         data = {
@@ -456,6 +457,7 @@ async def test_sensor_async_setup_entry_detected_flags(monkeypatch):
 
     class DummyEntry:
         entry_id = "test_entry"
+        options = {}
 
     class DummyCoordinator:
         data = {
@@ -489,6 +491,7 @@ async def test_sensor_async_setup_entry_model_mask(monkeypatch):
 
     class DummyEntry:
         entry_id = "test_entry"
+        options = {}
 
     class DummyCoordinator:
         data = {
@@ -515,6 +518,7 @@ async def test_sensor_hidro_skipped_without_hydrolysis(monkeypatch):
 
     class DummyEntry:
         entry_id = "test_entry"
+        options = {}
 
     class DummyCoordinator:
         data = {
@@ -604,6 +608,7 @@ async def test_sensor_temperature_skip_when_inactive():
 
     class DummyEntry:
         entry_id = "test_entry"
+        options = {}
 
     class DummyCoordinator:
         data = {
@@ -631,6 +636,7 @@ async def test_sensor_temperature_created_when_active():
 
     class DummyEntry:
         entry_id = "test_entry"
+        options = {}
 
     class DummyCoordinator:
         data = {
@@ -665,6 +671,7 @@ async def test_sensor_intelligent_key_skip_without_heating(sensor_key, value):
 
     class DummyEntry:
         entry_id = "test_entry"
+        options = {}
 
     class DummyCoordinator:
         config_entry = DummyEntry()
@@ -700,6 +707,7 @@ async def test_sensor_intelligent_key_created_with_heating(sensor_key, value):
 
     class DummyEntry:
         entry_id = "test_entry"
+        options = {}
 
     class DummyCoordinator:
         config_entry = DummyEntry()
@@ -755,6 +763,7 @@ async def test_async_setup_entry_no_data(caplog):
 
     class DummyEntry:
         entry_id = "test_entry"
+        options = {}
 
     class DummyCoordinator:
         data = None
@@ -783,6 +792,7 @@ async def test_sensor_setup_with_capability_snapshot_only():
 
     class DummyEntry:
         entry_id = "test_entry"
+        options = {}
 
     class DummyCoordinator:
         # Simulates the capability snapshot stored by set_winter_mode(True)
@@ -838,6 +848,7 @@ async def test_sensor_filtvalve_remaining_skipped_without_besgo():
 
     class DummyEntry:
         entry_id = "test_entry"
+        options = {}
 
     class DummyCoordinator:
         config_entry = DummyEntry()
@@ -862,6 +873,7 @@ async def test_sensor_filtvalve_remaining_created_with_besgo():
 
     class DummyEntry:
         entry_id = "test_entry"
+        options = {}
 
     class DummyCoordinator:
         config_entry = DummyEntry()
@@ -889,6 +901,7 @@ async def test_sensor_filtvalve_remaining_created_with_gpio_only():
 
     class DummyEntry:
         entry_id = "test_entry"
+        options = {}
 
     class DummyCoordinator:
         config_entry = DummyEntry()
@@ -924,3 +937,29 @@ def test_sensor_filtvalve_remaining_native_value():
         mock_coordinator, "test_entry", "MBF_PAR_FILTVALVE_REMAINING", {}
     )
     assert ent.native_value == 90
+
+
+def test_sensor_filtration_remaining_native_value():
+    """filtration_remaining sensor returns the aggregated remaining time."""
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {"filtration_remaining": 1800}
+    mock_coordinator.config_entry.entry_id = "test_entry"
+    mock_coordinator.device_slug = "vistapool"
+
+    from custom_components.vistapool.sensor import VistaPoolSensor
+
+    ent = VistaPoolSensor(mock_coordinator, "test_entry", "filtration_remaining", {})
+    assert ent.native_value == 1800
+
+
+def test_sensor_filtration_remaining_none_when_idle():
+    """filtration_remaining sensor returns None when no timer is counting down."""
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {"filtration_remaining": None}
+    mock_coordinator.config_entry.entry_id = "test_entry"
+    mock_coordinator.device_slug = "vistapool"
+
+    from custom_components.vistapool.sensor import VistaPoolSensor
+
+    ent = VistaPoolSensor(mock_coordinator, "test_entry", "filtration_remaining", {})
+    assert ent.native_value is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -942,24 +942,26 @@ def test_sensor_filtvalve_remaining_native_value():
 def test_sensor_filtration_remaining_native_value():
     """filtration_remaining sensor returns the aggregated remaining time."""
     mock_coordinator = MagicMock()
-    mock_coordinator.data = {"filtration_remaining": 1800}
+    mock_coordinator.data = {"FILTRATION_REMAINING": 1800}
     mock_coordinator.config_entry.entry_id = "test_entry"
+    mock_coordinator.config_entry.options = {}
     mock_coordinator.device_slug = "vistapool"
 
     from custom_components.vistapool.sensor import VistaPoolSensor
 
-    ent = VistaPoolSensor(mock_coordinator, "test_entry", "filtration_remaining", {})
+    ent = VistaPoolSensor(mock_coordinator, "test_entry", "FILTRATION_REMAINING", {})
     assert ent.native_value == 1800
 
 
 def test_sensor_filtration_remaining_none_when_idle():
     """filtration_remaining sensor returns None when no timer is counting down."""
     mock_coordinator = MagicMock()
-    mock_coordinator.data = {"filtration_remaining": None}
+    mock_coordinator.data = {"FILTRATION_REMAINING": None}
     mock_coordinator.config_entry.entry_id = "test_entry"
+    mock_coordinator.config_entry.options = {}
     mock_coordinator.device_slug = "vistapool"
 
     from custom_components.vistapool.sensor import VistaPoolSensor
 
-    ent = VistaPoolSensor(mock_coordinator, "test_entry", "filtration_remaining", {})
+    ent = VistaPoolSensor(mock_coordinator, "test_entry", "FILTRATION_REMAINING", {})
     assert ent.native_value is None


### PR DESCRIPTION
## ✨ Summary

Adds a new **Filtration Time Remaining** sensor that shows the remaining time (in seconds) of the currently running filtration cycle. The value is read from the `countdown` field (offset 9–10) of the filtration timer blocks, which the device firmware updates during active filtration.

Resolves #124

## 🔧 Changes

### Coordinator
- 📦 Store the `countdown` field from each timer block into coordinator data (`filtration{n}_countdown`)
- 🧮 Aggregate active countdowns into a single `filtration_remaining` value (max of non-zero countdowns across filtration timers 1–3)
- Returns `None` when no filtration cycle is active

### Sensor
- ➕ New `filtration_remaining` sensor definition with `SensorDeviceClass.DURATION` (unit: seconds)

### Translations
- 🌐 Added translations for all 7 languages: EN, CS, DE, ES, FR, IT, PL

### Tests
- ✅ Coordinator: verify `countdown` field is stored and `filtration_remaining` aggregation works correctly
- ✅ Sensor: verify `native_value` returns seconds and `None` when idle
- 🩹 Added missing `options = {}` to existing `DummyEntry` test mocks for consistency with real `ConfigEntry`

## ⚠️ Note

The `countdown` register field is documented for *countdown timer mode*. Whether the device firmware also populates it during standard auto/smart filtration modes depends on the specific firmware version. Community testing on real hardware is welcome — the sensor will show `None` (unknown) if the field is not updated by the device.

## 📁 Changed files

| File | Change |
|------|--------|
| `const.py` | +1 sensor definition |
| `coordinator.py` | +countdown storage, +aggregation logic |
| `translations/*.json` | +1 key in 7 files |
| `tests/test_coordinator.py` | +countdown assertions |
| `tests/test_sensor.py` | +2 new tests, +`options={}` to 13 mocks |