### PR TITLE
refactor: ♻️ migrate to repair issues and add parallel update limits

### DIFF
--- a/custom_components/vistapool/binary_sensor.py
+++ b/custom_components/vistapool/binary_sensor.py
@@ -29,6 +29,8 @@ from .helpers import is_device_time_out_of_sync
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 DISABLED_SUFFIXES = [
     " control module",
     " module regulated",

--- a/custom_components/vistapool/button.py
+++ b/custom_components/vistapool/button.py
@@ -27,6 +27,8 @@ from .helpers import has_filtvalve, prepare_device_time
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -22,6 +22,7 @@ from homeassistant.components import persistent_notification
 from homeassistant.const import CONF_NAME
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import slugify
@@ -136,28 +137,26 @@ class VistaPoolCoordinator(DataUpdateCoordinator):
                     MAX_RELAY_GPIO,
                 )
 
+        # Dismiss legacy persistent notification from versions before repair-issues migration
+        persistent_notification.async_dismiss(self.hass, f"{DOMAIN}_corrupted_gpio")
+
         if corrupted:
             details = "\n".join(
                 f"- **{label}** (`{key}`): value **{value}** (expected 0–{MAX_RELAY_GPIO})"
                 for key, label, value in corrupted
             )
-            persistent_notification.async_create(
+            ir.async_create_issue(
                 self.hass,
-                title="VistaPool: Corrupted GPIO register(s) detected",
-                message=(
-                    f"The following GPIO register(s) on your pool controller contain "
-                    f"invalid values:\n\n{details}\n\n"
-                    f"This typically happens when the Modbus gateway framing mode "
-                    f"does not match the integration's framer setting. "
-                    f"The affected function(s) will not work correctly until the "
-                    f"register(s) are restored to valid values.\n\n"
-                    f"See the integration documentation for repair instructions."
-                ),
-                notification_id=f"{DOMAIN}_corrupted_gpio",
+                DOMAIN,
+                "corrupted_gpio",
+                is_fixable=False,
+                severity=ir.IssueSeverity.ERROR,
+                translation_key="corrupted_gpio",
+                translation_placeholders={"details": details},
             )
         else:
-            # Clear any previous notification if registers are now valid
-            persistent_notification.async_dismiss(self.hass, f"{DOMAIN}_corrupted_gpio")
+            # Clear any previous issue if registers are now valid
+            ir.async_delete_issue(self.hass, DOMAIN, "corrupted_gpio")
             _LOGGER.info("GPIO registers passed sanity check: all values are valid")
 
     async def _async_update_data(self):

--- a/custom_components/vistapool/light.py
+++ b/custom_components/vistapool/light.py
@@ -27,6 +27,8 @@ from .entity import VistaPoolEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/vistapool/number.py
+++ b/custom_components/vistapool/number.py
@@ -35,6 +35,8 @@ from .helpers import is_hydrolysis_in_percent
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 def _should_skip_number(
     key: str,

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -43,6 +43,8 @@ from .helpers import (
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 _FILTRATION_SPEED_KEYS = (
     "MBF_PAR_FILTRATION_SPEED",
     "filtration1_speed",

--- a/custom_components/vistapool/sensor.py
+++ b/custom_components/vistapool/sensor.py
@@ -33,6 +33,8 @@ from .helpers import (
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 # Add mapping for MBF_PAR_FILT_MODE values
 # fmt: off
 FILTRATION_MODE_MAP = {

--- a/custom_components/vistapool/switch.py
+++ b/custom_components/vistapool/switch.py
@@ -33,6 +33,8 @@ from .entity import VistaPoolEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 def _should_skip_switch(
     key: str,

--- a/custom_components/vistapool/translations/cs.json
+++ b/custom_components/vistapool/translations/cs.json
@@ -559,5 +559,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "corrupted_gpio": {
+      "title": "Detekovány poškozené GPIO registry",
+      "description": "Následující GPIO registry na vašem ovladači bazénu obsahují neplatné hodnoty:\n\n{details}\n\nK tomu obvykle dochází, když režim rámování Modbus brány neodpovídá nastavení rámování v integraci. Postižené funkce nebudou správně fungovat, dokud nebudou registry obnoveny na platné hodnoty.\n\nViz dokumentaci integrace pro pokyny k opravě."
+    }
   }
 }

--- a/custom_components/vistapool/translations/de.json
+++ b/custom_components/vistapool/translations/de.json
@@ -559,5 +559,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "corrupted_gpio": {
+      "title": "Beschädigte GPIO-Register erkannt",
+      "description": "Die folgenden GPIO-Register Ihres Pool-Controllers enthalten ungültige Werte:\n\n{details}\n\nDies passiert typischerweise, wenn der Framing-Modus des Modbus-Gateways nicht mit der Framer-Einstellung der Integration übereinstimmt. Die betroffenen Funktionen funktionieren nicht korrekt, bis die Register auf gültige Werte zurückgesetzt werden.\n\nSiehe die Integrationsdokumentation für Reparaturanweisungen."
+    }
   }
 }

--- a/custom_components/vistapool/translations/en.json
+++ b/custom_components/vistapool/translations/en.json
@@ -559,5 +559,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "corrupted_gpio": {
+      "title": "Corrupted GPIO register(s) detected",
+      "description": "The following GPIO register(s) on your pool controller contain invalid values:\n\n{details}\n\nThis typically happens when the Modbus gateway framing mode does not match the integration's framer setting. The affected function(s) will not work correctly until the register(s) are restored to valid values.\n\nSee the integration documentation for repair instructions."
+    }
   }
 }

--- a/custom_components/vistapool/translations/es.json
+++ b/custom_components/vistapool/translations/es.json
@@ -559,5 +559,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "corrupted_gpio": {
+      "title": "Registros GPIO corruptos detectados",
+      "description": "Los siguientes registros GPIO de su controlador de piscina contienen valores no válidos:\n\n{details}\n\nEsto suele ocurrir cuando el modo de encuadre de la pasarela Modbus no coincide con la configuración del encuadre de la integración. Las funciones afectadas no funcionarán correctamente hasta que los registros se restauren a valores válidos.\n\nConsulte la documentación de la integración para instrucciones de reparación."
+    }
   }
 }

