### PR TITLE
feat(coordinator): ✨ add register integrity checks

### DIFF
--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -71,6 +71,21 @@ def is_valid_relay_gpio(gpio: int) -> bool:
     return 1 <= gpio <= MAX_RELAY_GPIO
 
 
+# GPIO registers that assign physical relay outputs.
+# Used for sanity-checking register values after the first Modbus read.
+GPIO_REGISTERS = {
+    "MBF_PAR_FILT_GPIO": "Filtration relay",
+    "MBF_PAR_LIGHTING_GPIO": "Lighting relay",
+    "MBF_PAR_HEATING_GPIO": "Heating relay",
+    "MBF_PAR_PH_ACID_RELAY_GPIO": "pH acid pump relay",
+    "MBF_PAR_PH_BASE_RELAY_GPIO": "pH base pump relay",
+    "MBF_PAR_RX_RELAY_GPIO": "Redox pump relay",
+    "MBF_PAR_CL_RELAY_GPIO": "Chlorine pump relay",
+    "MBF_PAR_CD_RELAY_GPIO": "Conductivity pump relay",
+    "MBF_PAR_UV_RELAY_GPIO": "UV lamp relay",
+    "MBF_PAR_FILTVALVE_GPIO": "Filter valve relay",
+}
+
 # Capability keys that drive entity-creation logic in every platform's async_setup_entry.
 # They are snapshotted when winter mode is enabled and persisted in entry.options so that
 # platforms can set up the correct set of entities after a HA restart in winter mode.

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -155,6 +155,10 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
                 ),
                 notification_id=f"{DOMAIN}_corrupted_gpio",
             )
+        else:
+            # Clear any previous notification if registers are now valid
+            persistent_notification.async_dismiss(self.hass, f"{DOMAIN}_corrupted_gpio")
+            _LOGGER.info("GPIO registers passed sanity check: all values are valid")
 
     async def _async_update_data(self):
         # Winter mode: skip all Modbus communication; entities remain but show unknown values

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -18,6 +18,7 @@ import json
 import logging
 from datetime import timedelta
 
+from homeassistant.components import persistent_notification
 from homeassistant.const import CONF_NAME
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -131,7 +132,7 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
                     key,
                     label,
                     value,
-                    value,
+                    value & 0xFFFF,
                     MAX_RELAY_GPIO,
                 )
 
@@ -140,7 +141,8 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
                 f"- **{label}** (`{key}`): value **{value}** (expected 0–{MAX_RELAY_GPIO})"
                 for key, label, value in corrupted
             )
