### PR TITLE
refactor(number): ♻️ extract entity skip logic into helper function

### DIFF
--- a/custom_components/vistapool/number.py
+++ b/custom_components/vistapool/number.py
@@ -59,11 +59,11 @@ def _should_skip_number(key: str, props: dict, data: dict, entry_options: dict) 
     if key == "MBF_PAR_PH2":
         if not bool(data.get("MBF_PAR_PH_BASE_RELAY_GPIO")):
             return True
-    # Conditionally add redox setpoint only if redox relay is assigned
+    # Conditionally add redox setpoint only if redox module is detected
     if key == "MBF_PAR_RX1":
         if not bool(data.get("Redox measurement module detected")):
             return True
-    # Conditionally add chlorine setpoint only if chlorine pump relay is assigned
+    # Conditionally add chlorine setpoint only if chlorine module is detected
     if key == "MBF_PAR_CL1":
         if not bool(data.get("Chlorine measurement module detected")):
             return True

--- a/custom_components/vistapool/number.py
+++ b/custom_components/vistapool/number.py
@@ -76,9 +76,10 @@ def _should_skip_number(key: str, props: dict, data: dict, entry_options: dict) 
             return True
     # Shutdown temperature needs hydrolysis and temperature sensor
     if key == "MBF_PAR_HIDRO_SHUTDOWN_TEMPERATURE":
-        if not data.get("Hydrolysis module detected") or data.get(
-            "MBF_PAR_TEMPERATURE_ACTIVE", 0
-        ) == 0:
+        if (
+            not data.get("Hydrolysis module detected")
+            or data.get("MBF_PAR_TEMPERATURE_ACTIVE", 0) == 0
+        ):
             return True
     return False
 

--- a/custom_components/vistapool/number.py
+++ b/custom_components/vistapool/number.py
@@ -35,6 +35,54 @@ from .helpers import is_hydrolysis_in_percent
 _LOGGER = logging.getLogger(__name__)
 
 
