### PR TITLE
chore(translations): 📝 add data_description to all config and options flow steps

### DIFF
--- a/custom_components/vistapool/translations/cs.json
+++ b/custom_components/vistapool/translations/cs.json
@@ -9,6 +9,12 @@
           "port": "TCP port pro Modbus (výchozí: 502).",
           "slave_id": "Modbus Adresa zařízení (výchozí: 1).",
           "modbus_framer": "Rámování protokolu: 'tcp' = Modbus TCP (MBAP header, pro TCP brány s konverzí), 'rtu' = RTU přes TCP (pro transparentní TCP brány)"
+        },
+        "data_description": {
+          "host": "Zadejte IP adresu Modbus TCP brány připojené k vašemu řadiči bazénu.",
+          "port": "Standardní port Modbus TCP. Změňte pouze pokud vaše brána používá nestandardní port.",
+          "slave_id": "Modbus slave adresa řadiče bazénu. Většina zařízení používá 1.",
+          "modbus_framer": "Vyberte 'tcp' pro brány, které převádějí mezi TCP a RTU. Vyberte 'rtu' pro transparentní brány, které přeposílají surové RTU rámce přes TCP."
         }
       },
       "user": {
@@ -27,6 +33,19 @@
           "use_filtration3": "Povolit 3. časovač filtrace pro automatický režim",
           "use_light": "Povolit relé Osvětlení",
           "use_cover_sensor": "Povolit senzor zakrytí bazénu"
+        },
+        "data_description": {
+          "name": "Používá se jako prefix pro všechna ID entit. Mezery se nahradí podtržítky, např. 'Bazén Západ' → sensor.bazen_zapad_measure_ph.",
+          "host": "Zadejte IP adresu Modbus TCP brány připojené k vašemu řadiči bazénu.",
+          "port": "Standardní port Modbus TCP. Změňte pouze pokud vaše brána používá nestandardní port.",
+          "scan_interval": "Jak často integrace čte data z řadiče bazénu.",
+          "slave_id": "Modbus slave adresa řadiče bazénu. Většina zařízení používá 1.",
+          "modbus_framer": "Vyberte 'tcp' pro brány, které převádějí mezi TCP a RTU. Vyberte 'rtu' pro transparentní brány, které přeposílají surové RTU rámce přes TCP.",
+          "use_filtration1": "Vytvoří entity časovačů pro konfiguraci automatického plánu filtrace.",
+          "use_filtration2": "Vytvoří entity časovačů pro konfiguraci automatického plánu filtrace.",
+          "use_filtration3": "Vytvoří entity časovačů pro konfiguraci automatického plánu filtrace.",
+          "use_light": "Vytvoří entity pro ovládání a sledování relé osvětlení bazénu.",
+          "use_cover_sensor": "Vytvoří binární senzor indikující, zda je bazén zakrytý nebo odkrytý."
         }
       }
     },
@@ -62,6 +81,22 @@
           "use_aux4": "Povolit relé Aux4",
           "unlock_advanced": "Odemknout pokročilé možnosti",
           "enable_backwash_option": "Povolit režim 'Backwash'"
+        },
+        "data_description": {
+          "scan_interval": "Nižší hodnoty zvyšují rychlost odezvy, ale generují více Modbus komunikace.",
+          "timer_resolution": "Určuje přesnost výběru času v entitách časovačů.",
+          "measure_when_filtration_off": "Pokud je vypnuto, chemická měření (pH, ORP atd.) probíhají pouze při běžícím filtračním čerpadle.",
+          "use_filtration1": "Vytvoří entity časovačů pro konfiguraci automatického plánu filtrace.",
+          "use_filtration2": "Vytvoří entity časovačů pro konfiguraci automatického plánu filtrace.",
+          "use_filtration3": "Vytvoří entity časovačů pro konfiguraci automatického plánu filtrace.",
+          "use_light": "Vytvoří entity pro ovládání a sledování relé osvětlení bazénu.",
+          "use_cover_sensor": "Vytvoří binární senzor a povolí entity související se zakrytím (redukce hydrolýzy, teplotní limit).",
+          "use_aux1": "Vytvoří přepínač a entity časovačů pro tento pomocný reléový výstup.",
+          "use_aux2": "Vytvoří přepínač a entity časovačů pro tento pomocný reléový výstup.",
+          "use_aux3": "Vytvoří přepínač a entity časovačů pro tento pomocný reléový výstup.",
+          "use_aux4": "Vytvoří přepínač a entity časovačů pro tento pomocný reléový výstup.",
+          "unlock_advanced": "Zadejte odemykací kód pro přístup k pokročilým nastavením (formát: prefix_zařízení + aktuální rok).",
+          "enable_backwash_option": "Přidá 'Backwash' do výběru režimu filtrace. Pouze pro systémy s manuálním vícecestným ventilem."
         }
       },
       "advanced": {
@@ -71,6 +106,11 @@
           "enable_backwash_option": "Povolit režim ‘Backwash’",
           "dev_overrides_enabled": "Povolit vývojářské přepisy hodnot",
           "dev_overrides": "Vývojářské přepisy (JSON objekt \"klíč\":hodnota)"
+        },
+        "data_description": {
+          "enable_backwash_option": "Přidá 'Backwash' do výběru režimu filtrace. Používejte opatrně — nesprávné použití může poškodit filtrační systém.",
+          "dev_overrides_enabled": "Pokud je povoleno, hodnoty z JSON přepisů se vkládají do dat koordinátoru pro testování.",
+          "dev_overrides": "JSON objekt, kde každý klíč je název Modbus registru a hodnota nahrazuje skutečné čtení."
         }
       }
     },

