### PR TITLE
fix(helpers): 🐛 handle cumulative relay speed bits for filtration

### DIFF
--- a/custom_components/vistapool/helpers.py
+++ b/custom_components/vistapool/helpers.py
@@ -240,12 +240,14 @@ def get_filtration_speed(data) -> int:
 
     par_filtration_conf = data.get("MBF_PAR_FILTRATION_CONF", 0)
     relay_speed = (relay_state & 0x0700) >> 8
-    if relay_speed == 1:
-        return 1  # Low
-    elif relay_speed == 2:
-        return 2  # Mid
-    elif relay_speed == 4:
+    # Check highest bit set – supports both individual-bit (1/2/4)
+    # and cumulative encodings (1/3/7) used by some controllers (#152).
+    if relay_speed & 0x04:
         return 3  # High
+    elif relay_speed & 0x02:
+        return 2  # Mid
+    elif relay_speed & 0x01:
+        return 1  # Low
 
     conf_speed = (par_filtration_conf & 0x0070) >> 4
     if conf_speed == 0:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -115,6 +115,24 @@ def test_get_filtration_speed_relay_speed_1():
     assert get_filtration_speed(d) == 1
 
 
+@pytest.mark.parametrize(
+    ("relay_state", "expected"),
+    [
+        (0x0302, 2),  # cumulative mid: bits 8+9 → relay_speed 0x03
+        (0x0702, 3),  # cumulative high: bits 8+9+10 → relay_speed 0x07
+    ],
+    ids=["cumulative-mid", "cumulative-high"],
+)
+def test_get_filtration_speed_cumulative_encoding(relay_state, expected):
+    """Controllers using cumulative (thermometer) speed bits (#152)."""
+    d = {
+        "MBF_RELAY_STATE": relay_state,
+        "MBF_PAR_FILTRATION_CONF": 0x0020,  # conf says high – must be ignored
+        "Filtration Pump": True,
+    }
+    assert get_filtration_speed(d) == expected
+
+
 @pytest.mark.parametrize("aux_bit", [0x0010, 0x0020, 0x0040])
 def test_get_filtration_speed_aux_bits_do_not_affect_speed(aux_bit):
     # filtration ON (0x0002), speed MID (0x0200), plus AUX relay bit set


### PR DESCRIPTION
## fix(helpers): 🐛 handle cumulative relay speed bits for filtration

### 📋 Summary

Fixes incorrect filtration speed reporting on controllers that use **cumulative (thermometer-style) encoding** for `MBF_RELAY_STATE` speed bits 8–10.

Resolves #152

---

### 🐛 Problem

The current filtration speed is read from `MBF_RELAY_STATE` bits 8–10 (mask `0x0700`). The previous implementation expected each speed level to set exactly **one** bit:

| value | bits  | speed |
| ----- | ----- | ----- |
| 1     | `001` | Low   |
| 2     | `010` | Mid   |
| 4     | `100` | High  |

Some controllers (e.g. **Hayward Aquarite HC LS**) use a **cumulative encoding** where higher levels also set all lower bits:

| value | bits  | speed |
| ----- | ----- | ----- |
| 1     | `001` | Low   |
| 3     | `011` | Mid   |
| 7     | `111` | High  |

When the timer set mid speed, `relay_speed` was `0x03` — unrecognized by the exact-match logic — causing a fallback to `MBF_PAR_FILTRATION_CONF`, which reported the _configured_ default speed (high) instead of the _actual_ running speed.

### ✅ Solution

Replace exact value matching (`== 1`, `== 2`, `== 4`) with **highest-bit-set checks** (`& 0x04`, `& 0x02`, `& 0x01`). This is fully backward compatible with both encoding styles:

| `relay_speed` | individual bits | cumulative bits | result  |
| ------------- | --------------- | --------------- | ------- |
| 1 (`001`)     | Low             | Low             | Low ✅  |
| 2 (`010`)     | Mid             | —               | Mid ✅  |
| 3 (`011`)     | —               | Mid             | Mid ✅  |
| 4 (`100`)     | High            | —               | High ✅ |
| 7 (`111`)     | —               | High            | High ✅ |

### 📝 Changes

- **`helpers.py`** — `get_filtration_speed()`: use bitwise highest-bit check instead of exact value matching
- **`test_helpers.py`** — add parametrized tests for cumulative encoding scenarios (`relay_speed` = `0x03` → mid, `0x07` → high)

### 🧪 Testing

- All **658 tests pass** ✅
- `ruff check` — all checks passed ✅
- `ruff format` — all files formatted ✅
- `basedpyright` — 0 new errors ✅