--- a/custom_components/vistapool/translations/fr.json
+++ b/custom_components/vistapool/translations/fr.json
@@ -560,5 +560,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "corrupted_gpio": {
+      "title": "Registres GPIO corrompus détectés",
+      "description": "Les registres GPIO suivants de votre contrôleur de piscine contiennent des valeurs invalides :\n\n{details}\n\nCela se produit généralement lorsque le mode de trame de la passerelle Modbus ne correspond pas au paramètre de trame de l'intégration. Les fonctions concernées ne fonctionneront pas correctement tant que les registres ne seront pas restaurés à des valeurs valides.\n\nConsultez la documentation de l'intégration pour les instructions de réparation."
+    }
   }
 }

--- a/custom_components/vistapool/translations/it.json
+++ b/custom_components/vistapool/translations/it.json
@@ -559,5 +559,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "corrupted_gpio": {
+      "title": "Registri GPIO corrotti rilevati",
+      "description": "I seguenti registri GPIO del controller della piscina contengono valori non validi:\n\n{details}\n\nQuesto accade tipicamente quando la modalità di framing del gateway Modbus non corrisponde all'impostazione del framer dell'integrazione. Le funzioni interessate non funzioneranno correttamente finché i registri non verranno ripristinati a valori validi.\n\nConsultare la documentazione dell'integrazione per le istruzioni di riparazione."
+    }
   }
 }

--- a/custom_components/vistapool/translations/pl.json
+++ b/custom_components/vistapool/translations/pl.json
@@ -559,5 +559,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "corrupted_gpio": {
+      "title": "Wykryto uszkodzone rejestry GPIO",
+      "description": "Następujące rejestry GPIO kontrolera basenu zawierają nieprawidłowe wartości:\n\n{details}\n\nZwykle dzieje się tak, gdy tryb ramkowania bramy Modbus nie odpowiada ustawieniu ramkowania w integracji. Dotknięte funkcje nie będą działać poprawnie, dopóki rejestry nie zostaną przywrócone do prawidłowych wartości.\n\nZapoznaj się z dokumentacją integracji, aby uzyskać instrukcje naprawy."
+    }
   }
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -18,7 +18,7 @@ import pytest
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from custom_components.vistapool.const import FOLLOW_UP_REFRESH_DELAY
+from custom_components.vistapool.const import DOMAIN, FOLLOW_UP_REFRESH_DELAY
 from custom_components.vistapool.coordinator import VistaPoolCoordinator
 
 
@@ -773,10 +773,9 @@ async def test_cancel_follow_up_refresh_noop_when_none(mock_entry):
 class TestGpioSanityCheck:
     """Tests for _check_gpio_registers."""
 
-    PATCH_TARGET = (
-        "custom_components.vistapool.coordinator.persistent_notification.async_create"
-    )
-    PATCH_DISMISS = (
+    PATCH_CREATE = "custom_components.vistapool.coordinator.ir.async_create_issue"
+    PATCH_DELETE = "custom_components.vistapool.coordinator.ir.async_delete_issue"
+    PATCH_LEGACY_DISMISS = (
         "custom_components.vistapool.coordinator.persistent_notification.async_dismiss"
     )
 
@@ -788,8 +787,8 @@ class TestGpioSanityCheck:
         )
         return coordinator, hass
 