--- a/custom_components/vistapool/translations/de.json
+++ b/custom_components/vistapool/translations/de.json
@@ -9,6 +9,12 @@
           "port": "TCP-Port für Modbus (Standard: 502).",
           "slave_id": "Modbus-Geräteadresse (Standard: 1).",
           "modbus_framer": "Protokoll-Framing: 'tcp' = Modbus TCP (MBAP-Header, für Gateways mit Konvertierung), 'rtu' = RTU über TCP (für transparente TCP-Gateways)"
+        },
+        "data_description": {
+          "host": "Geben Sie die IP-Adresse des Modbus-TCP-Gateways ein, das mit Ihrem Pool-Controller verbunden ist.",
+          "port": "Standard-Modbus-TCP-Port. Ändern Sie ihn nur, wenn Ihr Gateway einen nicht standardmäßigen Port verwendet.",
+          "slave_id": "Die Modbus-Slave-Adresse des Pool-Controllers. Die meisten Setups verwenden 1.",
+          "modbus_framer": "Wählen Sie 'tcp' für Gateways, die zwischen TCP und RTU konvertieren. Wählen Sie 'rtu' für transparente Gateways, die rohe RTU-Frames über TCP weiterleiten."
         }
       },
       "user": {
@@ -27,6 +33,19 @@
           "use_filtration3": "3. Filter-Timer für Automatikbetrieb aktivieren",
           "use_light": "Licht-Relais aktivieren",
           "use_cover_sensor": "Abdeckungssensor aktivieren"
+        },
+        "data_description": {
+          "name": "Wird als Präfix für alle Entitäten-IDs verwendet. Leerzeichen werden zu Unterstrichen, z.B. 'Pool West' → sensor.pool_west_measure_ph.",
+          "host": "Geben Sie die IP-Adresse des Modbus-TCP-Gateways ein, das mit Ihrem Pool-Controller verbunden ist.",
+          "port": "Standard-Modbus-TCP-Port. Ändern Sie ihn nur, wenn Ihr Gateway einen nicht standardmäßigen Port verwendet.",
+          "scan_interval": "Wie oft die Integration Daten vom Pool-Controller liest.",
+          "slave_id": "Die Modbus-Slave-Adresse des Pool-Controllers. Die meisten Setups verwenden 1.",
+          "modbus_framer": "Wählen Sie 'tcp' für Gateways, die zwischen TCP und RTU konvertieren. Wählen Sie 'rtu' für transparente Gateways, die rohe RTU-Frames über TCP weiterleiten.",
+          "use_filtration1": "Erstellt Timer-Entitäten zur Konfiguration des automatischen Filterplans.",
+          "use_filtration2": "Erstellt Timer-Entitäten zur Konfiguration des automatischen Filterplans.",
+          "use_filtration3": "Erstellt Timer-Entitäten zur Konfiguration des automatischen Filterplans.",
+          "use_light": "Erstellt Entitäten zur Steuerung und Überwachung des Licht-Relais.",
+          "use_cover_sensor": "Erstellt einen Binärsensor, der anzeigt, ob die Poolabdeckung geöffnet oder geschlossen ist."
         }
       }
     },
@@ -62,6 +81,22 @@
           "use_aux4": "Aux4-Relais aktivieren",
           "unlock_advanced": "Erweiterte Optionen freischalten",
           "enable_backwash_option": "'Backwash'-Modus aktivieren"