-            self.hass.components.persistent_notification.async_create(
+            persistent_notification.async_create(
+                self.hass,
                 title="VistaPool: Corrupted GPIO register(s) detected",
                 message=(
                     f"The following GPIO register(s) on your pool controller contain "

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -30,6 +30,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     FOLLOW_UP_REFRESH_DELAY,
+    GPIO_REGISTERS,
     HEATING_SETPOINT_REGISTER,
     INTELLIGENT_SETPOINT_REGISTER,
     MAX_RELAY_GPIO,
@@ -119,20 +120,8 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
         when the Modbus gateway framing mode does not match the integration's framer
         setting (e.g. transparent gateway with TCP framer).
         """
-        gpio_registers = {
-            "MBF_PAR_FILT_GPIO": "Filtration relay",
-            "MBF_PAR_LIGHTING_GPIO": "Lighting relay",
-            "MBF_PAR_HEATING_GPIO": "Heating relay",
-            "MBF_PAR_PH_ACID_RELAY_GPIO": "pH acid pump relay",
-            "MBF_PAR_PH_BASE_RELAY_GPIO": "pH base pump relay",
-            "MBF_PAR_RX_RELAY_GPIO": "Redox pump relay",
-            "MBF_PAR_CL_RELAY_GPIO": "Chlorine pump relay",
-            "MBF_PAR_CD_RELAY_GPIO": "Conductivity pump relay",
-            "MBF_PAR_UV_RELAY_GPIO": "UV lamp relay",
-            "MBF_PAR_FILTVALVE_GPIO": "Filter valve relay",
-        }
         corrupted = []
-        for key, label in gpio_registers.items():
+        for key, label in GPIO_REGISTERS.items():
             value = data.get(key)
             if value is not None and not (0 <= value <= MAX_RELAY_GPIO):
                 corrupted.append((key, label, value))

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -32,6 +32,7 @@ from .const import (
     FOLLOW_UP_REFRESH_DELAY,
     HEATING_SETPOINT_REGISTER,
     INTELLIGENT_SETPOINT_REGISTER,
+    MAX_RELAY_GPIO,
     TIMER_BLOCKS,
 )
 from .helpers import is_device_time_out_of_sync, parse_version, prepare_device_time
@@ -75,6 +76,7 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
         self._firmware = "?"
         self._model = "Unknown"
         self._follow_up_unsub: CALLBACK_TYPE | None = None
+        self._gpio_checked = False
 
     def request_refresh_with_followup(
         self, delay: float = FOLLOW_UP_REFRESH_DELAY
@@ -109,6 +111,60 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
 
         self._follow_up_unsub = async_call_later(self.hass, delay, _do_refresh)
 
+    def _check_gpio_registers(self, data: dict) -> None:
+        """Validate GPIO register values after first successful read.
+
+        GPIO registers assign physical relay outputs (valid range 0–MAX_RELAY_GPIO).
+        A value outside this range indicates register corruption, which can happen
+        when the Modbus gateway framing mode does not match the integration's framer
+        setting (e.g. transparent gateway with TCP framer).
+        """
+        gpio_registers = {
+            "MBF_PAR_FILT_GPIO": "Filtration relay",
+            "MBF_PAR_LIGHTING_GPIO": "Lighting relay",
+            "MBF_PAR_HEATING_GPIO": "Heating relay",
+            "MBF_PAR_PH_ACID_RELAY_GPIO": "pH acid pump relay",
+            "MBF_PAR_PH_BASE_RELAY_GPIO": "pH base pump relay",
+            "MBF_PAR_RX_RELAY_GPIO": "Redox pump relay",
+            "MBF_PAR_CL_RELAY_GPIO": "Chlorine pump relay",
+            "MBF_PAR_CD_RELAY_GPIO": "Conductivity pump relay",
+            "MBF_PAR_UV_RELAY_GPIO": "UV lamp relay",
+            "MBF_PAR_FILTVALVE_GPIO": "Filter valve relay",
+        }
+        corrupted = []
+        for key, label in gpio_registers.items():
+            value = data.get(key)
+            if value is not None and not (0 <= value <= MAX_RELAY_GPIO):
+                corrupted.append((key, label, value))
+                _LOGGER.error(
+                    "Corrupted GPIO register %s (%s): value %d (0x%04X) is outside "
+                    "valid range 0–%d. The pool controller may malfunction",
+                    key,
+                    label,
+                    value,
+                    value,
+                    MAX_RELAY_GPIO,
+                )
+
+        if corrupted:
+            details = "\n".join(
+                f"- **{label}** (`{key}`): value **{value}** (expected 0–{MAX_RELAY_GPIO})"
+                for key, label, value in corrupted
+            )
+            self.hass.components.persistent_notification.async_create(
+                title="VistaPool: Corrupted GPIO register(s) detected",
+                message=(
+                    f"The following GPIO register(s) on your pool controller contain "
+                    f"invalid values:\n\n{details}\n\n"
+                    f"This typically happens when the Modbus gateway framing mode "
+                    f"does not match the integration's framer setting. "
+                    f"The affected function(s) will not work correctly until the "
+                    f"register(s) are restored to valid values.\n\n"
+                    f"See the integration documentation for repair instructions."
+                ),
+                notification_id=f"{DOMAIN}_corrupted_gpio",
+            )
+
     async def _async_update_data(self):
         # Winter mode: skip all Modbus communication; entities remain but show unknown values
         if self.winter_mode:
@@ -129,6 +185,11 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
 
             self._firmware = parse_version(data.get("MBF_POWER_MODULE_VERSION"))
             self._model = "VistaPool"
+
+            # One-time GPIO sanity check after first successful read
+            if not self._gpio_checked:
+                self._gpio_checked = True
+                self._check_gpio_registers(data)
 
             options = self.entry.options
             enabled_timers = []

--- a/custom_components/vistapool/modbus.py
+++ b/custom_components/vistapool/modbus.py
@@ -1039,13 +1039,17 @@ class VistaPoolModbusClient:
 
             # Verify the read-back matches the written value
             if confirm.registers != value:
+                wrote = value if len(value) > 1 else value[0]
+                read_back = (
+                    confirm.registers if len(value) > 1 else confirm.registers[0]
+                )
                 _LOGGER.warning(
                     "Write verification mismatch at 0x%04X: wrote %s, read back %s. "
                     "This may indicate a framing misconfiguration between the "
                     "Modbus gateway and the integration",
                     address,
-                    value,
-                    confirm.registers,
+                    wrote,
+                    read_back,
                 )
 
             # If apply is True, save the configuration to EEPROM and execute

--- a/custom_components/vistapool/modbus.py
+++ b/custom_components/vistapool/modbus.py
@@ -1037,6 +1037,17 @@ class VistaPoolModbusClient:
                 _LOGGER.error("Read failed at 0x%04X: %s", address, confirm)
                 return None
 
+            # Verify the read-back matches the written value
+            if confirm.registers != value:
+                _LOGGER.warning(
+                    "Write verification mismatch at 0x%04X: wrote %s, read back %s. "
+                    "This may indicate a framing misconfiguration between the "
+                    "Modbus gateway and the integration",
+                    address,
+                    value,
+                    confirm.registers,
+                )
+
             # If apply is True, save the configuration to EEPROM and execute
             if apply:
                 await asyncio.sleep(0.1)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -776,6 +776,9 @@ class TestGpioSanityCheck:
     PATCH_TARGET = (
         "custom_components.vistapool.coordinator.persistent_notification.async_create"
     )
+    PATCH_DISMISS = (
+        "custom_components.vistapool.coordinator.persistent_notification.async_dismiss"
+    )
 
     def _make_coordinator(self, mock_entry):
         hass = MagicMock()
@@ -787,7 +790,7 @@ class TestGpioSanityCheck:
 
     def test_valid_gpio_values_no_notification(self, mock_entry):
         """No notification when all GPIO registers are within valid range."""
-        coordinator, _ = self._make_coordinator(mock_entry)
+        coordinator, hass = self._make_coordinator(mock_entry)
         data = {
             "MBF_PAR_FILT_GPIO": 2,
             "MBF_PAR_LIGHTING_GPIO": 3,
@@ -795,9 +798,13 @@ class TestGpioSanityCheck:
             "MBF_PAR_PH_ACID_RELAY_GPIO": 1,
             "MBF_PAR_UV_RELAY_GPIO": 0,
         }
-        with patch(self.PATCH_TARGET) as mock_notify:
+        with (
+            patch(self.PATCH_TARGET) as mock_notify,
+            patch(self.PATCH_DISMISS) as mock_dismiss,
+        ):
             coordinator._check_gpio_registers(data)
             mock_notify.assert_not_called()
+            mock_dismiss.assert_called_once_with(hass, "vistapool_corrupted_gpio")
 
     def test_corrupted_gpio_triggers_notification(self, mock_entry):
         """Notification is created when a GPIO register has an invalid value."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -809,10 +809,10 @@ class TestGpioSanityCheck:
         with patch(self.PATCH_TARGET) as mock_notify:
             coordinator._check_gpio_registers(data)
             mock_notify.assert_called_once()
-            call_kwargs = mock_notify.call_args.kwargs
-            assert call_kwargs.pop("hass", None) is None or True
-            # hass is passed as first positional arg
+            # hass must be passed as first positional arg, not as keyword
             assert mock_notify.call_args.args[0] is hass
+            assert "hass" not in mock_notify.call_args.kwargs
+            call_kwargs = mock_notify.call_args.kwargs
             assert "Corrupted GPIO" in call_kwargs["title"]
             assert "22846" in call_kwargs["message"]
             assert "MBF_PAR_FILT_GPIO" in call_kwargs["message"]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -773,6 +773,10 @@ async def test_cancel_follow_up_refresh_noop_when_none(mock_entry):
 class TestGpioSanityCheck:
     """Tests for _check_gpio_registers."""
 
+    PATCH_TARGET = (
+        "custom_components.vistapool.coordinator.persistent_notification.async_create"
+    )
+
     def _make_coordinator(self, mock_entry):
         hass = MagicMock()
         client = AsyncMock()
@@ -791,8 +795,9 @@ class TestGpioSanityCheck:
             "MBF_PAR_PH_ACID_RELAY_GPIO": 1,
             "MBF_PAR_UV_RELAY_GPIO": 0,
         }
-        coordinator._check_gpio_registers(data)
-        hass.components.persistent_notification.async_create.assert_not_called()
+        with patch(self.PATCH_TARGET) as mock_notify:
+            coordinator._check_gpio_registers(data)
+            mock_notify.assert_not_called()
 
     def test_corrupted_gpio_triggers_notification(self, mock_entry):
         """Notification is created when a GPIO register has an invalid value."""
@@ -801,15 +806,17 @@ class TestGpioSanityCheck:
             "MBF_PAR_FILT_GPIO": 22846,  # corrupted
             "MBF_PAR_LIGHTING_GPIO": 3,
         }
-        coordinator._check_gpio_registers(data)
-        hass.components.persistent_notification.async_create.assert_called_once()
-        call_kwargs = (
-            hass.components.persistent_notification.async_create.call_args.kwargs
-        )
-        assert "Corrupted GPIO" in call_kwargs["title"]
-        assert "22846" in call_kwargs["message"]
-        assert "MBF_PAR_FILT_GPIO" in call_kwargs["message"]
-        assert call_kwargs["notification_id"] == "vistapool_corrupted_gpio"
+        with patch(self.PATCH_TARGET) as mock_notify:
+            coordinator._check_gpio_registers(data)
+            mock_notify.assert_called_once()
+            call_kwargs = mock_notify.call_args.kwargs
+            assert call_kwargs.pop("hass", None) is None or True
+            # hass is passed as first positional arg
+            assert mock_notify.call_args.args[0] is hass
+            assert "Corrupted GPIO" in call_kwargs["title"]
+            assert "22846" in call_kwargs["message"]
+            assert "MBF_PAR_FILT_GPIO" in call_kwargs["message"]
+            assert call_kwargs["notification_id"] == "vistapool_corrupted_gpio"
 
     def test_multiple_corrupted_gpio_in_single_notification(self, mock_entry):
         """Multiple corrupted GPIO registers appear in a single notification."""
@@ -818,33 +825,35 @@ class TestGpioSanityCheck:
             "MBF_PAR_FILT_GPIO": 22846,
             "MBF_PAR_HEATING_GPIO": 65535,
         }