-    def test_valid_gpio_values_no_notification(self, mock_entry):
-        """No notification when all GPIO registers are within valid range."""
+    def test_valid_gpio_values_no_issue(self, mock_entry):
+        """No issue when all GPIO registers are within valid range."""
         coordinator, hass = self._make_coordinator(mock_entry)
         data = {
             "MBF_PAR_FILT_GPIO": 2,
@@ -799,68 +798,69 @@ class TestGpioSanityCheck:
             "MBF_PAR_UV_RELAY_GPIO": 0,
         }
         with (
-            patch(self.PATCH_TARGET) as mock_notify,
-            patch(self.PATCH_DISMISS) as mock_dismiss,
+            patch(self.PATCH_CREATE) as mock_create,
+            patch(self.PATCH_DELETE) as mock_delete,
         ):
             coordinator._check_gpio_registers(data)
-            mock_notify.assert_not_called()
-            mock_dismiss.assert_called_once_with(hass, "vistapool_corrupted_gpio")
+            mock_create.assert_not_called()
+            mock_delete.assert_called_once_with(hass, DOMAIN, "corrupted_gpio")
 
-    def test_corrupted_gpio_triggers_notification(self, mock_entry):
-        """Notification is created when a GPIO register has an invalid value."""
+    def test_corrupted_gpio_triggers_issue(self, mock_entry):
+        """Repair issue is created when a GPIO register has an invalid value."""
         coordinator, hass = self._make_coordinator(mock_entry)
         data = {
             "MBF_PAR_FILT_GPIO": 22846,  # corrupted
             "MBF_PAR_LIGHTING_GPIO": 3,
         }
-        with patch(self.PATCH_TARGET) as mock_notify:
+        with patch(self.PATCH_CREATE) as mock_create:
             coordinator._check_gpio_registers(data)
-            mock_notify.assert_called_once()
-            # hass must be passed as first positional arg, not as keyword
-            assert mock_notify.call_args.args[0] is hass
-            assert "hass" not in mock_notify.call_args.kwargs
-            call_kwargs = mock_notify.call_args.kwargs
-            assert "Corrupted GPIO" in call_kwargs["title"]
-            assert "22846" in call_kwargs["message"]
-            assert "MBF_PAR_FILT_GPIO" in call_kwargs["message"]
-            assert call_kwargs["notification_id"] == "vistapool_corrupted_gpio"
+            mock_create.assert_called_once()
+            call_kwargs = mock_create.call_args.kwargs
+            assert call_kwargs["translation_key"] == "corrupted_gpio"
+            assert "22846" in call_kwargs["translation_placeholders"]["details"]
+            assert (
+                "MBF_PAR_FILT_GPIO"
+                in call_kwargs["translation_placeholders"]["details"]
+            )
 
-    def test_multiple_corrupted_gpio_in_single_notification(self, mock_entry):
-        """Multiple corrupted GPIO registers appear in a single notification."""
+    def test_multiple_corrupted_gpio_in_single_issue(self, mock_entry):
+        """Multiple corrupted GPIO registers appear in a single repair issue."""
         coordinator, _ = self._make_coordinator(mock_entry)
         data = {
             "MBF_PAR_FILT_GPIO": 22846,
             "MBF_PAR_HEATING_GPIO": 65535,
         }
-        with patch(self.PATCH_TARGET) as mock_notify:
+        with patch(self.PATCH_CREATE) as mock_create:
             coordinator._check_gpio_registers(data)
-            mock_notify.assert_called_once()
-            msg = mock_notify.call_args.kwargs["message"]
-            assert "MBF_PAR_FILT_GPIO" in msg
-            assert "MBF_PAR_HEATING_GPIO" in msg
+            mock_create.assert_called_once()
+            details = mock_create.call_args.kwargs["translation_placeholders"][
+                "details"
+            ]
+            assert "MBF_PAR_FILT_GPIO" in details
+            assert "MBF_PAR_HEATING_GPIO" in details
 
-    def test_missing_gpio_keys_no_notification(self, mock_entry):
-        """No notification when GPIO keys are absent from data."""
+    def test_missing_gpio_keys_no_issue(self, mock_entry):
+        """No issue when GPIO keys are absent from data."""
         coordinator, _ = self._make_coordinator(mock_entry)
-        with patch(self.PATCH_TARGET) as mock_notify:
+        with patch(self.PATCH_CREATE) as mock_create:
             coordinator._check_gpio_registers({})