+        },
+        "data_description": {
+          "scan_interval": "Niedrigere Werte erhöhen die Reaktionsfähigkeit, erzeugen aber mehr Modbus-Verkehr.",
+          "timer_resolution": "Bestimmt die Granularität der Zeitauswahl in Timer-Entitäten.",
+          "measure_when_filtration_off": "Wenn deaktiviert, werden chemische Messungen (pH, ORP usw.) nur bei laufender Filterpumpe durchgeführt.",
+          "use_filtration1": "Erstellt Timer-Entitäten zur Konfiguration des automatischen Filterplans.",
+          "use_filtration2": "Erstellt Timer-Entitäten zur Konfiguration des automatischen Filterplans.",
+          "use_filtration3": "Erstellt Timer-Entitäten zur Konfiguration des automatischen Filterplans.",
+          "use_light": "Erstellt Entitäten zur Steuerung und Überwachung des Licht-Relais.",
+          "use_cover_sensor": "Erstellt einen Binärsensor und aktiviert abdeckungsbezogene Entitäten (Hydrolyse-Reduzierung, Abschalttemperatur).",
+          "use_aux1": "Erstellt Schalter- und Timer-Entitäten für diesen Hilfsrelais-Ausgang.",
+          "use_aux2": "Erstellt Schalter- und Timer-Entitäten für diesen Hilfsrelais-Ausgang.",
+          "use_aux3": "Erstellt Schalter- und Timer-Entitäten für diesen Hilfsrelais-Ausgang.",
+          "use_aux4": "Erstellt Schalter- und Timer-Entitäten für diesen Hilfsrelais-Ausgang.",
+          "unlock_advanced": "Geben Sie den Freischaltcode ein, um auf erweiterte Einstellungen zuzugreifen (Format: Gerätepräfix + aktuelles Jahr).",
+          "enable_backwash_option": "Fügt 'Backwash' zur Auswahl des Filtermodus hinzu. Nur für Systeme mit manuellem Mehrwegeventil."
         }
       },
       "advanced": {
@@ -71,6 +106,11 @@
           "enable_backwash_option": "‘Backwash’-Modus aktivieren",
           "dev_overrides_enabled": "Entwickler-Overrides aktivieren",
           "dev_overrides": "Entwickler-Overrides (JSON Objekt \"Schlüssel\":Wert)"
+        },
+        "data_description": {
+          "enable_backwash_option": "Fügt 'Backwash' zur Auswahl des Filtermodus hinzu. Vorsichtig verwenden — unsachgemäße Nutzung kann Ihr Filtersystem beschädigen.",
+          "dev_overrides_enabled": "Wenn aktiviert, werden Werte aus dem Override-JSON zu Testzwecken in die Koordinator-Daten eingefügt.",
+          "dev_overrides": "Ein JSON-Objekt, bei dem jeder Schlüssel ein Modbus-Registername ist und jeder Wert den tatsächlichen Messwert überschreibt."
         }
       }
     },

--- a/custom_components/vistapool/translations/en.json
+++ b/custom_components/vistapool/translations/en.json
@@ -9,6 +9,12 @@
           "port": "TCP port for Modbus (default: 502).",
           "slave_id": "Modbus device address (default: 1).",
           "modbus_framer": "Protocol framing: 'tcp' = Modbus TCP (MBAP header, for gateways with conversion), 'rtu' = RTU over TCP (for transparent TCP gateways)"
+        },
+        "data_description": {
+          "host": "Enter the IP address of the Modbus TCP gateway connected to your pool controller.",
+          "port": "Standard Modbus TCP port. Change only if your gateway uses a non-standard port.",
+          "slave_id": "The Modbus slave address of the pool controller. Most setups use 1.",
+          "modbus_framer": "Select 'tcp' for gateways that convert between TCP and RTU. Select 'rtu' for transparent gateways that forward raw RTU frames over TCP."
         }
       },
       "user": {
@@ -27,6 +33,19 @@
           "use_filtration3": "Enable 3rd filtration timer for automatic mode",
           "use_light": "Enable Light Relay",
           "use_cover_sensor": "Enable Pool Cover Sensor"
+        },
+        "data_description": {
+          "name": "Used as a prefix for all entity IDs. Spaces become underscores, e.g. 'Pool West' → sensor.pool_west_measure_ph.",
+          "host": "Enter the IP address of the Modbus TCP gateway connected to your pool controller.",
+          "port": "Standard Modbus TCP port. Change only if your gateway uses a non-standard port.",
+          "scan_interval": "How often the integration reads data from the pool controller.",
+          "slave_id": "The Modbus slave address of the pool controller. Most setups use 1.",
+          "modbus_framer": "Select 'tcp' for gateways that convert between TCP and RTU. Select 'rtu' for transparent gateways that forward raw RTU frames over TCP.",
+          "use_filtration1": "Creates timer entities for configuring automatic filtration schedule.",
+          "use_filtration2": "Creates timer entities for configuring automatic filtration schedule.",
+          "use_filtration3": "Creates timer entities for configuring automatic filtration schedule.",
+          "use_light": "Creates entities to control and monitor the pool light relay.",
+          "use_cover_sensor": "Creates a binary sensor indicating whether the pool cover is open or closed."
         }
       }
     },
@@ -62,6 +81,22 @@
           "use_aux4": "Enable Aux4 Relay",
           "unlock_advanced": "Unlock advanced options",
           "enable_backwash_option": "Enable 'Backwash' mode"