-        coordinator._check_gpio_registers(data)
-        hass.components.persistent_notification.async_create.assert_called_once()
-        msg = hass.components.persistent_notification.async_create.call_args.kwargs[
-            "message"
-        ]
-        assert "MBF_PAR_FILT_GPIO" in msg
-        assert "MBF_PAR_HEATING_GPIO" in msg
+        with patch(self.PATCH_TARGET) as mock_notify:
+            coordinator._check_gpio_registers(data)
+            mock_notify.assert_called_once()
+            msg = mock_notify.call_args.kwargs["message"]
+            assert "MBF_PAR_FILT_GPIO" in msg
+            assert "MBF_PAR_HEATING_GPIO" in msg
 
     def test_missing_gpio_keys_no_notification(self, mock_entry):
         """No notification when GPIO keys are absent from data."""
         coordinator, hass = self._make_coordinator(mock_entry)
-        coordinator._check_gpio_registers({})
-        hass.components.persistent_notification.async_create.assert_not_called()
+        with patch(self.PATCH_TARGET) as mock_notify:
+            coordinator._check_gpio_registers({})
+            mock_notify.assert_not_called()
 
     def test_zero_gpio_is_valid(self, mock_entry):
         """GPIO value 0 (unassigned) is within valid range and should not trigger notification."""
         coordinator, hass = self._make_coordinator(mock_entry)
         data = {"MBF_PAR_FILT_GPIO": 0}