-            mock_notify.assert_not_called()
+            mock_create.assert_not_called()
 
     def test_zero_gpio_is_valid(self, mock_entry):
-        """GPIO value 0 (unassigned) is within valid range and should not trigger notification."""
+        """GPIO value 0 (unassigned) is within valid range and should not trigger issue."""
         coordinator, _ = self._make_coordinator(mock_entry)
         data = {"MBF_PAR_FILT_GPIO": 0}
-        with patch(self.PATCH_TARGET) as mock_notify:
+        with patch(self.PATCH_CREATE) as mock_create:
             coordinator._check_gpio_registers(data)
-            mock_notify.assert_not_called()
+            mock_create.assert_not_called()
 
-    def test_negative_gpio_triggers_notification(self, mock_entry):
-        """Negative GPIO value is out of range and triggers notification."""
+    def test_negative_gpio_triggers_issue(self, mock_entry):
+        """Negative GPIO value is out of range and triggers issue."""
         coordinator, _ = self._make_coordinator(mock_entry)
         data = {"MBF_PAR_FILT_GPIO": -1}
-        with patch(self.PATCH_TARGET) as mock_notify:
+        with patch(self.PATCH_CREATE) as mock_create:
             coordinator._check_gpio_registers(data)
-            mock_notify.assert_called_once()
+            mock_create.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_gpio_check_runs_only_once(self, mock_entry):
@@ -874,12 +874,20 @@ class TestGpioSanityCheck:
         )
         coordinator.client.read_all_timers = AsyncMock(return_value={})
 
-        with patch(self.PATCH_TARGET) as mock_notify:
+        with patch(self.PATCH_CREATE) as mock_create:
             await coordinator._async_update_data()
             assert coordinator._gpio_checked is True
-            assert mock_notify.call_count == 1
+            assert mock_create.call_count == 1
 
             # Second call should NOT trigger check again
-            mock_notify.reset_mock()
+            mock_create.reset_mock()
             await coordinator._async_update_data()
-            mock_notify.assert_not_called()
+            mock_create.assert_not_called()
+
+    def test_legacy_persistent_notification_dismissed(self, mock_entry):
+        """Legacy persistent notification is always dismissed during GPIO check."""
+        coordinator, hass = self._make_coordinator(mock_entry)
+        data = {"MBF_PAR_FILT_GPIO": 2}
+        with patch(self.PATCH_LEGACY_DISMISS) as mock_dismiss:
+            coordinator._check_gpio_registers(data)
+            mock_dismiss.assert_called_once_with(hass, f"{DOMAIN}_corrupted_gpio")


### PR DESCRIPTION
## refactor: ♻️ add parallel update limits and migrate to repair issues

### 📋 Summary

This PR addresses two Silver-level quality scale requirements for the VistaPool integration:

1. **`parallel-updates`** — Define `PARALLEL_UPDATES` constants on all platform modules
2. **`repair-issues`** — Migrate corrupted GPIO notification from `persistent_notification` to the Repairs dashboard (`ir.async_create_issue`)

### 🔀 Changes

#### PARALLEL_UPDATES (7 files)

| Platform        | Value | Rationale                                                   |
| --------------- | ----- | ----------------------------------------------------------- |
| `sensor`        | `0`   | Read-only, no Modbus writes                                 |
| `binary_sensor` | `0`   | Read-only, no Modbus writes                                 |
| `switch`        | `1`   | Writes via `async_write_register` / `async_write_aux_relay` |
| `number`        | `1`   | Debounced writes via `async_write_register`                 |
| `button`        | `1`   | Multi-register write sequences                              |
| `select`        | `1`   | Writes via `async_write_register`                           |
| `light`         | `1`   | 3-register write sequence (function + timer + EXEC)         |

- `0` = unlimited (coordinator-based, no platform-level throttling needed)
- `1` = serialize writes to prevent concurrent multi-register Modbus sequences from interleaving

#### Repair Issues (coordinator.py + 7 translation files)

- ♻️ Replace `persistent_notification.async_create()` → `ir.async_create_issue()` with `translation_key="corrupted_gpio"` and `translation_placeholders`
- ♻️ Replace `persistent_notification.async_dismiss()` → `ir.async_delete_issue()`
- ➕ Add `issues.corrupted_gpio` translation strings to all 7 language files (en, cs, de, es, fr, it, pl)
- ✅ Update all GPIO sanity check tests to verify `ir.async_create_issue` / `ir.async_delete_issue` calls

### ✅ Checks

- 676/676 tests passing
- `ruff check` — all passed
- `ruff format` — all formatted
- `basedpyright` — 0 new errors (only pre-existing `reportMissingImports` in dev container)