+        },
+        "data_description": {
+          "scan_interval": "Lower values increase responsiveness but generate more Modbus traffic.",
+          "timer_resolution": "Determines the granularity of time selections in timer entities.",
+          "measure_when_filtration_off": "When disabled, chemical measurements (pH, ORP, etc.) are only taken while the filtration pump is running.",
+          "use_filtration1": "Creates timer entities for configuring automatic filtration schedule.",
+          "use_filtration2": "Creates timer entities for configuring automatic filtration schedule.",
+          "use_filtration3": "Creates timer entities for configuring automatic filtration schedule.",
+          "use_light": "Creates entities to control and monitor the pool light relay.",
+          "use_cover_sensor": "Creates a binary sensor and enables cover-related entities (hydrolysis cover reduction, shutdown temperature).",
+          "use_aux1": "Creates switch and timer entities for this auxiliary relay output.",
+          "use_aux2": "Creates switch and timer entities for this auxiliary relay output.",
+          "use_aux3": "Creates switch and timer entities for this auxiliary relay output.",
+          "use_aux4": "Creates switch and timer entities for this auxiliary relay output.",
+          "unlock_advanced": "Enter the unlock code to access advanced settings (format: device_prefix + current year).",
+          "enable_backwash_option": "Adds 'Backwash' to the filtration mode select. Only for systems with manual multi-way valves."
         }
       },
       "advanced": {
@@ -71,6 +106,11 @@
           "enable_backwash_option": "Enable ‘Backwash’ mode",
           "dev_overrides_enabled": "Enable developer overrides",
           "dev_overrides": "Developer overrides (JSON object of \"key\":value)"
+        },
+        "data_description": {
+          "enable_backwash_option": "Adds 'Backwash' to the filtration mode select. Use with caution — improper use may damage your filtration system.",
+          "dev_overrides_enabled": "When enabled, values from the override JSON are injected into coordinator data for testing.",
+          "dev_overrides": "A JSON object where each key is a Modbus register name and each value overrides the actual reading."
         }
       }
     },

--- a/custom_components/vistapool/translations/es.json
+++ b/custom_components/vistapool/translations/es.json
@@ -9,6 +9,12 @@
           "port": "Puerto TCP para Modbus (por defecto: 502).",
           "slave_id": "Dirección de dispositivo Modbus (por defecto: 1).",
           "modbus_framer": "Encuadre de protocolo: 'tcp' = Modbus TCP (cabecera MBAP, para pasarelas con conversión), 'rtu' = RTU sobre TCP (para pasarelas TCP transparentes)"
+        },
+        "data_description": {
+          "host": "Introduzca la dirección IP de la pasarela Modbus TCP conectada a su controlador de piscina.",
+          "port": "Puerto estándar de Modbus TCP. Cámbielo solo si su pasarela usa un puerto no estándar.",
+          "slave_id": "La dirección Modbus esclava del controlador de piscina. La mayoría de las configuraciones usan 1.",
+          "modbus_framer": "Seleccione 'tcp' para pasarelas que convierten entre TCP y RTU. Seleccione 'rtu' para pasarelas transparentes que reenvían tramas RTU sin procesar por TCP."
         }
       },
       "user": {
@@ -27,6 +33,19 @@
           "use_filtration3": "Activar el 3º temporizador de filtración para modo automático",
           "use_light": "Activar relé de luz",
           "use_cover_sensor": "Activar sensor de cubierta de piscina"
+        },
+        "data_description": {
+          "name": "Se usa como prefijo para todos los IDs de entidades. Los espacios se convierten en guiones bajos, p.ej. 'Piscina Oeste' → sensor.piscina_oeste_measure_ph.",
+          "host": "Introduzca la dirección IP de la pasarela Modbus TCP conectada a su controlador de piscina.",
+          "port": "Puerto estándar de Modbus TCP. Cámbielo solo si su pasarela usa un puerto no estándar.",
+          "scan_interval": "Con qué frecuencia la integración lee datos del controlador de piscina.",
+          "slave_id": "La dirección Modbus esclava del controlador de piscina. La mayoría de las configuraciones usan 1.",
+          "modbus_framer": "Seleccione 'tcp' para pasarelas que convierten entre TCP y RTU. Seleccione 'rtu' para pasarelas transparentes que reenvían tramas RTU sin procesar por TCP.",
+          "use_filtration1": "Crea entidades de temporizador para configurar el horario automático de filtración.",
+          "use_filtration2": "Crea entidades de temporizador para configurar el horario automático de filtración.",
+          "use_filtration3": "Crea entidades de temporizador para configurar el horario automático de filtración.",
+          "use_light": "Crea entidades para controlar y monitorear el relé de luz de la piscina.",
+          "use_cover_sensor": "Crea un sensor binario que indica si la cubierta de la piscina está abierta o cerrada."
         }
       }
     },
@@ -62,6 +81,22 @@
           "use_aux4": "Activar relé Aux4",
           "unlock_advanced": "Desbloquear opciones avanzadas",
           "enable_backwash_option": "Activar modo 'Backwash'"
