### PR TITLE
refactor: ♻️ move entity icons and error messages to translation files

### DIFF
--- a/custom_components/vistapool/__init__.py
+++ b/custom_components/vistapool/__init__.py
@@ -138,13 +138,20 @@ def _register_services(hass: HomeAssistant) -> None:
         if not entry:
             if entry_id:
                 raise ServiceValidationError(
-                    f"No VistaPool config entry found for entry_id '{entry_id}'"
+                    translation_domain=DOMAIN,
+                    translation_key="entry_not_found",
+                    translation_placeholders={"entry_id": entry_id},
                 )
-            raise ServiceValidationError("No loaded VistaPool config entry available")
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="no_loaded_entry",
+            )
         coordinator: VistaPoolCoordinator = entry.runtime_data
         if not coordinator:
             raise ServiceValidationError(
-                f"No VistaPool coordinator found for entry_id '{entry.entry_id}'"
+                translation_domain=DOMAIN,
+                translation_key="no_coordinator",
+                translation_placeholders={"entry_id": entry.entry_id},
             )
         return coordinator
 
@@ -153,12 +160,20 @@ def _register_services(hass: HomeAssistant) -> None:
         try:
             timer_name = call.data["timer"]
         except KeyError:
-            raise ServiceValidationError("Missing required parameter 'timer'")
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="missing_parameter",
+                translation_placeholders={"parameter": "timer"},
+            )
 
         if timer_name not in TIMER_BLOCKS:
             raise ServiceValidationError(
-                f"Invalid timer name '{timer_name}'. "
-                f"Valid timers: {', '.join(sorted(TIMER_BLOCKS))}"
+                translation_domain=DOMAIN,
+                translation_key="invalid_timer",
+                translation_placeholders={
+                    "timer_name": timer_name,
+                    "valid_timers": ", ".join(sorted(TIMER_BLOCKS)),
+                },
             )
 
         try:
@@ -194,7 +209,11 @@ def _register_services(hass: HomeAssistant) -> None:
             _LOGGER.error(
                 "Failed to set timer %s: %s", call.data.get("timer", "unknown"), e
             )
-            raise ServiceValidationError(f"Timer setting failed: {e}") from e
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="timer_failed",
+                translation_placeholders={"error": str(e)},
+            ) from e
 
     async def async_handle_write_register(call) -> None:
         """Handle the write_register service call."""
@@ -202,14 +221,19 @@ def _register_services(hass: HomeAssistant) -> None:
             raw_address = call.data["address"]
             raw_value = call.data["value"]
         except KeyError as exc:
-            raise ServiceValidationError(f"Missing required parameter '{exc.args[0]}'")
-
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="missing_parameter",
+                translation_placeholders={"parameter": exc.args[0]},
+            )
         address = parse_register_int(raw_address, "address")
         value = parse_register_int(raw_value, "value")
         apply = call.data.get("apply", True)
         if not isinstance(apply, bool):
             raise ServiceValidationError(
-                f"Invalid apply '{apply}': must be a boolean (true/false)"
+                translation_domain=DOMAIN,
+                translation_key="invalid_apply",
+                translation_placeholders={"apply": str(apply)},
             )
         coordinator = _get_coordinator(call)
 
@@ -219,7 +243,9 @@ def _register_services(hass: HomeAssistant) -> None:
             )
             if result is None:
                 raise ServiceValidationError(
-                    f"Write to register 0x{address:04X} failed"
+                    translation_domain=DOMAIN,
+                    translation_key="write_failed",
+                    translation_placeholders={"address": f"0x{address:04X}"},
                 )
             confirmed = result.get("confirmed")
             _LOGGER.info(
@@ -231,8 +257,13 @@ def _register_services(hass: HomeAssistant) -> None:
             )
             if confirmed != value:
                 raise ServiceValidationError(
-                    f"Write verification failed at 0x{address:04X}: "
-                    f"wrote {value}, read back {confirmed}"
+                    translation_domain=DOMAIN,
+                    translation_key="write_verification_failed",
+                    translation_placeholders={
+                        "address": f"0x{address:04X}",
+                        "value": str(value),
+                        "confirmed": str(confirmed),
+                    },
                 )
             coordinator.request_refresh_with_followup()
         except ServiceValidationError:
@@ -240,7 +271,12 @@ def _register_services(hass: HomeAssistant) -> None:
         except Exception as e:
             _LOGGER.error("Failed to write register 0x%04X: %s", address, e)
             raise ServiceValidationError(
-                f"Register write failed at 0x{address:04X}: {e}"
+                translation_domain=DOMAIN,
+                translation_key="register_write_failed",
+                translation_placeholders={
+                    "address": f"0x{address:04X}",
+                    "error": str(e),
+                },
             ) from e
 
     if not hass.services.has_service(DOMAIN, "set_timer"):

--- a/custom_components/vistapool/binary_sensor.py
+++ b/custom_components/vistapool/binary_sensor.py
@@ -205,8 +205,6 @@ class VistaPoolBinarySensor(VistaPoolEntity, BinarySensorEntity):  # type: ignor
 
         self._attr_device_class = props.get("device_class") or None
         self._attr_entity_category = props.get("entity_category") or None
-        self._icon_on = props.get("icon_on") or None
-        self._icon_off = props.get("icon_off") or None
 
         self._attr_entity_registry_enabled_default = props.get("enabled_default", True)
 
@@ -262,11 +260,6 @@ class VistaPoolBinarySensor(VistaPoolEntity, BinarySensorEntity):  # type: ignor
         else:
             value = self.coordinator.data.get(self._key)
             return None if value is None else bool(value)
-
-    @property
-    def icon(self) -> str | None:  # type: ignore[override]
-        """Return custom icon depending on state."""
-        return self._icon_on if self.is_on else self._icon_off or None
 
     @property
     def native_value(self) -> bool | None:  # type: ignore[override]

--- a/custom_components/vistapool/button.py
+++ b/custom_components/vistapool/button.py
@@ -69,7 +69,6 @@ class VistaPoolButton(VistaPoolEntity, ButtonEntity):  # type: ignore[reportInco
         self._attr_translation_key = VistaPoolEntity.slugify(self._key)
 
         self._attr_entity_category = props.get("entity_category") or None
-        self._attr_icon = props.get("icon") or "mdi:button-pointer"
 
         _LOGGER.debug(
             "INIT: suggested_object_id=%s, translation_key=%s, has_entity_name=%s",
@@ -124,8 +123,3 @@ class VistaPoolButton(VistaPoolEntity, ButtonEntity):  # type: ignore[reportInco
             getattr(self, "has_entity_name", None),
         )
         await super().async_added_to_hass()
-
-    @property
-    def icon(self) -> str | None:  # type: ignore[override]
-        """Return the icon for the button."""
-        return self._attr_icon