-        coordinator._check_gpio_registers(data)
-        hass.components.persistent_notification.async_create.assert_not_called()
+        with patch(self.PATCH_TARGET) as mock_notify:
+            coordinator._check_gpio_registers(data)
+            mock_notify.assert_not_called()
 
     def test_negative_gpio_triggers_notification(self, mock_entry):
         """Negative GPIO value is out of range and triggers notification."""
         coordinator, hass = self._make_coordinator(mock_entry)
         data = {"MBF_PAR_FILT_GPIO": -1}
-        coordinator._check_gpio_registers(data)
-        hass.components.persistent_notification.async_create.assert_called_once()
+        with patch(self.PATCH_TARGET) as mock_notify:
+            coordinator._check_gpio_registers(data)
+            mock_notify.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_gpio_check_runs_only_once(self, mock_entry):
@@ -858,11 +867,12 @@ class TestGpioSanityCheck:
         )
         coordinator.client.read_all_timers = AsyncMock(return_value={})
 
-        await coordinator._async_update_data()
-        assert coordinator._gpio_checked is True
-        assert hass.components.persistent_notification.async_create.call_count == 1
+        with patch(self.PATCH_TARGET) as mock_notify:
+            await coordinator._async_update_data()
+            assert coordinator._gpio_checked is True
+            assert mock_notify.call_count == 1
 