+def _should_skip_number(key: str, props: dict, data: dict, entry_options: dict) -> bool:
+    """Return True if a number entity should not be created."""
+    # Only create number entities if enabled in options
+    option_key = props.get("option")
+    if option_key and not entry_options.get(option_key, False):
+        return True
+    # Skip smart temperature numbers if no temperature sensor is active
+    if key in ("MBF_PAR_SMART_TEMP_HIGH", "MBF_PAR_SMART_TEMP_LOW"):
+        if not bool(data.get("MBF_PAR_TEMPERATURE_ACTIVE")):
+            return True
+    # Conditionally add heating setpoint only if heating relay is assigned
+    if key == "MBF_PAR_HEATING_TEMP":
+        if not bool(data.get("MBF_PAR_HEATING_GPIO")) or not bool(
+            data.get("MBF_PAR_TEMPERATURE_ACTIVE")
+        ):
+            return True
+    # Conditionally add pH high limit only if acid pump relay is assigned
+    if key == "MBF_PAR_PH1":
+        if not bool(data.get("MBF_PAR_PH_ACID_RELAY_GPIO")):
+            return True
+    # Conditionally add pH low limit only if base pump relay is assigned
+    if key == "MBF_PAR_PH2":
+        if not bool(data.get("MBF_PAR_PH_BASE_RELAY_GPIO")):
+            return True
+    # Conditionally add redox setpoint only if redox relay is assigned
+    if key == "MBF_PAR_RX1":
+        if not bool(data.get("Redox measurement module detected")):
+            return True
+    # Conditionally add chlorine setpoint only if chlorine pump relay is assigned
+    if key == "MBF_PAR_CL1":
+        if not bool(data.get("Chlorine measurement module detected")):
+            return True
+    # Skip hydrolysis target if no hydrolysis module is installed
+    if key == "MBF_PAR_HIDRO" and not data.get("Hydrolysis module detected"):
+        return True
+    # Cover reduction numbers only visible when hydrolysis module present
+    if key == "MBF_PAR_HIDRO_COVER_REDUCTION":
+        if not data.get("Hydrolysis module detected"):
+            return True
+    # Shutdown temperature needs hydrolysis and temperature sensor
+    if key == "MBF_PAR_HIDRO_SHUTDOWN_TEMPERATURE":
+        if not data.get("Hydrolysis module detected") or data.get(
+            "MBF_PAR_TEMPERATURE_ACTIVE", 0
+        ) == 0:
+            return True
+    return False
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
@@ -49,52 +97,8 @@ async def async_setup_entry(
         return
 
     for key, props in NUMBER_DEFINITIONS.items():
-        # Only create number entities if enabled in options
-        option_key = props.get("option")
-        if option_key and not entry.options.get(option_key, False):
+        if _should_skip_number(key, props, coordinator.data, entry.options):
             continue
-        # Skip smart temperature numbers if no temperature sensor is active
-        if key in ("MBF_PAR_SMART_TEMP_HIGH", "MBF_PAR_SMART_TEMP_LOW"):
-            if not bool(coordinator.data.get("MBF_PAR_TEMPERATURE_ACTIVE")):
-                continue
-        # Conditionally add heating setpoint only if heating relay is assigned
-        if key == "MBF_PAR_HEATING_TEMP":
-            if not bool(coordinator.data.get("MBF_PAR_HEATING_GPIO")) or not bool(
-                coordinator.data.get("MBF_PAR_TEMPERATURE_ACTIVE")
-            ):
-                continue
-        # Conditionally add pH high limit only if acid pump relay is assigned
-        if key == "MBF_PAR_PH1":
-            if not bool(coordinator.data.get("MBF_PAR_PH_ACID_RELAY_GPIO")):
-                continue
-        # Conditionally add pH low limit only if base pump relay is assigned
-        if key == "MBF_PAR_PH2":
-            if not bool(coordinator.data.get("MBF_PAR_PH_BASE_RELAY_GPIO")):
-                continue
-        # Conditionally add redox setpoint only if redox relay is assigned
-        if key == "MBF_PAR_RX1":
-            if not bool(coordinator.data.get("Redox measurement module detected")):
-                continue
-        # Conditionally add chlorine setpoint only if chlorine pump relay is assigned
-        if key == "MBF_PAR_CL1":
-            if not bool(coordinator.data.get("Chlorine measurement module detected")):
-                continue
-        # Skip hydrolysis target if no hydrolysis module is installed
-        if key == "MBF_PAR_HIDRO" and not coordinator.data.get(
-            "Hydrolysis module detected"
-        ):
-            continue
-        # Cover reduction numbers only visible when hydrolysis module present
-        if key == "MBF_PAR_HIDRO_COVER_REDUCTION":
-            if not coordinator.data.get("Hydrolysis module detected"):
-                continue
-        # Shutdown temperature needs hydrolysis and temperature sensor
-        if key == "MBF_PAR_HIDRO_SHUTDOWN_TEMPERATURE":
-            if (
-                not coordinator.data.get("Hydrolysis module detected")
-                or coordinator.data.get("MBF_PAR_TEMPERATURE_ACTIVE", 0) == 0
-            ):
-                continue
 
         entities.append(VistaPoolNumber(coordinator, entry_id, key, props))
 

--- a/custom_components/vistapool/number.py
+++ b/custom_components/vistapool/number.py
@@ -27,6 +27,7 @@ from .const import (
     HEATING_SETPOINT_REGISTER,
     INTELLIGENT_SETPOINT_REGISTER,
     NUMBER_DEFINITIONS,
+    is_valid_relay_gpio,
 )
 from .coordinator import VistaPoolCoordinator
 from .entity import VistaPoolEntity
@@ -45,19 +46,29 @@ def _should_skip_number(key: str, props: dict, data: dict, entry_options: dict) 
     if key in ("MBF_PAR_SMART_TEMP_HIGH", "MBF_PAR_SMART_TEMP_LOW"):
         if not bool(data.get("MBF_PAR_TEMPERATURE_ACTIVE")):
             return True
-    # Conditionally add heating setpoint only if heating relay is assigned
+    # Conditionally add heating setpoint only if heating relay is assigned.
+    # Only enforce when the GPIO key is present in data; a missing key
+    # (e.g. old capability snapshot) must not suppress the entity.
     if key == "MBF_PAR_HEATING_TEMP":
-        if not bool(data.get("MBF_PAR_HEATING_GPIO")) or not bool(
-            data.get("MBF_PAR_TEMPERATURE_ACTIVE")
+        if "MBF_PAR_HEATING_GPIO" in data and not is_valid_relay_gpio(
+            data["MBF_PAR_HEATING_GPIO"] or 0
         ):
             return True
-    # Conditionally add pH high limit only if acid pump relay is assigned
-    if key == "MBF_PAR_PH1":
-        if not bool(data.get("MBF_PAR_PH_ACID_RELAY_GPIO")):
+        if not bool(data.get("MBF_PAR_TEMPERATURE_ACTIVE")):
             return True
-    # Conditionally add pH low limit only if base pump relay is assigned
+    # Conditionally add pH high limit only if acid pump relay is assigned.
+    # Only enforce when the GPIO key is present in data.
+    if key == "MBF_PAR_PH1":
+        if "MBF_PAR_PH_ACID_RELAY_GPIO" in data and not is_valid_relay_gpio(
+            data["MBF_PAR_PH_ACID_RELAY_GPIO"] or 0
+        ):
+            return True
+    # Conditionally add pH low limit only if base pump relay is assigned.
+    # Only enforce when the GPIO key is present in data.
     if key == "MBF_PAR_PH2":
-        if not bool(data.get("MBF_PAR_PH_BASE_RELAY_GPIO")):
+        if "MBF_PAR_PH_BASE_RELAY_GPIO" in data and not is_valid_relay_gpio(
+            data["MBF_PAR_PH_BASE_RELAY_GPIO"] or 0
+        ):
             return True
     # Conditionally add redox setpoint only if redox module is detected
     if key == "MBF_PAR_RX1":


### PR DESCRIPTION
## ♻️ Summary

Extract the entity filtering logic from `async_setup_entry()` into a standalone `_should_skip_number()` helper function for better readability and testability.

## ⚠️ Behavioral changes

In addition to the structural refactor, this PR fixes the GPIO relay guard logic for three number entities (`MBF_PAR_HEATING_TEMP`, `MBF_PAR_PH1`, `MBF_PAR_PH2`):

- **Previously:** `not bool(data.get("MBF_PAR_*_GPIO"))` — a missing key returns `None`, which is falsy, so entities were **suppressed** when the GPIO key was absent from an older persisted `_capabilities` snapshot
- **Now:** `key in data and not is_valid_relay_gpio(data[key] or 0)` — the skip guard is only enforced when the GPIO key **actually exists** in `data`; a missing key no longer hides the entity
- Uses `is_valid_relay_gpio()` from `const.py` for consistent GPIO validation, aligned with the defensive pattern in `binary_sensor.py` and `light.py`

## 🔧 Changes

- ✨ Add `_should_skip_number(key, props, data, entry_options)` function consolidating all 10 skip conditions
- ♻️ Reduce `async_setup_entry()` loop body from ~42 lines to 3 lines
- 📝 Fix misleading comments for redox and chlorine skip conditions
- 🩹 Use defensive `key in data` + `is_valid_relay_gpio()` pattern for GPIO guards

## ✅ Testing

- All **614 tests pass**
- **100% code coverage** maintained