--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -177,7 +177,6 @@ SENSOR_DEFINITIONS = {
         "unit": "%",
         "device_class": SensorDeviceClass.POWER_FACTOR,
         "state_class": SensorStateClass.MEASUREMENT,
-        "icon": "mdi:atom",
     },
     "MBF_HIDRO_CURRENT": {
         "name": "Hydrolysis Intensity",
@@ -190,21 +189,18 @@ SENSOR_DEFINITIONS = {
         "name": "pH Level",
         "device_class": SensorDeviceClass.PH,
         "state_class": SensorStateClass.MEASUREMENT,
-        "icon": "mdi:ph",
     },
     "MBF_MEASURE_RX": {
         "name": "Redox Potential",
         "unit": "mV",
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
-        "icon": "mdi:gradient-vertical",
     },
     "MBF_MEASURE_CL": {
         "name": "Salt Level",
         "unit": "ppm",
         "device_class": None,
         "state_class": SensorStateClass.MEASUREMENT,
-        "icon": "mdi:shaker-outline",
     },
     "MBF_MEASURE_CONDUCTIVITY": {
         "name": "Conductivity Level",
@@ -232,7 +228,6 @@ SENSOR_DEFINITIONS = {
         "unit": None,
         "device_class": SensorDeviceClass.ENUM,
         "state_class": None,
-        "icon": "mdi:water-sync",
     },
     "MBF_PH_STATUS_ALARM": {
         "name": "pH Alarm",
@@ -240,21 +235,18 @@ SENSOR_DEFINITIONS = {
         "device_class": SensorDeviceClass.ENUM,
         "state_class": None,
         "entity_category": EntityCategory.DIAGNOSTIC,
-        "icon": "mdi:ph",
     },
     "HIDRO_POLARITY": {
         "name": "Hydrolysis Polarity",
         "unit": None,
         "device_class": SensorDeviceClass.ENUM,
         "state_class": None,
-        "icon": "mdi:plus-minus-variant",
     },
     "ION_POLARITY": {
         "name": "Ionizer Polarity",
         "unit": None,
         "device_class": SensorDeviceClass.ENUM,
         "state_class": None,
-        "icon": "mdi:plus-minus-variant",
     },
     "PH_PUMP_STATUS": {
         "name": "pH Pump Status",
@@ -262,21 +254,18 @@ SENSOR_DEFINITIONS = {
         "device_class": SensorDeviceClass.ENUM,
         "state_class": None,
         "entity_category": EntityCategory.DIAGNOSTIC,
-        "icon": "mdi:pump",
     },
     "FILTRATION_SPEED": {
         "name": "Filtration Current Speed",
         "unit": None,
         "device_class": SensorDeviceClass.ENUM,
         "state_class": None,
-        "icon": "mdi:fan",
     },
     "MBF_PAR_INTELLIGENT_INTERVALS": {
         "name": "Intelligent Mode Intervals",
         "unit": None,
         "device_class": None,
         "state_class": SensorStateClass.MEASUREMENT,
-        "icon": "mdi:counter",
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     "MBF_PAR_INTELLIGENT_TT_NEXT_INTERVAL": {
@@ -284,7 +273,6 @@ SENSOR_DEFINITIONS = {
         "unit": None,
         "device_class": SensorDeviceClass.TIMESTAMP,
         "state_class": None,
-        "icon": "mdi:timeline-clock-outline",
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     "MBF_PAR_FILTVALVE_REMAINING": {
@@ -292,7 +280,6 @@ SENSOR_DEFINITIONS = {
         "unit": "s",
         "device_class": SensorDeviceClass.DURATION,
         "state_class": SensorStateClass.MEASUREMENT,
-        "icon": "mdi:timer-sand",
         "display_precision": 0,
     },
     "FILTRATION_REMAINING": {
@@ -300,7 +287,6 @@ SENSOR_DEFINITIONS = {
         "unit": "s",
         "device_class": SensorDeviceClass.DURATION,
         "state_class": None,
-        "icon": "mdi:timer-sand",
         "display_precision": 0,
     },
 }
@@ -310,56 +296,40 @@ BINARY_SENSOR_DEFINITIONS = {
         "name": "Device Time Out Of Sync",
         "device_class": BinarySensorDeviceClass.PROBLEM,
         "entity_category": EntityCategory.DIAGNOSTIC,
-        "icon_on": "mdi:clock-alert",
-        "icon_off": "mdi:clock-check-outline",
     },
     # Relay states
     "pH Acid Pump": {
         "name": "pH Regulating",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "entity_category": EntityCategory.DIAGNOSTIC,
-        "icon_on": "mdi:pump",
-        "icon_off": "mdi:pump-off",
     },
     "Filtration Pump": {
         "name": "Filtration Running",
         "device_class": BinarySensorDeviceClass.RUNNING,
-        "icon_on": "mdi:pump",
-        "icon_off": "mdi:pump-off",
     },
     "Pool Light": {
         "name": "Pool Light",
         "device_class": BinarySensorDeviceClass.LIGHT,
-        "icon_on": "mdi:lightbulb-on",
-        "icon_off": "mdi:lightbulb-outline",
         "option": "use_light",
     },
     "AUX1": {
         "name": "Auxiliary Relay 1",
         "device_class": BinarySensorDeviceClass.POWER,
-        "icon_on": "mdi:electric-switch-closed",
-        "icon_off": "mdi:electric-switch",
         "option": "use_aux1",
     },
     "AUX2": {
         "name": "Auxiliary Relay 2",
         "device_class": BinarySensorDeviceClass.POWER,
-        "icon_on": "mdi:electric-switch-closed",
-        "icon_off": "mdi:electric-switch",
         "option": "use_aux2",
     },
     "AUX3": {
         "name": "Auxiliary Relay 3",
         "device_class": BinarySensorDeviceClass.POWER,
-        "icon_on": "mdi:electric-switch-closed",
-        "icon_off": "mdi:electric-switch",
         "option": "use_aux3",
     },
     "AUX4": {
         "name": "Auxiliary Relay 4",
         "device_class": BinarySensorDeviceClass.POWER,
-        "icon_on": "mdi:electric-switch-closed",
-        "icon_off": "mdi:electric-switch",
         "option": "use_aux4",
     },
     # pH/Redox/CL/CD status bits from decode_ph_rx_cl_cd_status_bits
@@ -380,8 +350,6 @@ BINARY_SENSOR_DEFINITIONS = {
         "name": "pH Measurement",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "entity_category": EntityCategory.DIAGNOSTIC,
-        "icon_on": "mdi:scale",
-        "icon_off": "mdi:scale-off",
     },
     "pH measurement module detected": {
         "name": "pH Measurement Module Detected",
@@ -393,8 +361,6 @@ BINARY_SENSOR_DEFINITIONS = {
         "name": "Redox Pump Active",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "entity_category": EntityCategory.DIAGNOSTIC,
-        "icon_on": "mdi:pump",
-        "icon_off": "mdi:pump-off",
     },
     "Redox control module": {
         "name": "Redox Regulation Active",
@@ -405,8 +371,6 @@ BINARY_SENSOR_DEFINITIONS = {
         "name": "Redox Measurement",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "entity_category": EntityCategory.DIAGNOSTIC,
-        "icon_on": "mdi:scale",
-        "icon_off": "mdi:scale-off",
     },
     "Redox measurement module detected": {
         "name": "Redox Measurement Module Detected",
@@ -423,8 +387,6 @@ BINARY_SENSOR_DEFINITIONS = {
         "name": "Chlorine Pump Active",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "entity_category": EntityCategory.DIAGNOSTIC,
-        "icon_on": "mdi:pump",
-        "icon_off": "mdi:pump-off",
     },
     "Chlorine control module": {
         "name": "Chlorine Regulation Active",
@@ -435,8 +397,6 @@ BINARY_SENSOR_DEFINITIONS = {
         "name": "Chlorine Measurement",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "entity_category": EntityCategory.DIAGNOSTIC,
-        "icon_on": "mdi:scale",
-        "icon_off": "mdi:scale-off",
     },
     "Chlorine measurement module detected": {
         "name": "Chlorine Measurement Module Detected",
@@ -448,8 +408,6 @@ BINARY_SENSOR_DEFINITIONS = {
         "name": "Conductivity Pump Active",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "entity_category": EntityCategory.DIAGNOSTIC,
-        "icon_on": "mdi:pump",
-        "icon_off": "mdi:pump-off",
     },
     "Conductivity control module": {
         "name": "Conductivity Regulation Active",
@@ -460,8 +418,6 @@ BINARY_SENSOR_DEFINITIONS = {
         "name": "Conductivity Measurement",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "entity_category": EntityCategory.DIAGNOSTIC,
-        "icon_on": "mdi:scale",
-        "icon_off": "mdi:scale-off",
     },
     "Conductivity measurement module detected": {
         "name": "Conductivity Measurement Module Detected",
@@ -542,15 +498,11 @@ BINARY_SENSOR_DEFINITIONS = {
         "name": "Heating",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "entity_category": EntityCategory.DIAGNOSTIC,
-        "icon_on": "mdi:radiator",
-        "icon_off": "mdi:radiator-off",
     },
     "UV Lamp": {
         "name": "UV Lamp",
         "device_class": BinarySensorDeviceClass.RUNNING,
         "entity_category": EntityCategory.DIAGNOSTIC,
-        "icon_on": "mdi:lightbulb-fluorescent-tube",
-        "icon_off": "mdi:lightbulb-fluorescent-tube-outline",
     },
     # Note: "HIDRO in dead time", "HIDRO in Pol1" and "HIDRO in Pol2" are merged
     # into the HIDRO_POLARITY enum sensor.
@@ -569,7 +521,6 @@ NUMBER_DEFINITIONS = {
         "scale": 10.0,
         "device_class": None,
         "entity_category": EntityCategory.CONFIG,
-        "icon": "mdi:air-humidifier",
     },
     "MBF_PAR_PH1": {
         "name": "pH Max Limit",
@@ -601,7 +552,6 @@ NUMBER_DEFINITIONS = {
         "scale": 1.0,
         "device_class": NumberDeviceClass.VOLTAGE,
         "entity_category": EntityCategory.CONFIG,
-        "icon": "mdi:gradient-vertical",
     },
     "MBF_PAR_CL1": {
         "name": "Chlorine Setpoint",
@@ -613,7 +563,6 @@ NUMBER_DEFINITIONS = {
         "scale": 100.0,
         "device_class": None,
         "entity_category": EntityCategory.CONFIG,
-        "icon": "mdi:test-tube",
     },
     "MBF_PAR_HEATING_TEMP": {
         "name": "Temperature Setpoint",
@@ -636,7 +585,6 @@ NUMBER_DEFINITIONS = {
         "scale": 1.0,
         "device_class": NumberDeviceClass.TEMPERATURE,
         "entity_category": EntityCategory.CONFIG,
-        "icon": "mdi:thermometer-chevron-up",
     },
     "MBF_PAR_SMART_TEMP_LOW": {
         "name": "Smart Lower Temperature",
@@ -648,7 +596,6 @@ NUMBER_DEFINITIONS = {
         "scale": 1.0,
         "device_class": NumberDeviceClass.TEMPERATURE,
         "entity_category": EntityCategory.CONFIG,
-        "icon": "mdi:thermometer-chevron-down",
     },
     "MBF_PAR_HIDRO_COVER_REDUCTION": {
         "name": "Hydrolysis Cover Reduction Percentage",
@@ -663,7 +610,6 @@ NUMBER_DEFINITIONS = {
         "scale": 1.0,
         "device_class": None,
         "entity_category": EntityCategory.CONFIG,
-        "icon": "mdi:pool",
         "option": "use_cover_sensor",
     },
     "MBF_PAR_HIDRO_SHUTDOWN_TEMPERATURE": {
@@ -679,7 +625,6 @@ NUMBER_DEFINITIONS = {
         "scale": 1.0,
         "device_class": NumberDeviceClass.TEMPERATURE,
         "entity_category": EntityCategory.CONFIG,
-        "icon": "mdi:thermometer-alert",
         "option": "use_cover_sensor",
     },
 }
@@ -687,24 +632,20 @@ NUMBER_DEFINITIONS = {
 BUTTON_DEFINITIONS = {
     "SYNC_TIME": {
         "name": "Synchronize Device Time",
-        "icon": "mdi:clock-check-outline",
         "entity_category": EntityCategory.CONFIG,
     },
     "MBF_ESCAPE": {
         "name": "Clear Errors",
-        "icon": "mdi:reload-alert",
         "entity_category": EntityCategory.CONFIG,
     },
     "BACKWASH": {
         "name": "Start Backwash",
-        "icon": "mdi:waves-arrow-left",
     },
 }
 
 SELECT_DEFINITIONS = {
     "MBF_PAR_FILT_MODE": {
         "name": "Filtration Mode",
-        "icon": "mdi:water-sync",
         "options_map": {
             0: "manual",
             1: "auto",
@@ -717,7 +658,6 @@ SELECT_DEFINITIONS = {
     },
     "MBF_PAR_FILTRATION_SPEED": {
         "name": "Filtration Speed",
-        "icon": "mdi:fan-speed-3",
         "options_map": {0: "low", 1: "mid", 2: "high"},
         "register": 0x050F,
         "mask": 0x0070,
@@ -725,7 +665,6 @@ SELECT_DEFINITIONS = {
     },
     "MBF_CELL_BOOST": {
         "name": "Boost Mode",
-        "icon": "mdi:flash-outline",
         "options_map": {
             0: "inactive",
             1: "active",
@@ -735,7 +674,6 @@ SELECT_DEFINITIONS = {
     },
     "MBF_PAR_FILTVALVE_MODE": {
         "name": "Backwash Valve Mode",
-        "icon": "mdi:valve",
         "entity_category": EntityCategory.CONFIG,
         "options_map": {
             # 0: "disabled",     # valve disabled – hidden (covered by MBF_PAR_FILTVALVE_ENABLE)
@@ -748,7 +686,6 @@ SELECT_DEFINITIONS = {
     },
     "MBF_PAR_FILTVALVE_PERIOD_MINUTES": {
         "name": "Backwash Repeat Interval",
-        "icon": "mdi:timer-refresh-outline",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "mapped_register",
         "fallback_suffix": "m",
@@ -767,7 +704,6 @@ SELECT_DEFINITIONS = {
     },
     "MBF_PAR_INTELLIGENT_FILT_MIN_TIME": {
         "name": "Intelligent Min Filtration Time",
-        "icon": "mdi:timer-lock-outline",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "mapped_register",
         "fallback_suffix": "m",
@@ -787,7 +723,6 @@ SELECT_DEFINITIONS = {
         "register": 0x041D,
     },
     "MBF_PAR_RELAY_ACTIVATION_DELAY": {
-        "icon": "mdi:timer-plus-outline",
         "register": 0x0433,
         "entity_category": EntityCategory.CONFIG,
         "select_type": "mapped_register",
@@ -810,7 +745,6 @@ SELECT_DEFINITIONS = {
     },
     "filtration1_start": {
         "name": "Filtration Timer 1 Start",
-        "icon": "mdi:clock-start",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -818,7 +752,6 @@ SELECT_DEFINITIONS = {
     },
     "filtration1_stop": {
         "name": "Filtration Timer 1 Stop",
-        "icon": "mdi:clock-end",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -826,7 +759,6 @@ SELECT_DEFINITIONS = {
     },
     "filtration2_start": {
         "name": "Filtration Timer 2 Start",
-        "icon": "mdi:clock-start",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -834,7 +766,6 @@ SELECT_DEFINITIONS = {
     },
     "filtration2_stop": {
         "name": "Filtration Timer 2 Stop",
-        "icon": "mdi:clock-end",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -842,7 +773,6 @@ SELECT_DEFINITIONS = {
     },
     "filtration3_start": {
         "name": "Filtration Timer 3 Start",
-        "icon": "mdi:clock-start",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -850,7 +780,6 @@ SELECT_DEFINITIONS = {
     },
     "filtration3_stop": {
         "name": "Filtration Timer 3 Stop",
-        "icon": "mdi:clock-end",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -858,7 +787,6 @@ SELECT_DEFINITIONS = {
     },
     "filtration1_speed": {
         "name": "Timer 1 - Filtration Speed",
-        "icon": "mdi:fan-speed-3",
         "entity_category": EntityCategory.CONFIG,
         "options_map": {0: "low", 1: "mid", 2: "high"},
         "register": 0x050F,
@@ -868,7 +796,6 @@ SELECT_DEFINITIONS = {
     },
     "filtration2_speed": {
         "name": "Timer 2 - Filtration Speed",
-        "icon": "mdi:fan-speed-3",
         "entity_category": EntityCategory.CONFIG,
         "options_map": {0: "low", 1: "mid", 2: "high"},
         "register": 0x050F,
@@ -878,7 +805,6 @@ SELECT_DEFINITIONS = {
     },
     "filtration3_speed": {
         "name": "Timer 3 - Filtration Speed",
-        "icon": "mdi:fan-speed-3",
         "entity_category": EntityCategory.CONFIG,
         "options_map": {0: "low", 1: "mid", 2: "high"},
         "register": 0x050F,
@@ -888,7 +814,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux1_start": {
         "name": "Relay AUX1 Timer 1 Start",
-        "icon": "mdi:clock-start",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -896,7 +821,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux1_stop": {
         "name": "Relay AUX1 Timer 1 Stop",
-        "icon": "mdi:clock-end",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -904,7 +828,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux1_period": {
         "name": "Relay AUX1 Timer 1 Repeat",
-        "icon": "mdi:repeat-variant",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_period",
         "register": None,
@@ -912,7 +835,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux1b_start": {
         "name": "Relay AUX1 Timer 2 Start",
-        "icon": "mdi:clock-start",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -920,7 +842,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux1b_stop": {
         "name": "Relay AUX1 Timer 2 Stop",
-        "icon": "mdi:clock-end",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -928,7 +849,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux1b_period": {
         "name": "Relay AUX1 Timer 2 Repeat",
-        "icon": "mdi:repeat-variant",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_period",
         "register": None,
@@ -936,7 +856,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux2_start": {
         "name": "Relay AUX2 Timer 1 Start",
-        "icon": "mdi:clock-start",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -944,7 +863,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux2_stop": {
         "name": "Relay AUX2 Timer 1 Stop",
-        "icon": "mdi:clock-end",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -952,7 +870,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux2_period": {
         "name": "Relay AUX2 Timer 1 Repeat",
-        "icon": "mdi:repeat-variant",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_period",
         "register": None,
@@ -960,7 +877,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux2b_start": {
         "name": "Relay AUX2 Timer 2 Start",
-        "icon": "mdi:clock-start",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -968,7 +884,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux2b_stop": {
         "name": "Relay AUX2 Timer 2 Stop",
-        "icon": "mdi:clock-end",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -976,7 +891,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux2b_period": {
         "name": "Relay AUX2 Timer 2 Repeat",
-        "icon": "mdi:repeat-variant",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_period",
         "register": None,
@@ -984,7 +898,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux3_start": {
         "name": "Relay AUX3 Timer 1 Start",
-        "icon": "mdi:clock-start",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -992,7 +905,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux3_stop": {
         "name": "Relay AUX3 Timer 1 Stop",
-        "icon": "mdi:clock-end",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -1000,7 +912,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux3_period": {
         "name": "Relay AUX3 Timer 1 Repeat",
-        "icon": "mdi:repeat-variant",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_period",
         "register": None,
@@ -1008,7 +919,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux3b_start": {
         "name": "Relay AUX3 Timer 2 Start",
-        "icon": "mdi:clock-start",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -1016,7 +926,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux3b_stop": {
         "name": "Relay AUX3 Timer 2 Stop",
-        "icon": "mdi:clock-end",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -1024,7 +933,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux3b_period": {
         "name": "Relay AUX3 Timer 2 Repeat",
-        "icon": "mdi:repeat-variant",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_period",
         "register": None,
@@ -1032,7 +940,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux4_start": {
         "name": "Relay AUX4 Timer 1 Start",
-        "icon": "mdi:clock-start",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -1040,7 +947,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux4_stop": {
         "name": "Relay AUX4 Timer 1 Stop",
-        "icon": "mdi:clock-end",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -1048,7 +954,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux4_period": {
         "name": "Relay AUX4 Timer 1 Repeat",
-        "icon": "mdi:repeat-variant",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_period",
         "register": None,
@@ -1056,7 +961,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux4b_start": {
         "name": "Relay AUX4 Timer 2 Start",
-        "icon": "mdi:clock-start",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -1064,7 +968,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux4b_stop": {
         "name": "Relay AUX4 Timer 2 Stop",
-        "icon": "mdi:clock-end",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -1072,7 +975,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux4b_period": {
         "name": "Relay AUX4 Timer 2 Repeat",
-        "icon": "mdi:repeat-variant",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_period",
         "register": None,
@@ -1080,7 +982,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_light_start": {
         "name": "Relay Light Timer 1 Start",
-        "icon": "mdi:clock-start",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -1088,7 +989,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_light_stop": {
         "name": "Relay Light Timer 1 Stop",
-        "icon": "mdi:clock-end",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_time",
         "register": None,
@@ -1096,7 +996,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_light_period": {
         "name": "Relay Light Timer 1 Repeat",
-        "icon": "mdi:repeat-variant",
         "entity_category": EntityCategory.CONFIG,
         "select_type": "timer_period",
         "register": None,
@@ -1104,7 +1003,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux1_mode": {
         "name": "AUX1 Mode",
-        "icon": "mdi:speedometer-medium",
         "options_map": {
             # 0: "disabled",
             1: "auto",
@@ -1119,7 +1017,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux2_mode": {
         "name": "AUX2 Mode",
-        "icon": "mdi:speedometer-medium",
         "options_map": {
             # 0: "disabled",
             1: "auto",
@@ -1134,7 +1031,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux3_mode": {
         "name": "AUX3 Mode",
-        "icon": "mdi:speedometer-medium",
         "options_map": {
             # 0: "disabled",
             1: "auto",
@@ -1149,7 +1045,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_aux4_mode": {
         "name": "AUX4 Mode",
-        "icon": "mdi:speedometer-medium",
         "options_map": {
             # 0: "disabled",
             1: "auto",
@@ -1164,7 +1059,6 @@ SELECT_DEFINITIONS = {
     },
     "relay_light_mode": {
         "name": "Light Mode",
-        "icon": "mdi:speedometer-medium",
         "options_map": {
             # 0: "disabled",
             1: "auto",
@@ -1182,50 +1076,39 @@ SELECT_DEFINITIONS = {
 SWITCH_DEFINITIONS = {
     "WINTER_MODE": {
         "name": "Winter Mode",
-        "icon_on": "mdi:snowflake",
-        "icon_off": "mdi:weather-sunny",
         "entity_category": EntityCategory.CONFIG,
         "switch_type": "winter_mode",
     },
     "TIME_AUTO_SYNC": {
         "name": "Automatic Time Sync",
-        "icon": "mdi:home-clock-outline",
         "entity_category": EntityCategory.CONFIG,
         "switch_type": "auto_time_sync",
     },
     "MBF_PAR_FILT_MANUAL_STATE": {
         "name": "Manual Filtration",
-        "icon": "mdi:pump",
         "entity_category": None,
         "switch_type": "manual_filtration",
     },
     "MBF_PAR_CLIMA_ONOFF": {
         "name": "Climate mode",
-        "icon_on": "mdi:hvac",
-        "icon_off": "mdi:hvac-off",
         "function_addr": 0x0417,
         "entity_category": EntityCategory.CONFIG,
         "switch_type": "climate_mode",
     },
     "MBF_PAR_SMART_ANTI_FREEZE": {
         "name": "Smart antifreeze",
-        "icon_on": "mdi:snowflake-melt",
-        "icon_off": "mdi:snowflake-alert",
         "function_addr": 0x041A,
         "entity_category": EntityCategory.CONFIG,
         "switch_type": "smart_anti_freeze",
     },
     "MBF_PAR_UV_MODE": {
         "name": "UV Mode",
-        "icon_on": "mdi:lightbulb-fluorescent-tube",
-        "icon_off": "mdi:lightbulb-fluorescent-tube-outline",
         "function_addr": 0x0427,
         "entity_category": EntityCategory.CONFIG,
         "switch_type": "uv_mode",
     },
     # "MBF_PAR_UV_HIDE_WARN_CLEAN": {
     #     "name": "Suppress UV Clean Warning",
-    #     "icon": "mdi:alert-minus-outline",
     #     "function_addr": 0x0428,
     #     "mask_bit": 0x0001,
     #     "data_key": "MBF_PAR_UV_HIDE_WARN",
@@ -1234,7 +1117,6 @@ SWITCH_DEFINITIONS = {
     # },
     # "MBF_PAR_UV_HIDE_WARN_REPLACE": {
     #     "name": "Suppress UV Replace Warning",
-    #     "icon": "mdi:alert-minus-outline",
     #     "function_addr": 0x0428,
     #     "mask_bit": 0x0002,
     #     "data_key": "MBF_PAR_UV_HIDE_WARN",
@@ -1243,8 +1125,6 @@ SWITCH_DEFINITIONS = {
     # },
     "MBF_PAR_HIDRO_COVER_ENABLE": {
         "name": "Hydrolysis Cover Reduction",
-        "icon_on": "mdi:pool",
-        "icon_off": "mdi:pool-thermometer",
         "function_addr": 0x042C,
         "mask_bit": 0x0001,
         "data_key": "MBF_PAR_HIDRO_COVER_ENABLE",
@@ -1254,8 +1134,6 @@ SWITCH_DEFINITIONS = {
     },
     "MBF_PAR_HIDRO_TEMP_SHUTDOWN": {
         "name": "Hydrolysis Temperature Shutdown",
-        "icon_on": "mdi:thermometer-alert",
-        "icon_off": "mdi:thermometer-off",
         "function_addr": 0x042C,
         "mask_bit": 0x0002,
         "data_key": "MBF_PAR_HIDRO_COVER_ENABLE",
@@ -1265,8 +1143,6 @@ SWITCH_DEFINITIONS = {
     },
     "aux1": {
         "name": "Auxiliary Relay 1",
-        "icon_on": "mdi:electric-switch-closed",
-        "icon_off": "mdi:electric-switch",
         "switch_type": "relay_timer",
         "timer_block_addr": 0x04AC,
         "function_addr": 0x04B7,
@@ -1275,8 +1151,6 @@ SWITCH_DEFINITIONS = {
     },
     "aux2": {
         "name": "Auxiliary Relay 2",
-        "icon_on": "mdi:electric-switch-closed",
-        "icon_off": "mdi:electric-switch",
         "switch_type": "relay_timer",
         "timer_block_addr": 0x04BB,
         "function_addr": 0x04C6,
@@ -1285,8 +1159,6 @@ SWITCH_DEFINITIONS = {
     },
     "aux3": {
         "name": "Auxiliary Relay 3",
-        "icon_on": "mdi:electric-switch-closed",
-        "icon_off": "mdi:electric-switch",
         "switch_type": "relay_timer",
         "timer_block_addr": 0x04CA,
         "function_addr": 0x04D5,
@@ -1295,8 +1167,6 @@ SWITCH_DEFINITIONS = {
     },
     "aux4": {
         "name": "Auxiliary Relay 4",
-        "icon_on": "mdi:electric-switch-closed",
-        "icon_off": "mdi:electric-switch",
         "switch_type": "relay_timer",
         "timer_block_addr": 0x04D9,
         "function_addr": 0x04E4,
@@ -1308,8 +1178,6 @@ SWITCH_DEFINITIONS = {
 LIGHT_DEFINITIONS = {
     "light": {
         "name": "Pool Light",
-        "icon_on": "mdi:lightbulb-on",
-        "icon_off": "mdi:lightbulb-off",
         "switch_type": "relay_timer",
         "timer_block_addr": 0x0470,
         "function_addr": 0x047B,

--- a/custom_components/vistapool/helpers.py
+++ b/custom_components/vistapool/helpers.py
@@ -371,22 +371,34 @@ def has_filtvalve(data: dict) -> bool:
 
 def parse_register_int(raw, name: str) -> int:
     """Parse an integer from decimal or hex string (e.g. '1539' or '0x0603')."""
+    from .const import DOMAIN
+
     if isinstance(raw, bool):
         raise ServiceValidationError(
-            f"Invalid {name} '{raw}': use a decimal number or hex (0x\u2026)"
+            translation_domain=DOMAIN,
+            translation_key="invalid_register_type",
+            translation_placeholders={"name": name, "value": str(raw)},
         )
     if isinstance(raw, float):
         raise ServiceValidationError(
-            f"Invalid {name} '{raw}': use an integer, not a float"
+            translation_domain=DOMAIN,
+            translation_key="invalid_register_float",
+            translation_placeholders={"name": name, "value": str(raw)},
         )
     try:
         val = int(raw, 0) if isinstance(raw, str) else int(raw)
     except (ValueError, TypeError):
         raise ServiceValidationError(
-            f"Invalid {name} '{raw}': use a decimal number or hex (0x\u2026)"
+            translation_domain=DOMAIN,
+            translation_key="invalid_register_type",
+            translation_placeholders={"name": name, "value": str(raw)},
         )
     if not 0 <= val <= 65535:
-        raise ServiceValidationError(f"{name} {val} out of range (0\u201365535)")
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="register_out_of_range",
+            translation_placeholders={"name": name, "value": str(val)},
+        )
     return val
 
 

--- a/custom_components/vistapool/icons.json
+++ b/custom_components/vistapool/icons.json
@@ -1,0 +1,315 @@
+{
+  "entity": {
+    "sensor": {
+      "ion_current": { "default": "mdi:atom" },
+      "hidro_current": {
+        "default": "mdi:air-humidifier-off",
+        "range": {
+          "10": "mdi:air-humidifier"
+        }
+      },
+      "measure_ph": { "default": "mdi:ph" },
+      "measure_rx": { "default": "mdi:gradient-vertical" },
+      "measure_cl": { "default": "mdi:shaker-outline" },
+      "filt_mode": {
+        "default": "mdi:water-sync",
+        "state": {
+          "manual": "mdi:water-boiler-alert",
+          "auto": "mdi:water-boiler-auto",
+          "heating": "mdi:water-boiler-alert",
+          "smart": "mdi:water-boiler-auto",
+          "intelligent": "mdi:water-boiler-auto",
+          "backwash": "mdi:water-boiler-off"
+        }
+      },
+      "ph_status_alarm": {
+        "default": "mdi:ph",
+        "state": {
+          "ok": "mdi:check-circle-outline",
+          "ph_high": "mdi:alert",
+          "ph_low": "mdi:alert",
+          "pump_stopped": "mdi:alert",
+          "ph_over": "mdi:alert",
+          "ph_under": "mdi:alert",
+          "tank_level": "mdi:alert"
+        }
+      },
+      "hidro_polarity": { "default": "mdi:plus-minus-variant" },
+      "ion_polarity": { "default": "mdi:plus-minus-variant" },
+      "ph_pump_status": { "default": "mdi:pump" },
+      "filtration_speed": { "default": "mdi:fan" },
+      "intelligent_intervals": { "default": "mdi:counter" },
+      "intelligent_tt_next_interval": { "default": "mdi:timeline-clock-outline" },
+      "filtvalve_remaining": { "default": "mdi:timer-sand" },
+      "filtration_remaining": { "default": "mdi:timer-sand" }
+    },
+    "binary_sensor": {
+      "device_time_out_of_sync": {
+        "default": "mdi:clock-check-outline",
+        "state": {
+          "on": "mdi:clock-alert",
+          "off": "mdi:clock-check-outline"
+        }
+      },
+      "ph_acid_pump": {
+        "default": "mdi:pump-off",
+        "state": {
+          "on": "mdi:pump",
+          "off": "mdi:pump-off"
+        }
+      },
+      "filtration_pump": {
+        "default": "mdi:pump-off",
+        "state": {
+          "on": "mdi:pump",
+          "off": "mdi:pump-off"
+        }
+      },
+      "pool_light": {
+        "default": "mdi:lightbulb-outline",
+        "state": {
+          "on": "mdi:lightbulb-on",
+          "off": "mdi:lightbulb-outline"
+        }
+      },
+      "aux1": {
+        "default": "mdi:electric-switch",
+        "state": {
+          "on": "mdi:electric-switch-closed",
+          "off": "mdi:electric-switch"
+        }
+      },
+      "aux2": {
+        "default": "mdi:electric-switch",
+        "state": {
+          "on": "mdi:electric-switch-closed",
+          "off": "mdi:electric-switch"
+        }
+      },
+      "aux3": {
+        "default": "mdi:electric-switch",
+        "state": {
+          "on": "mdi:electric-switch-closed",
+          "off": "mdi:electric-switch"
+        }
+      },
+      "aux4": {
+        "default": "mdi:electric-switch",
+        "state": {
+          "on": "mdi:electric-switch-closed",
+          "off": "mdi:electric-switch"
+        }
+      },
+      "ph_measurement_active": {
+        "default": "mdi:scale-off",
+        "state": {
+          "on": "mdi:scale",
+          "off": "mdi:scale-off"
+        }
+      },
+      "redox_pump_active": {
+        "default": "mdi:pump-off",
+        "state": {
+          "on": "mdi:pump",
+          "off": "mdi:pump-off"
+        }
+      },
+      "redox_measurement_active": {
+        "default": "mdi:scale-off",
+        "state": {
+          "on": "mdi:scale",
+          "off": "mdi:scale-off"
+        }
+      },
+      "chlorine_pump_active": {
+        "default": "mdi:pump-off",
+        "state": {
+          "on": "mdi:pump",
+          "off": "mdi:pump-off"
+        }
+      },
+      "chlorine_measurement_active": {
+        "default": "mdi:scale-off",
+        "state": {
+          "on": "mdi:scale",
+          "off": "mdi:scale-off"
+        }
+      },
+      "conductivity_pump_active": {
+        "default": "mdi:pump-off",
+        "state": {
+          "on": "mdi:pump",
+          "off": "mdi:pump-off"
+        }
+      },
+      "conductivity_measurement_active": {
+        "default": "mdi:scale-off",
+        "state": {
+          "on": "mdi:scale",
+          "off": "mdi:scale-off"
+        }
+      },
+      "heating": {
+        "default": "mdi:radiator-off",
+        "state": {
+          "on": "mdi:radiator",
+          "off": "mdi:radiator-off"
+        }
+      },
+      "uv_lamp": {
+        "default": "mdi:lightbulb-fluorescent-tube-outline",
+        "state": {
+          "on": "mdi:lightbulb-fluorescent-tube",
+          "off": "mdi:lightbulb-fluorescent-tube-outline"
+        }
+      }
+    },
+    "number": {
+      "hidro": { "default": "mdi:air-humidifier" },
+      "rx1": { "default": "mdi:gradient-vertical" },
+      "cl1": { "default": "mdi:test-tube" },
+      "smart_temp_high": { "default": "mdi:thermometer-chevron-up" },
+      "smart_temp_low": { "default": "mdi:thermometer-chevron-down" },
+      "hidro_cover_reduction": { "default": "mdi:pool" },
+      "hidro_shutdown_temperature": { "default": "mdi:thermometer-alert" }
+    },
+    "button": {
+      "sync_time": { "default": "mdi:clock-check-outline" },
+      "escape": { "default": "mdi:reload-alert" },
+      "backwash": { "default": "mdi:waves-arrow-left" }
+    },
+    "select": {
+      "filt_mode": { "default": "mdi:water-sync" },
+      "filtration_speed": { "default": "mdi:fan-speed-3" },
+      "cell_boost": { "default": "mdi:flash-outline" },
+      "filtvalve_mode": { "default": "mdi:valve" },
+      "filtvalve_period_minutes": { "default": "mdi:timer-refresh-outline" },
+      "intelligent_filt_min_time": { "default": "mdi:timer-lock-outline" },
+      "relay_activation_delay": { "default": "mdi:timer-plus-outline" },
+      "filtration1_start": { "default": "mdi:clock-start" },
+      "filtration1_stop": { "default": "mdi:clock-end" },
+      "filtration2_start": { "default": "mdi:clock-start" },
+      "filtration2_stop": { "default": "mdi:clock-end" },
+      "filtration3_start": { "default": "mdi:clock-start" },
+      "filtration3_stop": { "default": "mdi:clock-end" },
+      "filtration1_speed": { "default": "mdi:fan-speed-3" },
+      "filtration2_speed": { "default": "mdi:fan-speed-3" },
+      "filtration3_speed": { "default": "mdi:fan-speed-3" },
+      "relay_aux1_start": { "default": "mdi:clock-start" },
+      "relay_aux1_stop": { "default": "mdi:clock-end" },
+      "relay_aux1_period": { "default": "mdi:repeat-variant" },
+      "relay_aux1b_start": { "default": "mdi:clock-start" },
+      "relay_aux1b_stop": { "default": "mdi:clock-end" },
+      "relay_aux1b_period": { "default": "mdi:repeat-variant" },
+      "relay_aux2_start": { "default": "mdi:clock-start" },
+      "relay_aux2_stop": { "default": "mdi:clock-end" },
+      "relay_aux2_period": { "default": "mdi:repeat-variant" },
+      "relay_aux2b_start": { "default": "mdi:clock-start" },
+      "relay_aux2b_stop": { "default": "mdi:clock-end" },
+      "relay_aux2b_period": { "default": "mdi:repeat-variant" },
+      "relay_aux3_start": { "default": "mdi:clock-start" },
+      "relay_aux3_stop": { "default": "mdi:clock-end" },
+      "relay_aux3_period": { "default": "mdi:repeat-variant" },
+      "relay_aux3b_start": { "default": "mdi:clock-start" },
+      "relay_aux3b_stop": { "default": "mdi:clock-end" },
+      "relay_aux3b_period": { "default": "mdi:repeat-variant" },
+      "relay_aux4_start": { "default": "mdi:clock-start" },
+      "relay_aux4_stop": { "default": "mdi:clock-end" },
+      "relay_aux4_period": { "default": "mdi:repeat-variant" },
+      "relay_aux4b_start": { "default": "mdi:clock-start" },
+      "relay_aux4b_stop": { "default": "mdi:clock-end" },
+      "relay_aux4b_period": { "default": "mdi:repeat-variant" },
+      "relay_light_start": { "default": "mdi:clock-start" },
+      "relay_light_stop": { "default": "mdi:clock-end" },
+      "relay_light_period": { "default": "mdi:repeat-variant" },
+      "relay_aux1_mode": { "default": "mdi:speedometer-medium" },
+      "relay_aux2_mode": { "default": "mdi:speedometer-medium" },
+      "relay_aux3_mode": { "default": "mdi:speedometer-medium" },
+      "relay_aux4_mode": { "default": "mdi:speedometer-medium" },
+      "relay_light_mode": { "default": "mdi:speedometer-medium" }
+    },
+    "switch": {
+      "winter_mode": {
+        "default": "mdi:weather-sunny",
+        "state": {
+          "on": "mdi:snowflake",
+          "off": "mdi:weather-sunny"
+        }
+      },
+      "time_auto_sync": { "default": "mdi:home-clock-outline" },
+      "filt_manual_state": { "default": "mdi:pump" },
+      "clima_onoff": {
+        "default": "mdi:hvac-off",
+        "state": {
+          "on": "mdi:hvac",
+          "off": "mdi:hvac-off"
+        }
+      },
+      "smart_anti_freeze": {
+        "default": "mdi:snowflake-alert",
+        "state": {
+          "on": "mdi:snowflake-melt",
+          "off": "mdi:snowflake-alert"
+        }
+      },
+      "uv_mode": {
+        "default": "mdi:lightbulb-fluorescent-tube-outline",
+        "state": {
+          "on": "mdi:lightbulb-fluorescent-tube",
+          "off": "mdi:lightbulb-fluorescent-tube-outline"
+        }
+      },
+      "hidro_cover_enable": {
+        "default": "mdi:pool-thermometer",
+        "state": {
+          "on": "mdi:pool",
+          "off": "mdi:pool-thermometer"
+        }
+      },
+      "hidro_temp_shutdown": {
+        "default": "mdi:thermometer-off",
+        "state": {
+          "on": "mdi:thermometer-alert",
+          "off": "mdi:thermometer-off"
+        }
+      },
+      "aux1": {
+        "default": "mdi:electric-switch",
+        "state": {
+          "on": "mdi:electric-switch-closed",
+          "off": "mdi:electric-switch"
+        }
+      },
+      "aux2": {
+        "default": "mdi:electric-switch",
+        "state": {
+          "on": "mdi:electric-switch-closed",
+          "off": "mdi:electric-switch"
+        }
+      },
+      "aux3": {
+        "default": "mdi:electric-switch",
+        "state": {
+          "on": "mdi:electric-switch-closed",
+          "off": "mdi:electric-switch"
+        }
+      },
+      "aux4": {
+        "default": "mdi:electric-switch",
+        "state": {
+          "on": "mdi:electric-switch-closed",
+          "off": "mdi:electric-switch"
+        }
+      }
+    },
+    "light": {
+      "light": {
+        "default": "mdi:lightbulb-off",
+        "state": {
+          "on": "mdi:lightbulb-on",
+          "off": "mdi:lightbulb-off"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/vistapool/light.py
+++ b/custom_components/vistapool/light.py
@@ -79,9 +79,6 @@ class VistaPoolLight(VistaPoolEntity, LightEntity):  # type: ignore[reportIncomp
         self._attr_translation_key = VistaPoolEntity.slugify(self._key)
 
         self._switch_type = props.get("switch_type") or None
-        self._attr_icon = props.get("icon") or None
-        self._icon_on = props.get("icon_on")
-        self._icon_off = props.get("icon_off")
 
         # Initialize properties for relay timer switches
         self.timer_block_addr: int | None = props.get("timer_block_addr")
@@ -196,15 +193,6 @@ class VistaPoolLight(VistaPoolEntity, LightEntity):  # type: ignore[reportIncomp
             mode_val = self.coordinator.data.get("relay_light_enable", None)
             return mode_val in (0, 3, 4)
         return True
-
-    @property
-    def icon(self) -> str | None:  # type: ignore[override]
-        """Return custom icon depending on state."""
-        if self._icon_on and self._icon_off:
-            return self._icon_on if self.is_on else self._icon_off
-        if self._attr_icon:
-            return self._attr_icon
-        return None
 
     @property
     def supported_color_modes(self) -> set[str]:  # type: ignore[override]

--- a/custom_components/vistapool/number.py
+++ b/custom_components/vistapool/number.py
@@ -156,7 +156,6 @@ class VistaPoolNumber(VistaPoolEntity, NumberEntity):  # type: ignore[reportInco
 
         self._attr_device_class = props.get("device_class") or None
         self._attr_entity_category = props.get("entity_category") or None
-        self._attr_icon = props.get("icon")
         self._pending_write_task = None
         self._pending_value = None
         self._debounce_delay = 2.0
@@ -257,11 +256,6 @@ class VistaPoolNumber(VistaPoolEntity, NumberEntity):  # type: ignore[reportInco
         if self._key == "MBF_PAR_HEATING_TEMP":
             return 0
         return None
-
-    @property
-    def icon(self) -> str | None:  # type: ignore[override]
-        """Return custom icon depending on state."""
-        return self._attr_icon or None
 
     @property
     def native_value(self) -> float | int | str | None:  # type: ignore[override]

--- a/custom_components/vistapool/select.py
+++ b/custom_components/vistapool/select.py
@@ -132,7 +132,6 @@ class VistaPoolSelect(VistaPoolEntity, SelectEntity):  # type: ignore[reportInco
         self._attr_unique_id = f"{device_id}_{self._key.lower()}"
         self._attr_translation_key = VistaPoolEntity.slugify(self._key)
 
-        self._attr_icon = props.get("icon") or None
         self._options_map = dict(props.get("options_map") or {})
         self._attr_entity_category = props.get("entity_category") or None
         self._select_type = props.get("select_type") or None

--- a/custom_components/vistapool/sensor.py
+++ b/custom_components/vistapool/sensor.py
@@ -170,7 +170,6 @@ class VistaPoolSensor(VistaPoolEntity, SensorEntity):  # type: ignore[reportInco
         self._attr_device_class = props.get("device_class") or None
         self._attr_state_class = props.get("state_class") or None
         self._attr_entity_category = props.get("entity_category") or None
-        self._attr_icon = props.get("icon") or None
         self._attr_suggested_display_precision = props.get("display_precision")
 
         # Disable some entities by default.
@@ -193,42 +192,6 @@ class VistaPoolSensor(VistaPoolEntity, SensorEntity):  # type: ignore[reportInco
             getattr(self, "has_entity_name", None),
         )
         await super().async_added_to_hass()
-
-    @property
-    def icon(self) -> str | None:  # type: ignore[override]
-        raw: int | None = self.coordinator.data.get(self._key)
-        if raw is None:
-            return self._attr_icon or None
-        # Filtration mode icons
-        if self._key == "MBF_PAR_FILT_MODE":
-            mode = FILTRATION_MODE_MAP.get(raw)
-            if mode == "auto":
-                return "mdi:water-boiler-auto"
-            elif mode == "manual":
-                return "mdi:water-boiler-alert"
-            elif mode == "heating":
-                return "mdi:water-boiler-alert"
-            elif mode == "smart":
-                return "mdi:water-boiler-auto"
-            elif mode == "intelligent":
-                return "mdi:water-boiler-auto"
-            elif mode == "backwash":
-                return "mdi:water-boiler-off"
-        # PH alarm icons
-        if self._key == "MBF_PH_STATUS_ALARM":
-            status = PH_STATUS_ALARM_MAP.get(raw)
-            if status == "ok":
-                return "mdi:check-circle-outline"
-            if status is not None:
-                return "mdi:alert"
-            return self._attr_icon or None
-        if self._key == "MBF_HIDRO_CURRENT":
-            return (
-                "mdi:air-humidifier"
-                if bool(self.coordinator.data.get(self._key))
-                else "mdi:air-humidifier-off"
-            )
-        return self._attr_icon or None
 
     @property
     def suggested_display_precision(self) -> int | None:  # type: ignore[override]

--- a/custom_components/vistapool/switch.py
+++ b/custom_components/vistapool/switch.py
@@ -122,9 +122,6 @@ class VistaPoolSwitch(VistaPoolEntity, SwitchEntity):  # type: ignore[reportInco
             self._winter_mode_active = False
 
         self._attr_entity_category = props.get("entity_category") or None
-        self._icon_on = props.get("icon_on")
-        self._icon_off = props.get("icon_off")
-        self._attr_icon = props.get("icon") or None
 
         # Initialize properties for relay timer switches
         self.timer_block_addr: int | None = props.get("timer_block_addr")
@@ -379,12 +376,3 @@ class VistaPoolSwitch(VistaPoolEntity, SwitchEntity):  # type: ignore[reportInco
             # 3 = on, 4 = off → available; 0 (disabled) or 1 (auto) → not available
             return mode_val in (3, 4)
         return True
-
-    @property
-    def icon(self) -> str | None:  # type: ignore[override]
-        """Return the icon to use in the frontend, depending on the state."""
-        if self._icon_on and self._icon_off:
-            return self._icon_on if self.is_on else self._icon_off
-        if self._attr_icon:
-            return self._attr_icon
-        return None

--- a/custom_components/vistapool/translations/cs.json
+++ b/custom_components/vistapool/translations/cs.json
@@ -551,7 +551,7 @@
         },
         "value": {
           "name": "Hodnota",
-          "description": "Hodnota k zápisu (0–65535, dekadicky nebo hexadecimálně)."
+          "description": "Hodnota k zápisu (0-65535, dekadicky nebo hexadecimálně)."
         },
         "apply": {
           "name": "Použít",
@@ -559,6 +559,23 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "entry_not_found": { "message": "Nebyla nalezena konfigurace VistaPool pro entry_id {entry_id}" },
+    "no_loaded_entry": { "message": "Není k dispozici žádná načtená konfigurace VistaPool" },
+    "no_coordinator": { "message": "Nebyl nalezen koordinátor VistaPool pro entry_id {entry_id}" },
+    "missing_parameter": { "message": "Chybí povinný parametr {parameter}" },
+    "invalid_timer": { "message": "Neplatný název časovače {timer_name}. Platné časovače: {valid_timers}" },
+    "timer_failed": { "message": "Nastavení časovače selhalo: {error}" },
+    "invalid_apply": { "message": "Neplatná hodnota apply {apply}: musí být boolean (true/false)" },
+    "write_failed": { "message": "Zápis do registru {address} selhal" },
+    "write_verification_failed": {
+      "message": "Ověření zápisu na adrese {address} selhalo: zapsáno {value}, přečteno {confirmed}"
+    },
+    "register_write_failed": { "message": "Zápis do registru na adrese {address} selhal: {error}" },
+    "invalid_register_type": { "message": "Neplatná hodnota {name} {value}: použijte desítkové číslo nebo hex (0x…)" },
+    "invalid_register_float": { "message": "Neplatná hodnota {name} {value}: použijte celé číslo, ne desetinné" },
+    "register_out_of_range": { "message": "{name} {value} mimo rozsah (0-65535)" }
   },
   "issues": {
     "corrupted_gpio": {

--- a/custom_components/vistapool/translations/de.json
+++ b/custom_components/vistapool/translations/de.json
@@ -551,7 +551,7 @@
         },
         "value": {
           "name": "Wert",
-          "description": "Zu schreibender Wert (0–65535, dezimal oder hexadezimal)."
+          "description": "Zu schreibender Wert (0-65535, dezimal oder hexadezimal)."
         },
         "apply": {
           "name": "Anwenden",
@@ -559,6 +559,27 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "entry_not_found": { "message": "Kein VistaPool-Konfigurationseintrag für entry_id {entry_id} gefunden" },
+    "no_loaded_entry": { "message": "Kein geladener VistaPool-Konfigurationseintrag verfügbar" },
+    "no_coordinator": { "message": "Kein VistaPool-Koordinator für entry_id {entry_id} gefunden" },
+    "missing_parameter": { "message": "Erforderlicher Parameter {parameter} fehlt" },
+    "invalid_timer": { "message": "Ungültiger Timer-Name {timer_name}. Gültige Timer: {valid_timers}" },
+    "timer_failed": { "message": "Timer-Einstellung fehlgeschlagen: {error}" },
+    "invalid_apply": { "message": "Ungültiger Wert für apply {apply}: muss ein Boolean sein (true/false)" },
+    "write_failed": { "message": "Schreiben in Register {address} fehlgeschlagen" },
+    "write_verification_failed": {
+      "message": "Schreibverifizierung bei {address} fehlgeschlagen: geschrieben {value}, zurückgelesen {confirmed}"
+    },
+    "register_write_failed": { "message": "Registerschreiben bei {address} fehlgeschlagen: {error}" },
+    "invalid_register_type": {
+      "message": "Ungültiger Wert {name} {value}: verwenden Sie eine Dezimalzahl oder Hex (0x…)"
+    },
+    "invalid_register_float": {
+      "message": "Ungültiger Wert {name} {value}: verwenden Sie eine Ganzzahl, keine Gleitkommazahl"
+    },
+    "register_out_of_range": { "message": "{name} {value} außerhalb des Bereichs (0-65535)" }
   },
   "issues": {
     "corrupted_gpio": {

--- a/custom_components/vistapool/translations/en.json
+++ b/custom_components/vistapool/translations/en.json
@@ -551,7 +551,7 @@
         },
         "value": {
           "name": "Value",
-          "description": "Value to write (0–65535, decimal or hex)."
+          "description": "Value to write (0-65535, decimal or hex)."
         },
         "apply": {
           "name": "Apply",
@@ -559,6 +559,23 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "entry_not_found": { "message": "No VistaPool config entry found for entry_id {entry_id}" },
+    "no_loaded_entry": { "message": "No loaded VistaPool config entry available" },
+    "no_coordinator": { "message": "No VistaPool coordinator found for entry_id {entry_id}" },
+    "missing_parameter": { "message": "Missing required parameter {parameter}" },
+    "invalid_timer": { "message": "Invalid timer name {timer_name}. Valid timers: {valid_timers}" },
+    "timer_failed": { "message": "Timer setting failed: {error}" },
+    "invalid_apply": { "message": "Invalid apply {apply}: must be a boolean (true/false)" },
+    "write_failed": { "message": "Write to register {address} failed" },
+    "write_verification_failed": {
+      "message": "Write verification failed at {address}: wrote {value}, read back {confirmed}"
+    },
+    "register_write_failed": { "message": "Register write failed at {address}: {error}" },
+    "invalid_register_type": { "message": "Invalid {name} {value}: use a decimal number or hex (0x…)" },
+    "invalid_register_float": { "message": "Invalid {name} {value}: use an integer, not a float" },
+    "register_out_of_range": { "message": "{name} {value} out of range (0-65535)" }
   },
   "issues": {
     "corrupted_gpio": {

--- a/custom_components/vistapool/translations/es.json
+++ b/custom_components/vistapool/translations/es.json
@@ -551,7 +551,7 @@
         },
         "value": {
           "name": "Valor",
-          "description": "Valor a escribir (0–65535, decimal o hexadecimal)."
+          "description": "Valor a escribir (0-65535, decimal o hexadecimal)."
         },
         "apply": {
           "name": "Aplicar",
@@ -559,6 +559,25 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "entry_not_found": { "message": "No se encontró la entrada de configuración VistaPool para entry_id {entry_id}" },
+    "no_loaded_entry": { "message": "No hay ninguna entrada de configuración VistaPool cargada disponible" },
+    "no_coordinator": { "message": "No se encontró el coordinador VistaPool para entry_id {entry_id}" },
+    "missing_parameter": { "message": "Falta el parámetro obligatorio {parameter}" },
+    "invalid_timer": {
+      "message": "Nombre de temporizador no válido {timer_name}. Temporizadores válidos: {valid_timers}"
+    },
+    "timer_failed": { "message": "Error al configurar el temporizador: {error}" },
+    "invalid_apply": { "message": "Valor de apply no válido {apply}: debe ser un booleano (true/false)" },
+    "write_failed": { "message": "Error al escribir en el registro {address}" },
+    "write_verification_failed": {
+      "message": "Verificación de escritura fallida en {address}: se escribió {value}, se leyó {confirmed}"
+    },
+    "register_write_failed": { "message": "Error de escritura en registro en {address}: {error}" },
+    "invalid_register_type": { "message": "Valor no válido {name} {value}: use un número decimal o hex (0x…)" },
+    "invalid_register_float": { "message": "Valor no válido {name} {value}: use un entero, no un decimal" },
+    "register_out_of_range": { "message": "{name} {value} fuera de rango (0-65535)" }
   },
   "issues": {
     "corrupted_gpio": {

--- a/custom_components/vistapool/translations/fr.json
+++ b/custom_components/vistapool/translations/fr.json
@@ -552,7 +552,7 @@
         },
         "value": {
           "name": "Valeur",
-          "description": "Valeur à écrire (0–65535, décimal ou hexadécimal)."
+          "description": "Valeur à écrire (0-65535, décimal ou hexadécimal)."
         },
         "apply": {
           "name": "Appliquer",
@@ -560,6 +560,25 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "entry_not_found": { "message": "Aucune entrée de configuration VistaPool trouvée pour entry_id {entry_id}" },
+    "no_loaded_entry": { "message": "Aucune entrée de configuration VistaPool chargée disponible" },
+    "no_coordinator": { "message": "Aucun coordinateur VistaPool trouvé pour entry_id {entry_id}" },
+    "missing_parameter": { "message": "Paramètre obligatoire {parameter} manquant" },
+    "invalid_timer": { "message": "Nom de minuteur non valide {timer_name}. Minuteurs valides : {valid_timers}" },
+    "timer_failed": { "message": "Échec du réglage du minuteur : {error}" },
+    "invalid_apply": { "message": "Valeur apply non valide {apply} : doit être un booléen (true/false)" },
+    "write_failed": { "message": "Échec de l'écriture dans le registre {address}" },
+    "write_verification_failed": {
+      "message": "Vérification d'écriture échouée à {address} : écrit {value}, relu {confirmed}"
+    },
+    "register_write_failed": { "message": "Échec d'écriture du registre à {address} : {error}" },
+    "invalid_register_type": {
+      "message": "Valeur {name} non valide {value} : utilisez un nombre décimal ou hex (0x…)"
+    },
+    "invalid_register_float": { "message": "Valeur {name} non valide {value} : utilisez un entier, pas un décimal" },
+    "register_out_of_range": { "message": "{name} {value} hors limites (0-65535)" }
   },
   "issues": {
     "corrupted_gpio": {

--- a/custom_components/vistapool/translations/it.json
+++ b/custom_components/vistapool/translations/it.json
@@ -551,7 +551,7 @@
         },
         "value": {
           "name": "Valore",
-          "description": "Valore da scrivere (0–65535, decimale o esadecimale)."
+          "description": "Valore da scrivere (0-65535, decimale o esadecimale)."
         },
         "apply": {
           "name": "Applica",
@@ -559,6 +559,23 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "entry_not_found": { "message": "Nessuna voce di configurazione VistaPool trovata per entry_id {entry_id}" },
+    "no_loaded_entry": { "message": "Nessuna voce di configurazione VistaPool caricata disponibile" },
+    "no_coordinator": { "message": "Nessun coordinatore VistaPool trovato per entry_id {entry_id}" },
+    "missing_parameter": { "message": "Parametro obbligatorio {parameter} mancante" },
+    "invalid_timer": { "message": "Nome timer non valido {timer_name}. Timer validi: {valid_timers}" },
+    "timer_failed": { "message": "Impostazione timer fallita: {error}" },
+    "invalid_apply": { "message": "Valore apply non valido {apply}: deve essere un booleano (true/false)" },
+    "write_failed": { "message": "Scrittura nel registro {address} fallita" },
+    "write_verification_failed": {
+      "message": "Verifica scrittura fallita a {address}: scritto {value}, riletto {confirmed}"
+    },
+    "register_write_failed": { "message": "Scrittura registro fallita a {address}: {error}" },
+    "invalid_register_type": { "message": "Valore {name} non valido {value}: usare un numero decimale o hex (0x…)" },
+    "invalid_register_float": { "message": "Valore {name} non valido {value}: usare un intero, non un decimale" },
+    "register_out_of_range": { "message": "{name} {value} fuori intervallo (0-65535)" }
   },
   "issues": {
     "corrupted_gpio": {

--- a/custom_components/vistapool/translations/pl.json
+++ b/custom_components/vistapool/translations/pl.json
@@ -551,7 +551,7 @@
         },
         "value": {
           "name": "Wartość",
-          "description": "Wartość do zapisu (0–65535, dziesiętnie lub szesnastkowo)."
+          "description": "Wartość do zapisu (0-65535, dziesiętnie lub szesnastkowo)."
         },
         "apply": {
           "name": "Zastosuj",
@@ -559,6 +559,27 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "entry_not_found": { "message": "Nie znaleziono wpisu konfiguracji VistaPool dla entry_id {entry_id}" },
+    "no_loaded_entry": { "message": "Brak załadowanego wpisu konfiguracji VistaPool" },
+    "no_coordinator": { "message": "Nie znaleziono koordynatora VistaPool dla entry_id {entry_id}" },
+    "missing_parameter": { "message": "Brak wymaganego parametru {parameter}" },
+    "invalid_timer": { "message": "Nieprawidłowa nazwa timera {timer_name}. Prawidłowe timery: {valid_timers}" },
+    "timer_failed": { "message": "Ustawienie timera nie powiodło się: {error}" },
+    "invalid_apply": { "message": "Nieprawidłowa wartość apply {apply}: musi być wartością logiczną (true/false)" },
+    "write_failed": { "message": "Zapis do rejestru {address} nie powiódł się" },
+    "write_verification_failed": {
+      "message": "Weryfikacja zapisu pod adresem {address} nie powiodła się: zapisano {value}, odczytano {confirmed}"
+    },
+    "register_write_failed": { "message": "Zapis rejestru pod adresem {address} nie powiódł się: {error}" },
+    "invalid_register_type": {
+      "message": "Nieprawidłowa wartość {name} {value}: użyj liczby dziesiętnej lub hex (0x…)"
+    },
+    "invalid_register_float": {
+      "message": "Nieprawidłowa wartość {name} {value}: użyj liczby całkowitej, nie zmiennoprzecinkowej"
+    },
+    "register_out_of_range": { "message": "{name} {value} poza zakresem (0-65535)" }
   },
   "issues": {
     "corrupted_gpio": {

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -425,17 +425,6 @@ def test_is_on_status_dict(mock_coordinator):
     assert ent.is_on is None
 
 
-def test_icon_on_off(mock_coordinator):
-    props = make_props(icon_on="mdi:pump", icon_off="mdi:pump-off")
-    ent = VistaPoolBinarySensor(
-        mock_coordinator, "test_entry", "pH acid pump active", props
-    )
-    mock_coordinator.data = {"pH acid pump active": True}
-    assert ent.icon == "mdi:pump"
-    mock_coordinator.data = {"pH acid pump active": False}
-    assert ent.icon == "mdi:pump-off"
-
-
 def test_native_value(mock_coordinator):
     props = make_props()
     ent = VistaPoolBinarySensor(

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -36,13 +36,12 @@ def mock_coordinator():
 
 @pytest.fixture
 def button_props():
-    return {"icon": "mdi:button-pointer"}
+    return {}
 
 
 def test_button_attrs(mock_coordinator, button_props):
     ent = VistaPoolButton(mock_coordinator, "test_entry", "SYNC_TIME", button_props)
     assert ent._key == "SYNC_TIME"
-    assert ent.icon == "mdi:button-pointer"
 
 
 @pytest.mark.asyncio
@@ -87,9 +86,7 @@ async def test_button_async_setup_entry_adds_entities(monkeypatch):
     # Patch BUTTON_DEFINITIONS
     from custom_components.vistapool import button as btn_module
 
-    monkeypatch.setitem(
-        btn_module.BUTTON_DEFINITIONS, "TEST_BUTTON", {"icon": "mdi:test"}
-    )
+    monkeypatch.setitem(btn_module.BUTTON_DEFINITIONS, "TEST_BUTTON", {})
     await async_setup_entry(hass, entry, async_add_entities)  # type: ignore[arg-type]
     # Should add entity for each key in BUTTON_DEFINITIONS
     entities = async_add_entities.call_args[0][0]
@@ -126,7 +123,7 @@ async def test_button_async_setup_entry_no_data(monkeypatch, caplog):
 async def test_press_blocked_during_winter_mode(mock_coordinator, caplog):
     """async_press is ignored when winter mode is active."""
     mock_coordinator.winter_mode = True
-    props = {"name": "Sync Time", "icon": "mdi:clock"}
+    props = {"name": "Sync Time"}
     ent = VistaPoolButton(mock_coordinator, "test_entry", "SYNC_TIME", props)
     with caplog.at_level("WARNING"):
         await ent.async_press()
@@ -137,7 +134,7 @@ async def test_press_blocked_during_winter_mode(mock_coordinator, caplog):
 def test_available_false_during_winter_mode(mock_coordinator):
     """VistaPoolButton is unavailable when winter mode is active."""
     mock_coordinator.winter_mode = True
-    props = {"name": "Sync Time", "icon": "mdi:clock"}
+    props = {"name": "Sync Time"}
     ent = VistaPoolButton(mock_coordinator, "test_entry", "SYNC_TIME", props)
     assert ent.available is False
 
@@ -147,7 +144,7 @@ async def test_button_press_backwash_with_valve(mock_coordinator, caplog):
     """async_press for BACKWASH writes mode 13 when filtvalve is configured."""
     mock_coordinator.data = {"MBF_PAR_FILTVALVE_ENABLE": 1}
     mock_coordinator.device_name = "Test Pool"
-    props = {"name": "Start Backwash", "icon": "mdi:waves-arrow-left"}
+    props = {"name": "Start Backwash"}
     ent = VistaPoolButton(mock_coordinator, "test_entry", "BACKWASH", props)
     ent.hass = MagicMock()
     await ent.async_press()
@@ -160,7 +157,7 @@ async def test_button_press_backwash_no_valve(mock_coordinator, caplog):
     """async_press for BACKWASH logs warning and does nothing when valve not configured."""
     mock_coordinator.data = {"MBF_PAR_FILTVALVE_ENABLE": 0, "MBF_PAR_FILTVALVE_GPIO": 0}
     mock_coordinator.device_name = "Test Pool"
-    props = {"name": "Start Backwash", "icon": "mdi:waves-arrow-left"}
+    props = {"name": "Start Backwash"}
     ent = VistaPoolButton(mock_coordinator, "test_entry", "BACKWASH", props)
     ent.hass = MagicMock()
     with caplog.at_level("WARNING"):
@@ -175,7 +172,7 @@ async def test_button_press_backwash_gpio_only(mock_coordinator, caplog):
     """async_press for BACKWASH works when only GPIO is set (ENABLE=0, GPIO!=0)."""
     mock_coordinator.data = {"MBF_PAR_FILTVALVE_ENABLE": 0, "MBF_PAR_FILTVALVE_GPIO": 5}
     mock_coordinator.device_name = "Test Pool"
-    props = {"name": "Start Backwash", "icon": "mdi:waves-arrow-left"}
+    props = {"name": "Start Backwash"}
     ent = VistaPoolButton(mock_coordinator, "test_entry", "BACKWASH", props)
     ent.hass = MagicMock()
     await ent.async_press()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -195,8 +195,9 @@ async def test_async_handle_set_timer_invalid_timer_name(monkeypatch):
         for c in hass.services.async_register.call_args_list
         if c.args[1] == "set_timer"
     )
-    with pytest.raises(ServiceValidationError, match="Invalid timer name"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await service_func(call)
+    assert exc_info.value.translation_key == "invalid_timer"
 
 
 @pytest.mark.asyncio
@@ -219,8 +220,9 @@ async def test_async_handle_set_timer_missing_timer_key(monkeypatch):
         for c in hass.services.async_register.call_args_list
         if c.args[1] == "set_timer"
     )
-    with pytest.raises(ServiceValidationError, match="Missing required parameter"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await service_func(call)
+    assert exc_info.value.translation_key == "missing_parameter"
 
 
 @pytest.mark.asyncio
@@ -438,8 +440,9 @@ async def test_write_register_invalid_hex():
     handler = _get_write_register_handler(hass)
     call = MagicMock()
     call.data = {"address": "0xZZZZ", "value": "5", "entry_id": "entry1"}
-    with pytest.raises(ServiceValidationError, match="Invalid address"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await handler(call)
+    assert exc_info.value.translation_key == "invalid_register_type"
 
 
 @pytest.mark.asyncio
@@ -454,8 +457,9 @@ async def test_write_register_out_of_range():
     handler = _get_write_register_handler(hass)
     call = MagicMock()
     call.data = {"address": "0x0001", "value": "70000", "entry_id": "entry1"}
-    with pytest.raises(ServiceValidationError, match="out of range"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await handler(call)
+    assert exc_info.value.translation_key == "register_out_of_range"
 
 
 @pytest.mark.asyncio
@@ -503,8 +507,9 @@ async def test_write_register_apply_invalid_type():
         "apply": "false",
         "entry_id": "entry1",
     }
-    with pytest.raises(ServiceValidationError, match="Invalid apply"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await handler(call)
+    assert exc_info.value.translation_key == "invalid_apply"
 
 
 @pytest.mark.asyncio
@@ -519,8 +524,9 @@ async def test_write_register_rejects_bool():
     handler = _get_write_register_handler(hass)
     call = MagicMock()
     call.data = {"address": True, "value": "5", "entry_id": "entry1"}
-    with pytest.raises(ServiceValidationError, match="Invalid address"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await handler(call)
+    assert exc_info.value.translation_key == "invalid_register_type"
 
 
 @pytest.mark.asyncio
@@ -535,8 +541,9 @@ async def test_write_register_rejects_float():
     handler = _get_write_register_handler(hass)
     call = MagicMock()
     call.data = {"address": 1.5, "value": "5", "entry_id": "entry1"}
-    with pytest.raises(ServiceValidationError, match="not a float"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await handler(call)
+    assert exc_info.value.translation_key == "invalid_register_float"
 
 
 @pytest.mark.asyncio
@@ -551,8 +558,9 @@ async def test_write_register_missing_param():
     handler = _get_write_register_handler(hass)
     call = MagicMock()
     call.data = {"address": "0x0001", "entry_id": "entry1"}
-    with pytest.raises(ServiceValidationError, match="Missing required parameter"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await handler(call)
+    assert exc_info.value.translation_key == "missing_parameter"
 
 
 @pytest.mark.asyncio
@@ -569,8 +577,9 @@ async def test_write_register_returns_none():
     handler = _get_write_register_handler(hass)
     call = MagicMock()
     call.data = {"address": "0x0001", "value": "1", "entry_id": "entry1"}
-    with pytest.raises(ServiceValidationError, match="failed"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await handler(call)
+    assert exc_info.value.translation_key == "write_failed"
 
 
 @pytest.mark.asyncio
@@ -589,8 +598,9 @@ async def test_write_register_verification_mismatch():
     handler = _get_write_register_handler(hass)
     call = MagicMock()
     call.data = {"address": "0x0001", "value": "1", "entry_id": "entry1"}
-    with pytest.raises(ServiceValidationError, match="Write verification failed"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await handler(call)
+    assert exc_info.value.translation_key == "write_verification_failed"
 
 
 @pytest.mark.asyncio
@@ -609,8 +619,9 @@ async def test_write_register_generic_exception():
     handler = _get_write_register_handler(hass)
     call = MagicMock()
     call.data = {"address": "0x0001", "value": "1", "entry_id": "entry1"}
-    with pytest.raises(ServiceValidationError, match="Register write failed"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await handler(call)
+    assert exc_info.value.translation_key == "register_write_failed"
 
 
 @pytest.mark.asyncio
@@ -625,8 +636,9 @@ async def test_get_coordinator_not_found():
     handler = _get_write_register_handler(hass)
     call = MagicMock()
     call.data = {"address": "0x0001", "value": "1", "entry_id": "nonexistent"}
-    with pytest.raises(ServiceValidationError, match="No VistaPool config entry found"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await handler(call)
+    assert exc_info.value.translation_key == "entry_not_found"
 
 
 @pytest.mark.asyncio
@@ -641,8 +653,9 @@ async def test_get_coordinator_runtime_data_none():
     handler = _get_write_register_handler(hass)
     call = MagicMock()
     call.data = {"address": "0x0001", "value": "1", "entry_id": "entry1"}
-    with pytest.raises(ServiceValidationError, match="No VistaPool coordinator"):
+    with pytest.raises(ServiceValidationError) as exc_info:
         await handler(call)
+    assert exc_info.value.translation_key == "no_coordinator"
 
 
 @pytest.mark.asyncio

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -46,8 +46,6 @@ def mock_coordinator():
 def light_props():
     return {
         "switch_type": "relay_timer",
-        "icon_on": "mdi:lightbulb-on",
-        "icon_off": "mdi:lightbulb-off",
     }
 
 
@@ -55,7 +53,6 @@ def test_light_attrs(mock_coordinator, light_props):
     ent = VistaPoolLight(mock_coordinator, "test_entry", "light", light_props)
     assert ent._key == "light"
     assert ent._switch_type == "relay_timer"
-    assert ent.icon == "mdi:lightbulb-off"
 
 
 def test_light_is_on(mock_coordinator, light_props):
@@ -88,29 +85,6 @@ async def test_light_async_turn_off(mock_coordinator, light_props):
     ent.async_write_ha_state = MagicMock()
     await ent.async_turn_off()
     assert mock_coordinator.client.async_write_register.called
-
-
-def test_light_icon_on_off(mock_coordinator):
-    props = {"switch_type": "relay_timer", "icon_on": "mdi:on", "icon_off": "mdi:off"}
-    ent = VistaPoolLight(mock_coordinator, "test_entry", "light", props)
-    mock_coordinator.data["relay_light_enable"] = 3  # is_on True
-    assert ent.icon == "mdi:on"
-    mock_coordinator.data["relay_light_enable"] = 4  # is_on False
-    assert ent.icon == "mdi:off"
-
-
-def test_light_icon_attr_only(mock_coordinator):
-    props = {"switch_type": "relay_timer", "icon": "mdi:custom"}
-    ent = VistaPoolLight(mock_coordinator, "test_entry", "light", props)
-    # No _icon_on/_icon_off, fallback to _attr_icon
-    assert ent.icon == "mdi:custom"
-
-
-def test_light_icon_none(mock_coordinator):
-    props = {"switch_type": "relay_timer"}
-    ent = VistaPoolLight(mock_coordinator, "test_entry", "light", props)
-    # No icons at all
-    assert ent.icon is None
 
 
 def test_light_available_relay_timer(mock_coordinator, light_props):
@@ -162,8 +136,6 @@ async def test_light_async_setup_entry_adds_entities(monkeypatch):
         "Test Light",
         {
             "switch_type": "relay_timer",
-            "icon_on": "mdi:lightbulb-on",
-            "icon_off": "mdi:lightbulb-off",
         },
     )
 
@@ -229,8 +201,6 @@ async def test_light_async_setup_entry_skips_without_lighting_gpio(monkeypatch):
         "Test Light",
         {
             "switch_type": "relay_timer",
-            "icon_on": "mdi:lightbulb-on",
-            "icon_off": "mdi:lightbulb-off",
         },
     )
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -153,13 +153,6 @@ def test_native_step_dynamic(mock_coordinator):
     )
     assert ent_ph.native_step == 0.1
 
-    props = make_props(icon="mdi:beaker")
-    ent = VistaPoolNumber(mock_coordinator, "test_entry", "MBF_PAR_PH1", props)
-    assert ent.icon == "mdi:beaker"
-    props2 = make_props()
-    ent2 = VistaPoolNumber(mock_coordinator, "test_entry", "MBF_PAR_PH1", props2)
-    assert ent2.icon is None
-
 
 @pytest.mark.asyncio
 async def test_async_set_native_value_and_debounce(mock_coordinator):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -81,7 +81,6 @@ def boost_props():
             1: "active (redox disabled)",
             2: "active (redox enabled)",
         },
-        "icon": "mdi:lightning-bolt",
     }
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -42,21 +42,6 @@ def make_props(**kwargs):
     return d
 
 
-def test_icon_filtration_modes(mock_coordinator):
-    props = make_props(icon="mdi:water-sync")
-    ent = VistaPoolSensor(mock_coordinator, "test_entry", "MBF_PAR_FILT_MODE", props)
-    for raw, name in FILTRATION_MODE_MAP.items():
-        mock_coordinator.data = {"MBF_PAR_FILT_MODE": raw}
-        result = ent.icon
-        assert isinstance(result, str)
-
-
-def test_icon_default(mock_coordinator):
-    props = make_props(icon="mdi:ph")
-    ent = VistaPoolSensor(mock_coordinator, "test_entry", "MBF_MEASURE_PH", props)
-    assert ent.icon == "mdi:ph"
-
-
 def test_suggested_display_precision(mock_coordinator):
     from custom_components.vistapool.const import SENSOR_DEFINITIONS
 
@@ -556,74 +541,6 @@ def make_sensor(props, key, data):
     mock_coord.config_entry.options = {}
     mock_coord.entry = mock_coord.config_entry
     return VistaPoolSensor(mock_coord, "test_entry", key, props)
-
-
-@pytest.mark.parametrize(
-    "raw,expected_icon",
-    [
-        (1, "mdi:water-boiler-auto"),  # auto
-        (0, "mdi:water-boiler-alert"),  # manual
-        (2, "mdi:water-boiler-alert"),  # heating
-        (3, "mdi:water-boiler-auto"),  # smart
-        (4, "mdi:water-boiler-auto"),  # intelligent
-        (13, "mdi:water-boiler-off"),  # backwash
-    ],
-)
-def test_icon_filtration_mode(mock_coordinator, raw, expected_icon):
-    props = make_props(device_class="filtration_mode")
-    ent = VistaPoolSensor(mock_coordinator, "test_entry", "MBF_PAR_FILT_MODE", props)
-    mock_coordinator.data = {"MBF_PAR_FILT_MODE": raw}
-    assert ent.icon == expected_icon
-
-
-def test_icon_ph_alarm(mock_coordinator):
-    props = make_props(icon="mdi:alert")
-    ent = VistaPoolSensor(mock_coordinator, "test_entry", "MBF_PH_STATUS_ALARM", props)
-    # No alarm
-    mock_coordinator.data = {"MBF_PH_STATUS_ALARM": 0}
-    assert ent.icon == "mdi:check-circle-outline"
-    # Alarm
-    mock_coordinator.data = {"MBF_PH_STATUS_ALARM": 3}
-    assert ent.icon == "mdi:alert"
-
-
-def test_icon_ph_status_alarm_default_icon(mock_coordinator):
-    props = make_props(icon="mdi:ph")
-    ent = VistaPoolSensor(mock_coordinator, "test_entry", "MBF_PH_STATUS_ALARM", props)
-    mock_coordinator.data = {"MBF_PH_STATUS_ALARM": 0}
-    assert ent.icon == "mdi:check-circle-outline"
-    mock_coordinator.data = {"MBF_PH_STATUS_ALARM": 1}
-    assert ent.icon == "mdi:alert"
-    mock_coordinator.data = {"MBF_PH_STATUS_ALARM": None}
-    assert ent.icon == "mdi:ph"
-
-
-def test_icon_hidro_current(mock_coordinator):
-    props = make_props(icon="mdi:air-humidifier")
-    ent = VistaPoolSensor(mock_coordinator, "test_entry", "MBF_HIDRO_CURRENT", props)
-    mock_coordinator.data = {"MBF_HIDRO_CURRENT": True}
-    assert ent.icon == "mdi:air-humidifier"
-    mock_coordinator.data = {"MBF_HIDRO_CURRENT": False}
-    assert ent.icon == "mdi:air-humidifier-off"
-
-
-def test_icon_default_icon():
-    ent = make_sensor({"icon": "mdi:test"}, "MBF_MEASURE_PH", {})
-    assert ent.icon == "mdi:test"
-
-
-def test_icon_ph_alarm_unknown_status_code():
-    """PH_STATUS_ALARM with a raw value not in the map falls back to _attr_icon."""
-    ent = make_sensor(
-        {"icon": "mdi:ph-fallback"}, "MBF_PH_STATUS_ALARM", {"MBF_PH_STATUS_ALARM": 99}
-    )
-    assert ent.icon == "mdi:ph-fallback"
-
-
-def test_icon_fallback_for_non_special_key():
-    """A key with a non-None raw value that has no special icon logic returns _attr_icon."""
-    ent = make_sensor({"icon": "mdi:gauge"}, "MBF_MEASURE_RX", {"MBF_MEASURE_RX": 500})
-    assert ent.icon == "mdi:gauge"
 
 
 def test_native_value_returns_none_when_filtration_off():

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -314,17 +314,6 @@ def test_available_unknown_type(mock_coordinator):
     assert ent.available is True
 
 
-def test_icon_on_off(mock_coordinator):
-    props = make_props(
-        switch_type="aux", icon_on="mdi:lightbulb-on", icon_off="mdi:lightbulb-off"
-    )
-    ent = VistaPoolSwitch(mock_coordinator, "test_entry", "aux1", props)
-    mock_coordinator.data = {"aux1": True}
-    assert ent.icon == "mdi:lightbulb-on"
-    mock_coordinator.data = {"aux1": False}
-    assert ent.icon == "mdi:lightbulb-off"
-
-
 @pytest.mark.asyncio
 async def test_switch_async_setup_entry_adds_entities(monkeypatch):
     class DummyEntry:
@@ -463,18 +452,6 @@ def test_available_relay_timer(mock_coordinator):
     # relay_*_enable missing → unavailable
     mock_coordinator.data = {}
     assert ent.available is False
-
-
-def test_icon_fallback_none(mock_coordinator):
-    props = make_props()
-    ent = VistaPoolSwitch(mock_coordinator, "test_entry", "foo", props)
-    assert ent.icon is None
-
-
-def test_icon_fallback_attr_icon(mock_coordinator):
-    props = make_props(icon="mdi:test")
-    ent = VistaPoolSwitch(mock_coordinator, "test_entry", "foo", props)
-    assert ent.icon == "mdi:test"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## refactor: ♻️ move entity icons and error messages to translation files

### 📋 Summary

This PR addresses two Gold-level quality scale requirements for the VistaPool integration:

1. **`icon-translations`** — Move all entity icon definitions from Python code to `icons.json`
2. **`exception-translations`** — Migrate all `ServiceValidationError` messages to use `translation_key` / `translation_placeholders`

### 🔀 Changes

#### icons.json (new file + 9 platform/const cleanups)

- ➕ Create `icons.json` with 103 entity icon definitions across 7 platforms
- ♻️ Remove all `icon`, `icon_on`, `icon_off` keys from entity definitions in `const.py` (132 lines)
- ♻️ Remove `_attr_icon`, `_icon_on`, `_icon_off` assignments from all platform `__init__` methods
- ♻️ Remove `@property def icon` overrides from sensor, binary_sensor, switch, number, button, light
- ✅ Remove 20 icon-related tests (no longer needed — icons served via `icons.json`)

#### Exception translations (**init**.py + helpers.py + translations)

- ♻️ Migrate all `ServiceValidationError` calls to use `translation_domain`, `translation_key`, `translation_placeholders`
- ➕ Add 13 exception translation keys to all 7 translation files (`en`, `cs`, `de`, `es`, `fr`, `it`, `pl`)
- ✅ Update all test assertions from `match="..."` to `exc_info.value.translation_key == "..."`

### ✅ Checks

- 656/656 tests passing
- `ruff check` — all passed
- `ruff format` — all formatted
- `basedpyright` — 0 new errors (only pre-existing `reportMissingImports` in dev container)
