### PR TITLE
fix(diagnostics): 🔒️ use HA async_redact_data and remove data duplica…

### DIFF
--- a/custom_components/vistapool/diagnostics.py
+++ b/custom_components/vistapool/diagnostics.py
@@ -44,7 +44,7 @@ async def async_get_config_entry_diagnostics(
     }
 
     # Coordinator state (contains data, errors, etc.)
-    coordinator = hass.data[DOMAIN].get(entry.entry_id)
+    coordinator = hass.data.get(DOMAIN, {}).get(entry.entry_id)
     if coordinator is None:
         return diagnostics
 

--- a/custom_components/vistapool/diagnostics.py
+++ b/custom_components/vistapool/diagnostics.py
@@ -16,30 +16,30 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 
+TO_REDACT = {"password", "token", "host", "port"}
+
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
-) -> dict:
+) -> dict[str, Any]:
     """Return diagnostics for a VistaPool config entry."""
 
-    diagnostics: dict = {}
+    diagnostics: dict[str, Any] = {}
 
-    # Basic config and options (without any sensitive data)
-    SENSITIVE_KEYS = {"password", "token", "host", "port"}
     diagnostics["config_entry"] = {
-        "data": {
-            k: v
-            for k, v in entry.data.items()
-            if not any(s in k for s in SENSITIVE_KEYS)
-        },
+        "data": async_redact_data(dict(entry.data), TO_REDACT),
         "options": dict(entry.options),
         "title": entry.title,
         "entry_id": entry.entry_id,
+        "unique_id": entry.unique_id,
         "version": entry.version,
     }
 
@@ -56,14 +56,13 @@ async def async_get_config_entry_diagnostics(
         "last_exception": str(getattr(coordinator, "last_exception", "")),
         "firmware": getattr(coordinator, "firmware", None),
         "model": getattr(coordinator, "model", None),
-        "client": str(getattr(coordinator, "client", "")),
     }
 
     # Additional client details
     client = getattr(coordinator, "client", None)
     if client and hasattr(client, "connection_stats"):
-        diagnostics["connection_stats"] = client.connection_stats
-
-    diagnostics["last_device_data"] = getattr(coordinator, "data", {})
+        diagnostics["connection_stats"] = async_redact_data(
+            dict(client.connection_stats), TO_REDACT
+        )
 
     return diagnostics

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -34,6 +34,7 @@ async def test_diagnostics_redacts_sensitive_config_data():
     entry.options = {"option1": True}
     entry.title = "Test Pool"
     entry.entry_id = "entry1"
+    entry.unique_id = "neopool_0000000100AC00CD00120034"
     entry.version = 1
 
     client = MagicMock()
@@ -76,6 +77,9 @@ async def test_diagnostics_redacts_sensitive_config_data():
     assert stats["unit_id"] == 1
 
     assert diagnostics["config_entry"]["title"] == "Test Pool"
+    assert (
+        diagnostics["config_entry"]["unique_id"] == "neopool_0000000100AC00CD00120034"
+    )
     assert diagnostics["coordinator"]["firmware"] == "1.0"
     assert diagnostics["coordinator"]["model"] == "Vistapool"
 
@@ -86,6 +90,7 @@ async def test_diagnostics_without_coordinator():
     entry.data = {"host": "1.2.3.4"}
     entry.options = {}
     entry.entry_id = "entry42"
+    entry.unique_id = None
     entry.version = 1
     entry.title = "Pool"
     hass = MagicMock()
@@ -102,6 +107,7 @@ async def test_diagnostics_no_client():
     entry.data = {}
     entry.options = {}
     entry.entry_id = "entry1"