+        },
+        "data_description": {
+          "scan_interval": "Valores más bajos aumentan la capacidad de respuesta pero generan más tráfico Modbus.",
+          "timer_resolution": "Determina la granularidad de las selecciones de tiempo en entidades de temporizador.",
+          "measure_when_filtration_off": "Cuando está desactivado, las mediciones químicas (pH, ORP, etc.) solo se realizan mientras la bomba de filtración está en funcionamiento.",
+          "use_filtration1": "Crea entidades de temporizador para configurar el horario automático de filtración.",
+          "use_filtration2": "Crea entidades de temporizador para configurar el horario automático de filtración.",
+          "use_filtration3": "Crea entidades de temporizador para configurar el horario automático de filtración.",
+          "use_light": "Crea entidades para controlar y monitorear el relé de luz de la piscina.",
+          "use_cover_sensor": "Crea un sensor binario y habilita entidades relacionadas con la cubierta (reducción de hidrólisis, temperatura de apagado).",
+          "use_aux1": "Crea entidades de interruptor y temporizador para esta salida de relé auxiliar.",
+          "use_aux2": "Crea entidades de interruptor y temporizador para esta salida de relé auxiliar.",
+          "use_aux3": "Crea entidades de interruptor y temporizador para esta salida de relé auxiliar.",
+          "use_aux4": "Crea entidades de interruptor y temporizador para esta salida de relé auxiliar.",
+          "unlock_advanced": "Introduzca el código de desbloqueo para acceder a configuraciones avanzadas (formato: prefijo_dispositivo + año actual).",
+          "enable_backwash_option": "Añade 'Backwash' a la selección del modo de filtración. Solo para sistemas con válvula multivía manual."
         }
       },
       "advanced": {
@@ -71,6 +106,11 @@
           "enable_backwash_option": "Activar modo ‘Backwash’",
           "dev_overrides_enabled": "Habilitar sobrescrituras de desarrollador",
           "dev_overrides": "Sobrescrituras de desarrollador (objeto JSON \"clave\":valor)"
+        },
+        "data_description": {
+          "enable_backwash_option": "Añade 'Backwash' a la selección del modo de filtración. Use con precaución — el uso inadecuado puede dañar su sistema de filtración.",
+          "dev_overrides_enabled": "Cuando está habilitado, los valores del JSON de sobrescritura se inyectan en los datos del coordinador para pruebas.",
+          "dev_overrides": "Un objeto JSON donde cada clave es un nombre de registro Modbus y cada valor reemplaza la lectura real."
         }
       }
     },

--- a/custom_components/vistapool/translations/fr.json
+++ b/custom_components/vistapool/translations/fr.json
@@ -9,6 +9,12 @@
           "port": "Port TCP pour Modbus (défaut : 502).",
           "slave_id": "Adresse de l’appareil Modbus (défaut : 1).",
           "modbus_framer": "Tramage du protocole : 'tcp' = Modbus TCP (en-tête MBAP, pour les passerelles avec conversion), 'rtu' = RTU sur TCP (pour les passerelles TCP transparentes)"
+        },
+        "data_description": {
+          "host": "Entrez l'adresse IP de la passerelle Modbus TCP connectée à votre contrôleur de piscine.",
+          "port": "Port Modbus TCP standard. Ne le modifiez que si votre passerelle utilise un port non standard.",
+          "slave_id": "L'adresse Modbus esclave du contrôleur de piscine. La plupart des configurations utilisent 1.",
+          "modbus_framer": "Sélectionnez 'tcp' pour les passerelles qui convertissent entre TCP et RTU. Sélectionnez 'rtu' pour les passerelles transparentes qui transmettent les trames RTU brutes via TCP."
         }
       },
       "user": {
@@ -27,6 +33,19 @@
           "use_filtration3": "Activer le 3ème minuteur de filtration pour le mode automatique",
           "use_light": "Activer le relais Lumière",
           "use_cover_sensor": "Activer le capteur de couverture de piscine"
+        },
+        "data_description": {
+          "name": "Utilisé comme préfixe pour tous les IDs d'entités. Les espaces deviennent des tirets bas, ex. 'Piscine Ouest' → sensor.piscine_ouest_measure_ph.",
+          "host": "Entrez l'adresse IP de la passerelle Modbus TCP connectée à votre contrôleur de piscine.",
+          "port": "Port Modbus TCP standard. Ne le modifiez que si votre passerelle utilise un port non standard.",
+          "scan_interval": "À quelle fréquence l'intégration lit les données du contrôleur de piscine.",
+          "slave_id": "L'adresse Modbus esclave du contrôleur de piscine. La plupart des configurations utilisent 1.",
+          "modbus_framer": "Sélectionnez 'tcp' pour les passerelles qui convertissent entre TCP et RTU. Sélectionnez 'rtu' pour les passerelles transparentes qui transmettent les trames RTU brutes via TCP.",
+          "use_filtration1": "Crée des entités de minuterie pour configurer le programme automatique de filtration.",
+          "use_filtration2": "Crée des entités de minuterie pour configurer le programme automatique de filtration.",
+          "use_filtration3": "Crée des entités de minuterie pour configurer le programme automatique de filtration.",
+          "use_light": "Crée des entités pour contrôler et surveiller le relais lumière de la piscine.",
+          "use_cover_sensor": "Crée un capteur binaire indiquant si la couverture de la piscine est ouverte ou fermée."
         }
       }
     },
@@ -62,6 +81,22 @@
           "use_aux4": "Activer le relais Aux4",
           "unlock_advanced": "Débloquer les options avancées",
           "enable_backwash_option": "Activer le mode 'Backwash'"