-        # Second call should NOT trigger check again
-        hass.components.persistent_notification.async_create.reset_mock()
-        await coordinator._async_update_data()
-        hass.components.persistent_notification.async_create.assert_not_called()
+            # Second call should NOT trigger check again
+            mock_notify.reset_mock()
+            await coordinator._async_update_data()
+            mock_notify.assert_not_called()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -768,3 +768,101 @@ async def test_cancel_follow_up_refresh_noop_when_none(mock_entry):
     assert coordinator._follow_up_unsub is None
     coordinator.cancel_follow_up_refresh()  # should not raise
     assert coordinator._follow_up_unsub is None
+
+
+class TestGpioSanityCheck:
+    """Tests for _check_gpio_registers."""
+
+    def _make_coordinator(self, mock_entry):
+        hass = MagicMock()
+        client = AsyncMock()
+        coordinator = VistaPoolCoordinator(
+            hass, client, mock_entry, mock_entry.entry_id
+        )
+        return coordinator, hass
+
+    def test_valid_gpio_values_no_notification(self, mock_entry):
+        """No notification when all GPIO registers are within valid range."""
+        coordinator, hass = self._make_coordinator(mock_entry)
+        data = {
+            "MBF_PAR_FILT_GPIO": 2,
+            "MBF_PAR_LIGHTING_GPIO": 3,
+            "MBF_PAR_HEATING_GPIO": 7,
+            "MBF_PAR_PH_ACID_RELAY_GPIO": 1,
+            "MBF_PAR_UV_RELAY_GPIO": 0,
+        }
+        coordinator._check_gpio_registers(data)
+        hass.components.persistent_notification.async_create.assert_not_called()
+
+    def test_corrupted_gpio_triggers_notification(self, mock_entry):
+        """Notification is created when a GPIO register has an invalid value."""
+        coordinator, hass = self._make_coordinator(mock_entry)
+        data = {
+            "MBF_PAR_FILT_GPIO": 22846,  # corrupted
+            "MBF_PAR_LIGHTING_GPIO": 3,
+        }
+        coordinator._check_gpio_registers(data)
+        hass.components.persistent_notification.async_create.assert_called_once()
+        call_kwargs = (
+            hass.components.persistent_notification.async_create.call_args.kwargs
+        )
+        assert "Corrupted GPIO" in call_kwargs["title"]
+        assert "22846" in call_kwargs["message"]
+        assert "MBF_PAR_FILT_GPIO" in call_kwargs["message"]
+        assert call_kwargs["notification_id"] == "vistapool_corrupted_gpio"
+
+    def test_multiple_corrupted_gpio_in_single_notification(self, mock_entry):
+        """Multiple corrupted GPIO registers appear in a single notification."""
+        coordinator, hass = self._make_coordinator(mock_entry)
+        data = {
+            "MBF_PAR_FILT_GPIO": 22846,
+            "MBF_PAR_HEATING_GPIO": 65535,
+        }
+        coordinator._check_gpio_registers(data)
+        hass.components.persistent_notification.async_create.assert_called_once()
+        msg = hass.components.persistent_notification.async_create.call_args.kwargs[
+            "message"
+        ]
+        assert "MBF_PAR_FILT_GPIO" in msg
+        assert "MBF_PAR_HEATING_GPIO" in msg
+
+    def test_missing_gpio_keys_no_notification(self, mock_entry):
+        """No notification when GPIO keys are absent from data."""
+        coordinator, hass = self._make_coordinator(mock_entry)
+        coordinator._check_gpio_registers({})
+        hass.components.persistent_notification.async_create.assert_not_called()
+
+    def test_zero_gpio_is_valid(self, mock_entry):
+        """GPIO value 0 (unassigned) is within valid range and should not trigger notification."""
+        coordinator, hass = self._make_coordinator(mock_entry)
+        data = {"MBF_PAR_FILT_GPIO": 0}
+        coordinator._check_gpio_registers(data)
+        hass.components.persistent_notification.async_create.assert_not_called()
+
+    def test_negative_gpio_triggers_notification(self, mock_entry):
+        """Negative GPIO value is out of range and triggers notification."""
+        coordinator, hass = self._make_coordinator(mock_entry)
+        data = {"MBF_PAR_FILT_GPIO": -1}
+        coordinator._check_gpio_registers(data)
+        hass.components.persistent_notification.async_create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_gpio_check_runs_only_once(self, mock_entry):
+        """_check_gpio_registers is called only on the first successful read."""
+        coordinator, hass = self._make_coordinator(mock_entry)
+        coordinator.client.async_read_all = AsyncMock(
+            return_value={
+                "MBF_POWER_MODULE_VERSION": 0x1234,
+                "MBF_PAR_FILT_GPIO": 22846,
+            }
+        )
+        coordinator.client.read_all_timers = AsyncMock(return_value={})
+
+        await coordinator._async_update_data()
+        assert coordinator._gpio_checked is True
+        assert hass.components.persistent_notification.async_create.call_count == 1
+
+        # Second call should NOT trigger check again
+        hass.components.persistent_notification.async_create.reset_mock()
+        await coordinator._async_update_data()
+        hass.components.persistent_notification.async_create.assert_not_called()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -787,7 +787,7 @@ class TestGpioSanityCheck:
 
     def test_valid_gpio_values_no_notification(self, mock_entry):
         """No notification when all GPIO registers are within valid range."""