+    entry.unique_id = None
     entry.version = 1
     entry.title = "Pool"
     coordinator = MagicMock(
@@ -132,6 +138,7 @@ async def test_diagnostics_no_duplicate_data():
     entry.data = {}
     entry.options = {}
     entry.entry_id = "entry1"
+    entry.unique_id = None
     entry.version = 1
     entry.title = "Pool"
     coordinator = MagicMock()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -18,16 +18,17 @@ import pytest
 
 from custom_components.vistapool.diagnostics import async_get_config_entry_diagnostics
 
+REDACTED = "**REDACTED**"
+
 
 @pytest.mark.asyncio
-async def test_async_get_config_entry_diagnostics_filters_sensitive_data():
-    # Prepare a mock config_entry with sensitive data
+async def test_diagnostics_redacts_sensitive_config_data():
     entry = MagicMock()
     entry.data = {
         "host": "192.168.1.100",
         "port": 8899,
         "password": "secret",
-        "apitoken": "abcdef",
+        "token": "abcdef",
         "user": "admin",
     }
     entry.options = {"option1": True}
@@ -35,7 +36,6 @@ async def test_async_get_config_entry_diagnostics_filters_sensitive_data():
     entry.entry_id = "entry1"
     entry.version = 1
 
-    # Prepare a mock client
     client = MagicMock()
     client.connection_stats = {
         "retries": 3,
@@ -45,7 +45,6 @@ async def test_async_get_config_entry_diagnostics_filters_sensitive_data():
         "connected": True,
     }
 
-    # Prepare a mock coordinator
     coordinator = MagicMock()
     coordinator.last_update_success = True
     coordinator.last_update_time = "2025-07-19 10:00:00"
@@ -56,70 +55,91 @@ async def test_async_get_config_entry_diagnostics_filters_sensitive_data():
     coordinator.model = "Vistapool"
     coordinator.client = client
 
-    # Prepare a mock hass object with the coordinator registered
     hass = MagicMock()
     hass.data = {"vistapool": {"entry1": coordinator}}
 
     diagnostics = await async_get_config_entry_diagnostics(hass, entry)
-    # Ensure password, apitoken, host, and port are filtered out from the result
-    data_keys = diagnostics["config_entry"]["data"].keys()
-    assert "password" not in data_keys
-    assert "apitoken" not in data_keys
-    assert "host" not in data_keys
-    assert "port" not in data_keys
-    assert "user" in data_keys
 
-    # Ensure all sections are present and have correct values
+    # Sensitive keys are present but redacted
+    config_data = diagnostics["config_entry"]["data"]
+    assert config_data["host"] == REDACTED
+    assert config_data["port"] == REDACTED
+    assert config_data["password"] == REDACTED
+    assert config_data["token"] == REDACTED
+    assert config_data["user"] == "admin"
+
+    # connection_stats sensitive keys are also redacted
+    stats = diagnostics["connection_stats"]
+    assert stats["host"] == REDACTED
+    assert stats["port"] == REDACTED
+    assert stats["retries"] == 3
+    assert stats["unit_id"] == 1
+
     assert diagnostics["config_entry"]["title"] == "Test Pool"
-    assert diagnostics["config_entry"]["entry_id"] == "entry1"
     assert diagnostics["coordinator"]["firmware"] == "1.0"
     assert diagnostics["coordinator"]["model"] == "Vistapool"
-    assert diagnostics["connection_stats"]["retries"] == 3
 
 
 @pytest.mark.asyncio
-async def test_diagnostics_without_coordinator_returns_empty():
-    # Prepare a mock config_entry without a matching coordinator in hass.data
+async def test_diagnostics_without_coordinator():
     entry = MagicMock()
+    entry.data = {"host": "1.2.3.4"}
+    entry.options = {}
     entry.entry_id = "entry42"
+    entry.version = 1
+    entry.title = "Pool"
     hass = MagicMock()
     hass.data = {"vistapool": {}}
 
     diagnostics = await async_get_config_entry_diagnostics(hass, entry)
-    # If no coordinator is found, diagnostics should be minimal
     assert diagnostics["config_entry"]["entry_id"] == "entry42"
-    assert "coordinator" not in diagnostics or diagnostics["coordinator"] is None
+    assert "coordinator" not in diagnostics
 
 
 @pytest.mark.asyncio
-async def test_diagnostics_with_coordinator_but_no_client():
-    # Prepare a mock config_entry with a coordinator that has no client
+async def test_diagnostics_no_client():
     entry = MagicMock()
+    entry.data = {}
+    entry.options = {}
     entry.entry_id = "entry1"
+    entry.version = 1
+    entry.title = "Pool"
+    coordinator = MagicMock(
+        spec=[
+            "last_update_success",
+            "last_update_time",
+            "data",
+            "update_interval",
+            "last_exception",
+            "firmware",
+            "model",
+            "client",
+        ]
+    )
+    coordinator.client = None
     hass = MagicMock()
-    coordinator = MagicMock()
-    coordinator.client = None  # Simulate missing client
     hass.data = {"vistapool": {"entry1": coordinator}}
 
     diagnostics = await async_get_config_entry_diagnostics(hass, entry)
-    # Diagnostics should not fail if client is None
     assert diagnostics["config_entry"]["entry_id"] == "entry1"
-    assert "client" not in diagnostics or diagnostics["client"] is None
+    assert "connection_stats" not in diagnostics
 
 
 @pytest.mark.asyncio
-async def test_diagnostics_with_coordinator_with_partial_attributes():
-    # Prepare a mock config_entry with coordinator missing some attributes
+async def test_diagnostics_no_duplicate_data():
+    """Coordinator data must not appear twice in the output."""
     entry = MagicMock()
+    entry.data = {}
+    entry.options = {}
     entry.entry_id = "entry1"
-    hass = MagicMock()
+    entry.version = 1
+    entry.title = "Pool"
     coordinator = MagicMock()
-    # Only set data and client, omit other attributes
     coordinator.data = {"key": "value"}
-    coordinator.client = MagicMock()
+    coordinator.client = None
+    hass = MagicMock()
     hass.data = {"vistapool": {"entry1": coordinator}}
 
     diagnostics = await async_get_config_entry_diagnostics(hass, entry)
-    # Ensure diagnostics still contain available attributes
     assert diagnostics["coordinator"]["data"] == {"key": "value"}
-    assert "connection_stats" in diagnostics
+    assert "last_device_data" not in diagnostics


### PR DESCRIPTION
## 🔒️ Fix sensitive data redaction and remove duplication in diagnostics

### Problem

The diagnostics module had several issues:

1. **Unredacted sensitive data in `connection_stats`** — device IP address (`host`) and `port` were exposed in plaintext
2. **Duplicate data** — `last_device_data` was a 100% copy of `coordinator.data` (250+ lines of redundancy)
3. **Custom filtering instead of HA standard** — sensitive keys were completely removed instead of being redacted to `**REDACTED**`
4. **Useless `client` repr** — `<...VistaPoolModbusClient object at 0x...>` provided no diagnostic value
5. **Missing `unique_id`** — config entry `unique_id` was not included in diagnostics output

### Changes

- ✨ Use HA standard `async_redact_data` — sensitive keys remain visible with value `**REDACTED**`
- 🔒️ Redact `host` and `port` in `connection_stats`
- 🗑️ Remove duplicate `last_device_data`
- 🗑️ Remove `client` str repr from coordinator section
- ➕ Add `unique_id` to config entry output

### Tests

- ✅ 651 passed, 100% coverage
- ✅ Tests verify `**REDACTED**` values instead of key absence
- ✅ Test for redaction in `connection_stats`
- ✅ Explicit test for no data duplication (`last_device_data`)