+        },
+        "data_description": {
+          "scan_interval": "Des valeurs plus basses augmentent la réactivité mais génèrent plus de trafic Modbus.",
+          "timer_resolution": "Détermine la granularité des sélections de temps dans les entités de minuterie.",
+          "measure_when_filtration_off": "Lorsque désactivé, les mesures chimiques (pH, ORP, etc.) ne sont effectuées que lorsque la pompe de filtration fonctionne.",
+          "use_filtration1": "Crée des entités de minuterie pour configurer le programme automatique de filtration.",
+          "use_filtration2": "Crée des entités de minuterie pour configurer le programme automatique de filtration.",
+          "use_filtration3": "Crée des entités de minuterie pour configurer le programme automatique de filtration.",
+          "use_light": "Crée des entités pour contrôler et surveiller le relais lumière de la piscine.",
+          "use_cover_sensor": "Crée un capteur binaire et active les entités liées à la couverture (réduction d'hydrolyse, température d'arrêt).",
+          "use_aux1": "Crée des entités d'interrupteur et de minuterie pour cette sortie relais auxiliaire.",
+          "use_aux2": "Crée des entités d'interrupteur et de minuterie pour cette sortie relais auxiliaire.",
+          "use_aux3": "Crée des entités d'interrupteur et de minuterie pour cette sortie relais auxiliaire.",
+          "use_aux4": "Crée des entités d'interrupteur et de minuterie pour cette sortie relais auxiliaire.",
+          "unlock_advanced": "Entrez le code de déverrouillage pour accéder aux paramètres avancés (format : préfixe_appareil + année en cours).",
+          "enable_backwash_option": "Ajoute 'Backwash' à la sélection du mode de filtration. Uniquement pour les systèmes avec vanne multivoies manuelle."
         }
       },
       "advanced": {
@@ -71,6 +106,11 @@
           "enable_backwash_option": "Activer le mode ‘Backwash’",
           "dev_overrides_enabled": "Activer les substitutions développeur",
           "dev_overrides": "Substitutions développeur (objet JSON \"clé\":valeur)"
+        },
+        "data_description": {
+          "enable_backwash_option": "Ajoute 'Backwash' à la sélection du mode de filtration. À utiliser avec précaution — une mauvaise utilisation peut endommager votre système de filtration.",
+          "dev_overrides_enabled": "Lorsqu'activé, les valeurs du JSON de substitution sont injectées dans les données du coordinateur pour les tests.",
+          "dev_overrides": "Un objet JSON où chaque clé est un nom de registre Modbus et chaque valeur remplace la lecture réelle."
         }
       }
     },

--- a/custom_components/vistapool/translations/it.json
+++ b/custom_components/vistapool/translations/it.json
@@ -9,6 +9,12 @@
           "port": "Porta TCP per Modbus (predefinito: 502).",
           "slave_id": "Indirizzo dispositivo Modbus (predefinito: 1).",
           "modbus_framer": "Framing del protocollo: 'tcp' = Modbus TCP (intestazione MBAP, per gateway con conversione), 'rtu' = RTU su TCP (per gateway TCP trasparenti)"
+        },
+        "data_description": {
+          "host": "Inserire l'indirizzo IP del gateway Modbus TCP collegato al controller della piscina.",
+          "port": "Porta Modbus TCP standard. Modificare solo se il gateway utilizza una porta non standard.",
+          "slave_id": "L'indirizzo Modbus slave del controller della piscina. La maggior parte delle configurazioni usa 1.",
+          "modbus_framer": "Selezionare 'tcp' per gateway che convertono tra TCP e RTU. Selezionare 'rtu' per gateway trasparenti che inoltrano frame RTU grezzi su TCP."
         }
       },
       "user": {
@@ -27,6 +33,19 @@
           "use_filtration3": "Abilita il 3° timer di filtrazione per la modalità automatica",
           "use_light": "Abilita relè luce",
           "use_cover_sensor": "Abilita sensore copertura piscina"
+        },
+        "data_description": {
+          "name": "Usato come prefisso per tutti gli ID entità. Gli spazi diventano trattini bassi, es. 'Piscina Ovest' → sensor.piscina_ovest_measure_ph.",
+          "host": "Inserire l'indirizzo IP del gateway Modbus TCP collegato al controller della piscina.",
+          "port": "Porta Modbus TCP standard. Modificare solo se il gateway utilizza una porta non standard.",
+          "scan_interval": "Quanto spesso l'integrazione legge i dati dal controller della piscina.",
+          "slave_id": "L'indirizzo Modbus slave del controller della piscina. La maggior parte delle configurazioni usa 1.",
+          "modbus_framer": "Selezionare 'tcp' per gateway che convertono tra TCP e RTU. Selezionare 'rtu' per gateway trasparenti che inoltrano frame RTU grezzi su TCP.",
+          "use_filtration1": "Crea entità timer per configurare la programmazione automatica della filtrazione.",
+          "use_filtration2": "Crea entità timer per configurare la programmazione automatica della filtrazione.",
+          "use_filtration3": "Crea entità timer per configurare la programmazione automatica della filtrazione.",
+          "use_light": "Crea entità per controllare e monitorare il relè luce della piscina.",
+          "use_cover_sensor": "Crea un sensore binario che indica se la copertura della piscina è aperta o chiusa."
         }
       }
     },
@@ -62,6 +81,22 @@
           "use_aux4": "Abilita relè Aux4",
           "unlock_advanced": "Sblocca opzioni avanzate",
           "enable_backwash_option": "Abilita modalità 'Backwash'"