-        coordinator, hass = self._make_coordinator(mock_entry)
+        coordinator, _ = self._make_coordinator(mock_entry)
         data = {
             "MBF_PAR_FILT_GPIO": 2,
             "MBF_PAR_LIGHTING_GPIO": 3,
@@ -820,7 +820,7 @@ class TestGpioSanityCheck:
 
     def test_multiple_corrupted_gpio_in_single_notification(self, mock_entry):
         """Multiple corrupted GPIO registers appear in a single notification."""
-        coordinator, hass = self._make_coordinator(mock_entry)
+        coordinator, _ = self._make_coordinator(mock_entry)
         data = {
             "MBF_PAR_FILT_GPIO": 22846,
             "MBF_PAR_HEATING_GPIO": 65535,
@@ -834,14 +834,14 @@ class TestGpioSanityCheck:
 
     def test_missing_gpio_keys_no_notification(self, mock_entry):
         """No notification when GPIO keys are absent from data."""
-        coordinator, hass = self._make_coordinator(mock_entry)
+        coordinator, _ = self._make_coordinator(mock_entry)
         with patch(self.PATCH_TARGET) as mock_notify:
             coordinator._check_gpio_registers({})
             mock_notify.assert_not_called()
 
     def test_zero_gpio_is_valid(self, mock_entry):
         """GPIO value 0 (unassigned) is within valid range and should not trigger notification."""
-        coordinator, hass = self._make_coordinator(mock_entry)
+        coordinator, _ = self._make_coordinator(mock_entry)
         data = {"MBF_PAR_FILT_GPIO": 0}
         with patch(self.PATCH_TARGET) as mock_notify:
             coordinator._check_gpio_registers(data)
@@ -849,7 +849,7 @@ class TestGpioSanityCheck:
 
     def test_negative_gpio_triggers_notification(self, mock_entry):
         """Negative GPIO value is out of range and triggers notification."""
-        coordinator, hass = self._make_coordinator(mock_entry)
+        coordinator, _ = self._make_coordinator(mock_entry)
         data = {"MBF_PAR_FILT_GPIO": -1}
         with patch(self.PATCH_TARGET) as mock_notify:
             coordinator._check_gpio_registers(data)
@@ -858,7 +858,7 @@ class TestGpioSanityCheck:
     @pytest.mark.asyncio
     async def test_gpio_check_runs_only_once(self, mock_entry):
         """_check_gpio_registers is called only on the first successful read."""
-        coordinator, hass = self._make_coordinator(mock_entry)
+        coordinator, _ = self._make_coordinator(mock_entry)
         coordinator.client.async_read_all = AsyncMock(
             return_value={
                 "MBF_POWER_MODULE_VERSION": 0x1234,

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -809,6 +809,34 @@ async def test_perform_write_register_happy_path(config, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_perform_write_register_mismatch_warning(config, monkeypatch, caplog):
+    """Test _perform_write_register logs warning when read-back differs from written value."""
+    client = vistapool_modbus.VistaPoolModbusClient(config)
+    fake_modbus = AsyncMock()
+    fake_modbus.connected = True
+
+    class DummyResp:
+        def __init__(self, val, is_error=False):
+            self.isError = lambda: is_error
+            self.registers = [val]
+
+    fake_modbus.write_registers = AsyncMock(return_value=DummyResp(123, False))
+    # Read-back returns a different value
+    fake_modbus.read_holding_registers = AsyncMock(return_value=DummyResp(999, False))
+    monkeypatch.setattr(client, "get_client", AsyncMock(return_value=fake_modbus))
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        result = await client._perform_write_register(0x0100, 123)
+    # Should still return a result (the write itself succeeded)
+    assert result is not None
+    assert result["confirmed"] == 999
+    assert "Write verification mismatch" in caplog.text
+    assert "framing misconfiguration" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_perform_write_register_write_isError(config, monkeypatch):
     """Test _perform_write_register returns None if write_registers returns error."""
     client = vistapool_modbus.VistaPoolModbusClient(config)


### PR DESCRIPTION
## ✨ What

Adds two safety mechanisms to detect Modbus register corruption and framing misconfigurations:

### 1. GPIO register sanity check (coordinator)
- 🔍 Validates 10 GPIO registers after the **first successful Modbus read**
- ✅ Valid range: `0–7` (0 = unassigned, 1–7 = relay number)
- 🔔 Creates a **persistent notification** in HA when corrupted values are detected
- 📝 Logs `ERROR` with register name, value, and hex representation
- ⚡ Runs only once per config entry lifecycle (flag `_gpio_checked`)

### 2. Write verification (modbus)
- 🔍 **Compares read-back value** against written value after every register write
- ⚠️ Logs `WARNING` on mismatch, hinting at possible framing misconfiguration
- ✅ Does not block the write — detection only, not prevention

## 🐛 Why

A user reported their pool controller became completely unresponsive (Discussion #132). Investigation revealed that register `MBF_PAR_FILT_GPIO` (0x0412) contained value **22846** instead of the valid range 0–7. This corrupted value meant the controller didn't know which relay to activate for filtration — nothing worked, not even from the physical panel.

The most likely cause: a **framing mismatch** between the Modbus gateway (transparent mode) and the integration (TCP framer). In this scenario, the MBAP header passes through to RS485 raw and the controller misinterprets it as an RTU write command to a random register.

| Gateway | Integration framer | Result |
|---|---|---|
| Modbus TCP↔RTU | `tcp` | ✅ Correct |
| Transparent | `rtu` | ✅ Correct |
| Modbus TCP↔RTU | `rtu` | ⚠️ Timeout (safe) |
| Transparent | `tcp` | 🔴 **Dangerous — random register writes** |

## 🧪 Tests

- 7 new tests for GPIO sanity check (valid, corrupted, multiple, missing, zero, negative, runs-once)
- 1 new test for write verification mismatch warning
- All **622 tests pass**

## 📁 Changed files

| File | Change |
|---|---|
| `coordinator.py` | `_check_gpio_registers()` method + one-time call after first read |
| `modbus.py` | Write read-back comparison in `_perform_write_register()` |
| `test_coordinator.py` | `TestGpioSanityCheck` class (7 tests) |
| `test_modbus.py` | `test_perform_write_register_mismatch_warning` |