+        },
+        "data_description": {
+          "scan_interval": "Valori più bassi aumentano la reattività ma generano più traffico Modbus.",
+          "timer_resolution": "Determina la granularità delle selezioni temporali nelle entità timer.",
+          "measure_when_filtration_off": "Quando disabilitato, le misurazioni chimiche (pH, ORP, ecc.) vengono effettuate solo quando la pompa di filtrazione è in funzione.",
+          "use_filtration1": "Crea entità timer per configurare la programmazione automatica della filtrazione.",
+          "use_filtration2": "Crea entità timer per configurare la programmazione automatica della filtrazione.",
+          "use_filtration3": "Crea entità timer per configurare la programmazione automatica della filtrazione.",
+          "use_light": "Crea entità per controllare e monitorare il relè luce della piscina.",
+          "use_cover_sensor": "Crea un sensore binario e abilita le entità relative alla copertura (riduzione idrolisi, temperatura di spegnimento).",
+          "use_aux1": "Crea entità interruttore e timer per questa uscita relè ausiliaria.",
+          "use_aux2": "Crea entità interruttore e timer per questa uscita relè ausiliaria.",
+          "use_aux3": "Crea entità interruttore e timer per questa uscita relè ausiliaria.",
+          "use_aux4": "Crea entità interruttore e timer per questa uscita relè ausiliaria.",
+          "unlock_advanced": "Inserire il codice di sblocco per accedere alle impostazioni avanzate (formato: prefisso_dispositivo + anno corrente).",
+          "enable_backwash_option": "Aggiunge 'Backwash' alla selezione della modalità di filtrazione. Solo per sistemi con valvola multivia manuale."
         }
       },
       "advanced": {
@@ -71,6 +106,11 @@
           "enable_backwash_option": "Abilita modalità ‘Backwash’",
           "dev_overrides_enabled": "Abilita override sviluppatore",
           "dev_overrides": "Override sviluppatore (oggetto JSON \"chiave\":valore)"
+        },
+        "data_description": {
+          "enable_backwash_option": "Aggiunge 'Backwash' alla selezione della modalità di filtrazione. Usare con cautela — un uso improprio può danneggiare il sistema di filtrazione.",
+          "dev_overrides_enabled": "Quando abilitato, i valori dal JSON di override vengono iniettati nei dati del coordinatore per i test.",
+          "dev_overrides": "Un oggetto JSON dove ogni chiave è un nome di registro Modbus e ogni valore sostituisce la lettura reale."
         }
       }
     },

--- a/custom_components/vistapool/translations/pl.json
+++ b/custom_components/vistapool/translations/pl.json
@@ -9,6 +9,12 @@
           "port": "Port TCP dla Modbus (domyślnie: 502).",
           "slave_id": "Adres urządzenia Modbus (domyślnie: 1).",
           "modbus_framer": "Ramkowanie protokołu: 'tcp' = Modbus TCP (nagłówek MBAP, dla bramek z konwersją), 'rtu' = RTU przez TCP (dla transparentnych bramek TCP)"
+        },
+        "data_description": {
+          "host": "Wprowadź adres IP bramki Modbus TCP podłączonej do kontrolera basenu.",
+          "port": "Standardowy port Modbus TCP. Zmień tylko jeśli bramka używa niestandardowego portu.",
+          "slave_id": "Adres Modbus slave kontrolera basenu. Większość konfiguracji używa 1.",
+          "modbus_framer": "Wybierz 'tcp' dla bramek konwertujących między TCP a RTU. Wybierz 'rtu' dla transparentnych bramek przesyłających surowe ramki RTU przez TCP."
         }
       },
       "user": {
@@ -27,6 +33,19 @@
           "use_filtration3": "Włącz 3. timer filtracji w trybie automatycznym",
           "use_light": "Włącz przekaźnik oświetlenia",
           "use_cover_sensor": "Włącz czujnik przykrycia basenu"
+        },
+        "data_description": {
+          "name": "Używana jako prefiks dla wszystkich ID encji. Spacje zamieniane są na podkreślenia, np. 'Basen Zachodni' → sensor.basen_zachodni_measure_ph.",
+          "host": "Wprowadź adres IP bramki Modbus TCP podłączonej do kontrolera basenu.",
+          "port": "Standardowy port Modbus TCP. Zmień tylko jeśli bramka używa niestandardowego portu.",
+          "scan_interval": "Jak często integracja odczytuje dane z kontrolera basenu.",
+          "slave_id": "Adres Modbus slave kontrolera basenu. Większość konfiguracji używa 1.",
+          "modbus_framer": "Wybierz 'tcp' dla bramek konwertujących między TCP a RTU. Wybierz 'rtu' dla transparentnych bramek przesyłających surowe ramki RTU przez TCP.",
+          "use_filtration1": "Tworzy encje timerów do konfiguracji automatycznego harmonogramu filtracji.",
+          "use_filtration2": "Tworzy encje timerów do konfiguracji automatycznego harmonogramu filtracji.",
+          "use_filtration3": "Tworzy encje timerów do konfiguracji automatycznego harmonogramu filtracji.",
+          "use_light": "Tworzy encje do sterowania i monitorowania przekaźnika oświetlenia basenu.",
+          "use_cover_sensor": "Tworzy czujnik binarny wskazujący, czy przykrycie basenu jest otwarte czy zamknięte."
         }
       }
     },
@@ -62,6 +81,22 @@
           "use_aux4": "Włącz przekaźnik Aux4",
           "unlock_advanced": "Odblokuj opcje zaawansowane",
           "enable_backwash_option": "Włącz tryb 'Backwash'"
+        },
+        "data_description": {
+          "scan_interval": "Niższe wartości zwiększają responsywność, ale generują więcej ruchu Modbus.",
+          "timer_resolution": "Określa dokładność wyboru czasu w encjach timerów.",
+          "measure_when_filtration_off": "Gdy wyłączone, pomiary chemiczne (pH, ORP itp.) są wykonywane tylko podczas pracy pompy filtracyjnej.",
+          "use_filtration1": "Tworzy encje timerów do konfiguracji automatycznego harmonogramu filtracji.",
+          "use_filtration2": "Tworzy encje timerów do konfiguracji automatycznego harmonogramu filtracji.",
+          "use_filtration3": "Tworzy encje timerów do konfiguracji automatycznego harmonogramu filtracji.",
+          "use_light": "Tworzy encje do sterowania i monitorowania przekaźnika oświetlenia basenu.",
+          "use_cover_sensor": "Tworzy czujnik binarny i umożliwia encje związane z przykryciem (redukcja hydrolizy, temperatura wyłączenia).",
+          "use_aux1": "Tworzy encje przełącznika i timera dla tego pomocniczego wyjścia przekaźnikowego.",
+          "use_aux2": "Tworzy encje przełącznika i timera dla tego pomocniczego wyjścia przekaźnikowego.",
+          "use_aux3": "Tworzy encje przełącznika i timera dla tego pomocniczego wyjścia przekaźnikowego.",
+          "use_aux4": "Tworzy encje przełącznika i timera dla tego pomocniczego wyjścia przekaźnikowego.",
+          "unlock_advanced": "Wprowadź kod odblokowujący, aby uzyskać dostęp do ustawień zaawansowanych (format: prefiks_urządzenia + bieżący rok).",
+          "enable_backwash_option": "Dodaje 'Backwash' do wyboru trybu filtracji. Tylko dla systemów z ręcznym zaworem wielodrożnym."
         }
       },
       "advanced": {
@@ -71,6 +106,11 @@
           "enable_backwash_option": "Włącz tryb ‘Backwash’",
           "dev_overrides_enabled": "Włącz nadpisania deweloperskie",
           "dev_overrides": "Nadpisania deweloperskie (obiekt JSON \"klucz\":wartość)"
+        },
+        "data_description": {
+          "enable_backwash_option": "Dodaje 'Backwash' do wyboru trybu filtracji. Używaj ostrożnie — niewłaściwe użycie może uszkodzić system filtracji.",
+          "dev_overrides_enabled": "Gdy włączone, wartości z JSON nadpisań są wstrzykiwane do danych koordynatora w celach testowych.",
+          "dev_overrides": "Obiekt JSON, gdzie każdy klucz to nazwa rejestru Modbus, a wartość zastępuje rzeczywisty odczyt."
         }
       }
     },


### PR DESCRIPTION
## 📝 add `data_description` to all config and options flow steps

### 📋 Summary

Adds `data_description` blocks to all 7 translation files (cs, de, en, es, fr, it, pl) for every config flow and options flow step. This provides contextual help text below form fields in the Home Assistant UI, improving the setup experience for users.

### ✨ What changed

- ➕ Added `data_description` to **`config.step.reconfigure`** (4 fields: host, port, slave_id, modbus_framer)
- ➕ Added `data_description` to **`config.step.user`** (11 fields: name, host, port, scan_interval, slave_id, modbus_framer, use_filtration1–3, use_light, use_cover_sensor)
- ➕ Added `data_description` to **`options.step.init`** (14 fields: scan_interval, timer_resolution, measure_when_filtration_off, use_filtration1–3, use_light, use_cover_sensor, use_aux1–4, unlock_advanced, enable_backwash_option)
- ➕ Added `data_description` to **`options.step.advanced`** (3 fields: enable_backwash_option, dev_overrides_enabled, dev_overrides)

### 🌍 Languages

All 7 supported languages updated with native translations:

| Language   | File      |
| ---------- | --------- |
| 🇨🇿 Czech   | `cs.json` |
| 🇩🇪 German  | `de.json` |
| 🇬🇧 English | `en.json` |
| 🇪🇸 Spanish | `es.json` |
| 🇫🇷 French  | `fr.json` |
| 🇮🇹 Italian | `it.json` |
| 🇵🇱 Polish  | `pl.json` |

### 🎯 Motivation

- Fulfills the **`config-flow` → `data_description`** requirement from the [HA Integration Quality Scale checklist](https://developers.home-assistant.io/docs/core/integration-quality-scale/checklist) (Bronze tier)
- Provides users with inline contextual help during setup and configuration, reducing guesswork and support questions

### 🧪 Testing

- ✅ All 7 JSON files validated (`python -m json.tool`)
- ✅ All 658 tests pass
- ✅ No functional code changes — translation files only
