### PR TITLE
feat(sensor): ✨ add filtration pump power and energy sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If you find this integration useful, consider supporting its development:
 - **Reliable single Modbus TCP connection per device/hub** (improves stability, avoids connection issues).
 - **Multi-hub support**: Add multiple VistaPool devices, each with a custom prefix (used in entity IDs).
 - **Sensors**:
-  pH, Redox (ORP), Salt, Conductivity, Water Temperature, Ionization, Hydrolysis Intensity/Voltage, Device Time, Status/Alarm bits, Filtration speed _(if supported)_, Backwash remaining time _(if Besgo automatic filter valve is configured)_.
+  pH, Redox (ORP), Salt, Conductivity, Water Temperature, Ionization, Hydrolysis Intensity/Voltage, Device Time, Status/Alarm bits, Filtration speed _(if supported)_, Backwash remaining time _(if Besgo automatic filter valve is configured)_, **Filtration pump power & energy** _(if pump wattage is configured in Options)_.
 - **Numbers**:
   Setpoints for pH, Redox, Chlorine, Temperature, Hydrolysis production, Hydrolysis cover reduction % _(if hydrolysis module present + cover sensor enabled)_, Hydrolysis shutdown temperature threshold _(if hydrolysis module + temperature sensor + cover sensor enabled)_.
 - **Switches**:
@@ -158,6 +158,7 @@ After initial setup, you can fine-tune the integration:
 - **Enable/disable relays** (Light and AUX1–AUX4 are default: disabled)
 - **Enable/disable cover sensor** (pool cover input — enables cover-related entities; default: disabled)
 - **Enable/disable filtration timers** (filtration1, filtration2, filtration3)
+- **Filtration pump power** (rated wattage in W; when non-zero, creates instantaneous power and cumulative energy sensors usable in the Energy dashboard)
 - **Unlock advanced features** (see [below](#advanced-options-unlocking-backwash-mode))
 
 Go to **Settings → Devices & Services → VistaPool Modbus Integration → Configure**  
@@ -229,7 +230,8 @@ Entities are lowercased and prefixed by your custom name, e.g. `sensor.pool1_fil
 - **Sensors**:
   `sensor.<name>_measure_ph`, `sensor.<name>_measure_temperature`, `sensor.<name>_filt_mode`,
   `sensor.<name>_filtration_speed` _(if supported)_,
-  `sensor.<name>_filtvalve_remaining` _(if Besgo valve configured)_
+  `sensor.<name>_filtvalve_remaining` _(if Besgo valve configured)_,
+  `sensor.<name>_filtration_pump_power`, `sensor.<name>_filtration_pump_energy` _(if pump wattage configured in Options)_
 - **Numbers**:
   `number.<name>_hidro`, `number.<name>_ph1`,
   `number.<name>_heating_temp` _(if supported)_,
@@ -262,6 +264,7 @@ Entities are lowercased and prefixed by your custom name, e.g. `sensor.pool1_fil
 - **Besgo valve entities** (`sensor filtvalve_remaining`, `select filtvalve_period_minutes`, `select filtvalve_mode`): Only created when Besgo valve is detected (`MBF_PAR_FILTVALVE_ENABLE = 1`).
 - **Reload on options change:** Integration is reloaded automatically on option changes.
 - **Filtration speed sensor/control:** Only available for variable-speed pump models.
+- **Filtration pump power & energy sensors:** Created only when a non-zero pump wattage is set in Options. `sensor.<name>_filtration_pump_power` (W) shows instantaneous consumption; `sensor.<name>_filtration_pump_energy` (Wh) accumulates total energy — both can be added to the **Energy dashboard** under _Individual devices_.
 - **Boost control (select):** Only if Hydro/Electrolysis module is present.
 - **Reset Alarm button:** Allows clearing of error and alarm states from HA.
 

--- a/custom_components/vistapool/config_flow.py
+++ b/custom_components/vistapool/config_flow.py
@@ -30,6 +30,7 @@ from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 from homeassistant.util import slugify
 
 from .const import (
+    CONF_FILTRATION_PUMP_POWER,
     DEFAULT_MODBUS_FRAMER,
     DEFAULT_NAME,
     DEFAULT_PORT,
@@ -102,6 +103,10 @@ class VistaPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
                         ]
                     )
                 ),
+                vol.Optional(
+                    CONF_FILTRATION_PUMP_POWER,
+                    default=0,
+                ): int,
                 vol.Optional(
                     "use_filtration1",
                     default=True,

--- a/custom_components/vistapool/config_flow.py
+++ b/custom_components/vistapool/config_flow.py
@@ -106,7 +106,7 @@ class VistaPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
                 vol.Optional(
                     CONF_FILTRATION_PUMP_POWER,
                     default=0,
-                ): int,
+                ): vol.All(int, vol.Range(min=0)),
                 vol.Optional(
                     "use_filtration1",
                     default=True,

--- a/custom_components/vistapool/const.py
+++ b/custom_components/vistapool/const.py
@@ -57,6 +57,8 @@ DEFAULT_PORT = 502
 DEFAULT_SLAVE_ID = 1
 DEFAULT_MODBUS_FRAMER = "tcp"  # "tcp" = standard Modbus TCP (MBAP header), "rtu" = RTU over TCP (no MBAP, CRC)
 
+CONF_FILTRATION_PUMP_POWER = "filtration_pump_power"
+
 MANUAL_FILTRATION_REGISTER = 0x0413
 EEPROM_SAVE_REGISTER = 0x02F0
 EXEC_REGISTER = 0x02F5
@@ -290,6 +292,13 @@ SENSOR_DEFINITIONS = {
         "state_class": None,
         "display_precision": 0,
         "entity_registry_enabled_default": False,
+    },
+    CONF_FILTRATION_PUMP_POWER: {
+        "name": "Filtration Pump Power",
+        "unit": "W",
+        "device_class": SensorDeviceClass.POWER,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "display_precision": 0,
     },
 }
 

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -31,6 +31,7 @@ from homeassistant.util import slugify
 
 from .const import (
     CAPABILITY_KEYS,
+    CONF_FILTRATION_PUMP_POWER,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     FOLLOW_UP_REFRESH_DELAY,
@@ -253,6 +254,11 @@ class VistaPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if cd is not None and cd > 0:
                     filt_remaining = max(filt_remaining or 0, cd)
             data["FILTRATION_REMAINING"] = filt_remaining
+
+            pump_power = int(self.entry.options.get(CONF_FILTRATION_PUMP_POWER, 0) or 0)
+            data[CONF_FILTRATION_PUMP_POWER] = (
+                pump_power if data.get("Filtration Pump") else 0
+            )
 
             if self.auto_time_sync:
                 if is_device_time_out_of_sync(data, self.hass):

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -255,8 +255,12 @@ class VistaPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     filt_remaining = max(filt_remaining or 0, cd)
             data["FILTRATION_REMAINING"] = filt_remaining
 
-            pump_power = max(0, int(self.entry.options.get(CONF_FILTRATION_PUMP_POWER, 0) or 0))
-            data[CONF_FILTRATION_PUMP_POWER] = pump_power if data.get("Filtration Pump") else 0
+            pump_power = max(
+                0, int(self.entry.options.get(CONF_FILTRATION_PUMP_POWER, 0) or 0)
+            )
+            data[CONF_FILTRATION_PUMP_POWER] = (
+                pump_power if data.get("Filtration Pump") else 0
+            )
 
             if self.auto_time_sync:
                 if is_device_time_out_of_sync(data, self.hass):

--- a/custom_components/vistapool/coordinator.py
+++ b/custom_components/vistapool/coordinator.py
@@ -255,10 +255,8 @@ class VistaPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     filt_remaining = max(filt_remaining or 0, cd)
             data["FILTRATION_REMAINING"] = filt_remaining
 
-            pump_power = int(self.entry.options.get(CONF_FILTRATION_PUMP_POWER, 0) or 0)
-            data[CONF_FILTRATION_PUMP_POWER] = (
-                pump_power if data.get("Filtration Pump") else 0
-            )
+            pump_power = max(0, int(self.entry.options.get(CONF_FILTRATION_PUMP_POWER, 0) or 0))
+            data[CONF_FILTRATION_PUMP_POWER] = pump_power if data.get("Filtration Pump") else 0
 
             if self.auto_time_sync:
                 if is_device_time_out_of_sync(data, self.hass):

--- a/custom_components/vistapool/options_flow.py
+++ b/custom_components/vistapool/options_flow.py
@@ -25,7 +25,11 @@ from homeassistant.const import CONF_NAME
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 from homeassistant.util import slugify
 
-from .const import DEFAULT_SCAN_INTERVAL, DEFAULT_TIMER_RESOLUTION
+from .const import (
+    CONF_FILTRATION_PUMP_POWER,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_TIMER_RESOLUTION,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,6 +78,10 @@ class VistaPoolOptionsFlowHandler(config_entries.OptionsFlow):
                 "measure_when_filtration_off",
                 default=options.get("measure_when_filtration_off", False),
             ): bool,
+            vol.Optional(
+                CONF_FILTRATION_PUMP_POWER,
+                default=options.get(CONF_FILTRATION_PUMP_POWER, 0),
+            ): int,
             vol.Optional(
                 "use_filtration1",
                 default=options.get("use_filtration1", True),

--- a/custom_components/vistapool/options_flow.py
+++ b/custom_components/vistapool/options_flow.py
@@ -81,7 +81,7 @@ class VistaPoolOptionsFlowHandler(config_entries.OptionsFlow):
             vol.Optional(
                 CONF_FILTRATION_PUMP_POWER,
                 default=options.get(CONF_FILTRATION_PUMP_POWER, 0),
-            ): int,
+            ): vol.All(int, vol.Range(min=0)),
             vol.Optional(
                 "use_filtration1",
                 default=options.get("use_filtration1", True),

--- a/custom_components/vistapool/sensor.py
+++ b/custom_components/vistapool/sensor.py
@@ -15,6 +15,7 @@
 """VistaPool Integration for Home Assistant - Sensor Module"""
 
 import logging
+import math
 from datetime import datetime
 from typing import Any
 
@@ -405,7 +406,9 @@ class VistaPoolFiltrationEnergySensor(VistaPoolEntity, SensorEntity, RestoreEnti
             "unknown",
         ):
             try:
-                self._total_wh = float(last_state.state)
+                restored = float(last_state.state)
+                if math.isfinite(restored) and restored >= 0:
+                    self._total_wh = restored
             except ValueError:
                 pass
 

--- a/custom_components/vistapool/sensor.py
+++ b/custom_components/vistapool/sensor.py
@@ -18,12 +18,19 @@ import logging
 from datetime import datetime
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util import dt as dt_util
 
 from . import VistaPoolConfigEntry
-from .const import SENSOR_DEFINITIONS
+from .const import CONF_FILTRATION_PUMP_POWER, SENSOR_DEFINITIONS
 from .coordinator import VistaPoolCoordinator
 from .entity import VistaPoolEntity
 from .helpers import (
@@ -67,8 +74,10 @@ PH_STATUS_ALARM_MAP = {
 }
 
 
-def _should_skip_sensor(key: str, data: dict) -> bool:
+def _should_skip_sensor(key: str, data: dict, options: dict | None = None) -> bool:
     """Return True if a sensor entity should not be created."""
+    if key == CONF_FILTRATION_PUMP_POWER:
+        return not int((options or {}).get(CONF_FILTRATION_PUMP_POWER, 0) or 0)
     if key == "MBF_MEASURE_TEMPERATURE" and not bool(
         data.get("MBF_PAR_TEMPERATURE_ACTIVE")
     ):
@@ -137,7 +146,7 @@ async def async_setup_entry(
 
     # Loop through the defined sensors and create SensorEntity instances
     for key, props in SENSOR_DEFINITIONS.items():
-        if _should_skip_sensor(key, coordinator.data):
+        if _should_skip_sensor(key, coordinator.data, dict(entry.options)):
             continue
 
         entities.append(
@@ -148,6 +157,13 @@ async def async_setup_entry(
                 props,
             )
         )
+
+    pump_power = int(entry.options.get(CONF_FILTRATION_PUMP_POWER, 0) or 0)
+    if pump_power > 0:
+        entities.append(
+            VistaPoolFiltrationEnergySensor(coordinator, entry.entry_id, pump_power)
+        )
+
     async_add_entities(entities)
 
 
@@ -347,3 +363,64 @@ class VistaPoolSensor(VistaPoolEntity, SensorEntity):  # type: ignore[reportInco
                 return ["off", "idle", "base"]
             return ["off", "idle", "acid", "base", "both"]
         return None  # pragma: no cover
+
+
+class VistaPoolFiltrationEnergySensor(VistaPoolEntity, SensorEntity, RestoreEntity):  # type: ignore[reportIncompatibleVariableOverride]
+    """Cumulative energy consumed by the filtration pump (Wh).
+
+    Integrates instantaneous power over time using coordinator update timestamps.
+    Suitable for the Energy dashboard "Individual devices" energy tracking.
+    """
+
+    _winter_mode_active = False
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
+    _attr_translation_key = "filtration_pump_energy"
+
+    def __init__(
+        self,
+        coordinator: VistaPoolCoordinator,
+        entry_id: str,
+        pump_power_w: int,
+    ) -> None:
+        super().__init__(coordinator, entry_id)
+        self._pump_power_w = pump_power_w
+        self._attr_suggested_object_id = (
+            f"{coordinator.device_slug}_filtration_pump_energy"
+        )
+        device_id = coordinator.entry.unique_id or entry_id
+        self._attr_unique_id = f"{device_id}_filtration_pump_energy"
+        self._total_wh: float = 0.0
+        self._last_update: datetime | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last known energy value from entity state after restart."""
+        await super().async_added_to_hass()
+        if (
+            last_state := await self.async_get_last_state()
+        ) and last_state.state not in (
+            None,
+            "unavailable",
+            "unknown",
+        ):
+            try:
+                self._total_wh = float(last_state.state)
+            except ValueError:
+                pass
+
+    def _handle_coordinator_update(self) -> None:
+        """Accumulate energy on each coordinator update."""
+        now = dt_util.utcnow()
+        if self._last_update is not None and self.coordinator.data.get(
+            "Filtration Pump"
+        ):
+            elapsed_h = (now - self._last_update).total_seconds() / 3600.0
+            self._total_wh += self._pump_power_w * elapsed_h
+        self._last_update = now
+        super()._handle_coordinator_update()
+
+    @property
+    def native_value(self) -> float:  # type: ignore[override]
+        """Return accumulated energy in Wh."""
+        return round(self._total_wh, 3)

--- a/custom_components/vistapool/sensor.py
+++ b/custom_components/vistapool/sensor.py
@@ -394,6 +394,7 @@ class VistaPoolFiltrationEnergySensor(VistaPoolEntity, SensorEntity, RestoreEnti
         self._attr_unique_id = f"{device_id}_filtration_pump_energy"
         self._total_wh: float = 0.0
         self._last_update: datetime | None = None
+        self._last_pump_on: bool = False
 
     async def async_added_to_hass(self) -> None:
         """Restore last known energy value from entity state after restart."""
@@ -415,12 +416,11 @@ class VistaPoolFiltrationEnergySensor(VistaPoolEntity, SensorEntity, RestoreEnti
     def _handle_coordinator_update(self) -> None:
         """Accumulate energy on each coordinator update."""
         now = dt_util.utcnow()
-        if self._last_update is not None and self.coordinator.data.get(
-            "Filtration Pump"
-        ):
+        if self._last_update is not None and self._last_pump_on:
             elapsed_h = (now - self._last_update).total_seconds() / 3600.0
             self._total_wh += self._pump_power_w * elapsed_h
         self._last_update = now
+        self._last_pump_on = bool(self.coordinator.data.get("Filtration Pump"))
         super()._handle_coordinator_update()
 
     @property

--- a/custom_components/vistapool/sensor.py
+++ b/custom_components/vistapool/sensor.py
@@ -77,7 +77,7 @@ PH_STATUS_ALARM_MAP = {
 def _should_skip_sensor(key: str, data: dict, options: dict | None = None) -> bool:
     """Return True if a sensor entity should not be created."""
     if key == CONF_FILTRATION_PUMP_POWER:
-        return not int((options or {}).get(CONF_FILTRATION_PUMP_POWER, 0) or 0)
+        return int((options or {}).get(CONF_FILTRATION_PUMP_POWER, 0) or 0) <= 0
     if key == "MBF_MEASURE_TEMPERATURE" and not bool(
         data.get("MBF_PAR_TEMPERATURE_ACTIVE")
     ):
@@ -144,9 +144,9 @@ async def async_setup_entry(
         _LOGGER.warning("No data from Modbus, skipping sensor setup!")
         return
 
-    # Loop through the defined sensors and create SensorEntity instances
+    options = dict(entry.options)
     for key, props in SENSOR_DEFINITIONS.items():
-        if _should_skip_sensor(key, coordinator.data, dict(entry.options)):
+        if _should_skip_sensor(key, coordinator.data, options):
             continue
 
         entities.append(

--- a/custom_components/vistapool/translations/cs.json
+++ b/custom_components/vistapool/translations/cs.json
@@ -45,7 +45,8 @@
           "use_filtration2": "Vytvoří entity časovačů pro konfiguraci automatického plánu filtrace.",
           "use_filtration3": "Vytvoří entity časovačů pro konfiguraci automatického plánu filtrace.",
           "use_light": "Vytvoří entity pro ovládání a sledování relé osvětlení bazénu.",
-          "use_cover_sensor": "Vytvoří binární senzor indikující, zda je bazén zakrytý nebo odkrytý."
+          "use_cover_sensor": "Vytvoří binární senzor indikující, zda je bazén zakrytý nebo odkrytý.",
+          "filtration_pump_power": "Zadejte jmenovitý příkon filtračního čerpadla. Při nenulové hodnotě se vytvoří dva senzory: okamžitý příkon (W) a kumulativní spotřeba energie (Wh), oba použitelné v přehledu energie."
         }
       }
     },
@@ -80,7 +81,8 @@
           "use_aux3": "Povolit relé Aux3",
           "use_aux4": "Povolit relé Aux4",
           "unlock_advanced": "Odemknout pokročilé možnosti",
-          "enable_backwash_option": "Povolit režim 'Backwash'"
+          "enable_backwash_option": "Povolit režim 'Backwash'",
+          "filtration_pump_power": "Příkon filtračního čerpadla (W, 0 = zakázáno)"
         },
         "data_description": {
           "scan_interval": "Nižší hodnoty zvyšují rychlost odezvy, ale generují více Modbus komunikace.",
@@ -96,7 +98,8 @@
           "use_aux3": "Vytvoří přepínač a entity časovačů pro tento pomocný reléový výstup.",
           "use_aux4": "Vytvoří přepínač a entity časovačů pro tento pomocný reléový výstup.",
           "unlock_advanced": "Zadejte odemykací kód pro přístup k pokročilým nastavením (formát: prefix_zařízení + aktuální rok).",
-          "enable_backwash_option": "Přidá 'Backwash' do výběru režimu filtrace. Pouze pro systémy s manuálním vícecestným ventilem."
+          "enable_backwash_option": "Přidá 'Backwash' do výběru režimu filtrace. Pouze pro systémy s manuálním vícecestným ventilem.",
+          "filtration_pump_power": "Zadejte jmenovitý příkon filtračního čerpadla. Při nenulové hodnotě se vytvoří dva senzory: okamžitý příkon (W) a kumulativní spotřeba energie (Wh), oba použitelné v přehledu energie."
         }
       },
       "advanced": {
@@ -201,6 +204,12 @@
       },
       "filtration_remaining": {
         "name": "Zbývající čas filtrace"
+      },
+      "filtration_pump_power": {
+        "name": "Příkon filtračního čerpadla"
+      },
+      "filtration_pump_energy": {
+        "name": "Spotřeba energie filtrace"
       }
     },
     "binary_sensor": {

--- a/custom_components/vistapool/translations/cs.json
+++ b/custom_components/vistapool/translations/cs.json
@@ -32,7 +32,8 @@
           "use_filtration2": "Povolit 2. časovač filtrace pro automatický režim",
           "use_filtration3": "Povolit 3. časovač filtrace pro automatický režim",
           "use_light": "Povolit relé Osvětlení",
-          "use_cover_sensor": "Povolit senzor zakrytí bazénu"
+          "use_cover_sensor": "Povolit senzor zakrytí bazénu",
+          "filtration_pump_power": "Příkon filtračního čerpadla (W, 0 = zakázáno)"
         },
         "data_description": {
           "name": "Používá se jako prefix pro všechna ID entit. Mezery se nahradí podtržítky, např. 'Bazén Západ' → sensor.bazen_zapad_measure_ph.",

--- a/custom_components/vistapool/translations/de.json
+++ b/custom_components/vistapool/translations/de.json
@@ -80,7 +80,8 @@
           "use_aux3": "Aux3-Relais aktivieren",
           "use_aux4": "Aux4-Relais aktivieren",
           "unlock_advanced": "Erweiterte Optionen freischalten",
-          "enable_backwash_option": "'Backwash'-Modus aktivieren"
+          "enable_backwash_option": "'Backwash'-Modus aktivieren",
+          "filtration_pump_power": "Leistung der Filtrationspumpe (W, 0 = deaktiviert)"
         },
         "data_description": {
           "scan_interval": "Niedrigere Werte erhöhen die Reaktionsfähigkeit, erzeugen aber mehr Modbus-Verkehr.",
@@ -96,7 +97,8 @@
           "use_aux3": "Erstellt Schalter- und Timer-Entitäten für diesen Hilfsrelais-Ausgang.",
           "use_aux4": "Erstellt Schalter- und Timer-Entitäten für diesen Hilfsrelais-Ausgang.",
           "unlock_advanced": "Geben Sie den Freischaltcode ein, um auf erweiterte Einstellungen zuzugreifen (Format: Gerätepräfix + aktuelles Jahr).",
-          "enable_backwash_option": "Fügt 'Backwash' zur Auswahl des Filtermodus hinzu. Nur für Systeme mit manuellem Mehrwegeventil."
+          "enable_backwash_option": "Fügt 'Backwash' zur Auswahl des Filtermodus hinzu. Nur für Systeme mit manuellem Mehrwegeventil.",
+          "filtration_pump_power": "Geben Sie die Nennleistung der Filtrationspumpe an. Bei einem Wert ungleich null werden zwei Sensoren erstellt: momentane Leistung (W) und kumulierter Energieverbrauch (Wh), beide nutzbar im Energie-Dashboard."
         }
       },
       "advanced": {

--- a/custom_components/vistapool/translations/de.json
+++ b/custom_components/vistapool/translations/de.json
@@ -32,7 +32,8 @@
           "use_filtration2": "2. Filter-Timer für Automatikbetrieb aktivieren",
           "use_filtration3": "3. Filter-Timer für Automatikbetrieb aktivieren",
           "use_light": "Licht-Relais aktivieren",
-          "use_cover_sensor": "Abdeckungssensor aktivieren"
+          "use_cover_sensor": "Abdeckungssensor aktivieren",
+          "filtration_pump_power": "Leistung der Filtrationspumpe (W, 0 = deaktiviert)"
         },
         "data_description": {
           "name": "Wird als Präfix für alle Entitäten-IDs verwendet. Leerzeichen werden zu Unterstrichen, z.B. 'Pool West' → sensor.pool_west_measure_ph.",
@@ -45,7 +46,8 @@
           "use_filtration2": "Erstellt Timer-Entitäten zur Konfiguration des automatischen Filterplans.",
           "use_filtration3": "Erstellt Timer-Entitäten zur Konfiguration des automatischen Filterplans.",
           "use_light": "Erstellt Entitäten zur Steuerung und Überwachung des Licht-Relais.",
-          "use_cover_sensor": "Erstellt einen Binärsensor, der anzeigt, ob die Poolabdeckung geöffnet oder geschlossen ist."
+          "use_cover_sensor": "Erstellt einen Binärsensor, der anzeigt, ob die Poolabdeckung geöffnet oder geschlossen ist.",
+          "filtration_pump_power": "Geben Sie die Nennleistung der Filtrationspumpe an. Bei einem Wert ungleich null werden zwei Sensoren erstellt: momentane Leistung (W) und kumulierter Energieverbrauch (Wh), beide nutzbar im Energie-Dashboard."
         }
       }
     },

--- a/custom_components/vistapool/translations/en.json
+++ b/custom_components/vistapool/translations/en.json
@@ -32,7 +32,8 @@
           "use_filtration2": "Enable 2nd filtration timer for automatic mode",
           "use_filtration3": "Enable 3rd filtration timer for automatic mode",
           "use_light": "Enable Light Relay",
-          "use_cover_sensor": "Enable Pool Cover Sensor"
+          "use_cover_sensor": "Enable Pool Cover Sensor",
+          "filtration_pump_power": "Filtration pump power (W, 0 = disabled)"
         },
         "data_description": {
           "name": "Used as a prefix for all entity IDs. Spaces become underscores, e.g. 'Pool West' → sensor.pool_west_measure_ph.",
@@ -45,7 +46,8 @@
           "use_filtration2": "Creates timer entities for configuring automatic filtration schedule.",
           "use_filtration3": "Creates timer entities for configuring automatic filtration schedule.",
           "use_light": "Creates entities to control and monitor the pool light relay.",
-          "use_cover_sensor": "Creates a binary sensor indicating whether the pool cover is open or closed."
+          "use_cover_sensor": "Creates a binary sensor indicating whether the pool cover is open or closed.",
+          "filtration_pump_power": "Set the rated wattage of the filtration pump. When non-zero, two sensors are created: instantaneous power (W) and cumulative energy (Wh), both usable in the Energy dashboard."
         }
       }
     },
@@ -80,7 +82,8 @@
           "use_aux3": "Enable Aux3 Relay",
           "use_aux4": "Enable Aux4 Relay",
           "unlock_advanced": "Unlock advanced options",
-          "enable_backwash_option": "Enable 'Backwash' mode"
+          "enable_backwash_option": "Enable 'Backwash' mode",
+          "filtration_pump_power": "Filtration pump power (W, 0 = disabled)"
         },
         "data_description": {
           "scan_interval": "Lower values increase responsiveness but generate more Modbus traffic.",
@@ -96,7 +99,8 @@
           "use_aux3": "Creates switch and timer entities for this auxiliary relay output.",
           "use_aux4": "Creates switch and timer entities for this auxiliary relay output.",
           "unlock_advanced": "Enter the unlock code to access advanced settings (format: device_prefix + current year).",
-          "enable_backwash_option": "Adds 'Backwash' to the filtration mode select. Only for systems with manual multi-way valves."
+          "enable_backwash_option": "Adds 'Backwash' to the filtration mode select. Only for systems with manual multi-way valves.",
+          "filtration_pump_power": "Set the rated wattage of the filtration pump. When non-zero, two sensors are created: instantaneous power (W) and cumulative energy (Wh), both usable in the Energy dashboard."
         }
       },
       "advanced": {
@@ -201,6 +205,12 @@
       },
       "filtration_remaining": {
         "name": "Filtration Time Remaining"
+      },
+      "filtration_pump_power": {
+        "name": "Filtration Pump Power"
+      },
+      "filtration_pump_energy": {
+        "name": "Filtration Pump Energy"
       }
     },
     "binary_sensor": {

--- a/custom_components/vistapool/translations/es.json
+++ b/custom_components/vistapool/translations/es.json
@@ -80,7 +80,8 @@
           "use_aux3": "Activar relé Aux3",
           "use_aux4": "Activar relé Aux4",
           "unlock_advanced": "Desbloquear opciones avanzadas",
-          "enable_backwash_option": "Activar modo 'Backwash'"
+          "enable_backwash_option": "Activar modo 'Backwash'",
+          "filtration_pump_power": "Potencia de la bomba de filtración (W, 0 = desactivado)"
         },
         "data_description": {
           "scan_interval": "Valores más bajos aumentan la capacidad de respuesta pero generan más tráfico Modbus.",
@@ -96,7 +97,8 @@
           "use_aux3": "Crea entidades de interruptor y temporizador para esta salida de relé auxiliar.",
           "use_aux4": "Crea entidades de interruptor y temporizador para esta salida de relé auxiliar.",
           "unlock_advanced": "Introduzca el código de desbloqueo para acceder a configuraciones avanzadas (formato: prefijo_dispositivo + año actual).",
-          "enable_backwash_option": "Añade 'Backwash' a la selección del modo de filtración. Solo para sistemas con válvula multivía manual."
+          "enable_backwash_option": "Añade 'Backwash' a la selección del modo de filtración. Solo para sistemas con válvula multivía manual.",
+          "filtration_pump_power": "Indique la potencia nominal de la bomba de filtración. Con un valor distinto de cero se crean dos sensores: potencia instantánea (W) y energía acumulada (Wh), ambos utilizables en el panel de energía."
         }
       },
       "advanced": {

--- a/custom_components/vistapool/translations/es.json
+++ b/custom_components/vistapool/translations/es.json
@@ -32,7 +32,8 @@
           "use_filtration2": "Activar el 2º temporizador de filtración para modo automático",
           "use_filtration3": "Activar el 3º temporizador de filtración para modo automático",
           "use_light": "Activar relé de luz",
-          "use_cover_sensor": "Activar sensor de cubierta de piscina"
+          "use_cover_sensor": "Activar sensor de cubierta de piscina",
+          "filtration_pump_power": "Potencia de la bomba de filtración (W, 0 = desactivado)"
         },
         "data_description": {
           "name": "Se usa como prefijo para todos los IDs de entidades. Los espacios se convierten en guiones bajos, p.ej. 'Piscina Oeste' → sensor.piscina_oeste_measure_ph.",
@@ -45,7 +46,8 @@
           "use_filtration2": "Crea entidades de temporizador para configurar el horario automático de filtración.",
           "use_filtration3": "Crea entidades de temporizador para configurar el horario automático de filtración.",
           "use_light": "Crea entidades para controlar y monitorear el relé de luz de la piscina.",
-          "use_cover_sensor": "Crea un sensor binario que indica si la cubierta de la piscina está abierta o cerrada."
+          "use_cover_sensor": "Crea un sensor binario que indica si la cubierta de la piscina está abierta o cerrada.",
+          "filtration_pump_power": "Indique la potencia nominal de la bomba de filtración. Con un valor distinto de cero se crean dos sensores: potencia instantánea (W) y energía acumulada (Wh), ambos utilizables en el panel de energía."
         }
       }
     },

--- a/custom_components/vistapool/translations/fr.json
+++ b/custom_components/vistapool/translations/fr.json
@@ -80,7 +80,8 @@
           "use_aux3": "Activer le relais Aux3",
           "use_aux4": "Activer le relais Aux4",
           "unlock_advanced": "Débloquer les options avancées",
-          "enable_backwash_option": "Activer le mode 'Backwash'"
+          "enable_backwash_option": "Activer le mode 'Backwash'",
+          "filtration_pump_power": "Puissance de la pompe de filtration (W, 0 = désactivé)"
         },
         "data_description": {
           "scan_interval": "Des valeurs plus basses augmentent la réactivité mais génèrent plus de trafic Modbus.",
@@ -96,7 +97,8 @@
           "use_aux3": "Crée des entités d'interrupteur et de minuterie pour cette sortie relais auxiliaire.",
           "use_aux4": "Crée des entités d'interrupteur et de minuterie pour cette sortie relais auxiliaire.",
           "unlock_advanced": "Entrez le code de déverrouillage pour accéder aux paramètres avancés (format : préfixe_appareil + année en cours).",
-          "enable_backwash_option": "Ajoute 'Backwash' à la sélection du mode de filtration. Uniquement pour les systèmes avec vanne multivoies manuelle."
+          "enable_backwash_option": "Ajoute 'Backwash' à la sélection du mode de filtration. Uniquement pour les systèmes avec vanne multivoies manuelle.",
+          "filtration_pump_power": "Indiquez la puissance nominale de la pompe de filtration. Avec une valeur non nulle, deux capteurs sont créés : puissance instantanée (W) et énergie cumulée (Wh), tous deux utilisables dans le tableau de bord énergétique."
         }
       },
       "advanced": {

--- a/custom_components/vistapool/translations/fr.json
+++ b/custom_components/vistapool/translations/fr.json
@@ -32,7 +32,8 @@
           "use_filtration2": "Activer le 2ème minuteur de filtration pour le mode automatique",
           "use_filtration3": "Activer le 3ème minuteur de filtration pour le mode automatique",
           "use_light": "Activer le relais Lumière",
-          "use_cover_sensor": "Activer le capteur de couverture de piscine"
+          "use_cover_sensor": "Activer le capteur de couverture de piscine",
+          "filtration_pump_power": "Puissance de la pompe de filtration (W, 0 = désactivé)"
         },
         "data_description": {
           "name": "Utilisé comme préfixe pour tous les IDs d'entités. Les espaces deviennent des tirets bas, ex. 'Piscine Ouest' → sensor.piscine_ouest_measure_ph.",
@@ -45,7 +46,8 @@
           "use_filtration2": "Crée des entités de minuterie pour configurer le programme automatique de filtration.",
           "use_filtration3": "Crée des entités de minuterie pour configurer le programme automatique de filtration.",
           "use_light": "Crée des entités pour contrôler et surveiller le relais lumière de la piscine.",
-          "use_cover_sensor": "Crée un capteur binaire indiquant si la couverture de la piscine est ouverte ou fermée."
+          "use_cover_sensor": "Crée un capteur binaire indiquant si la couverture de la piscine est ouverte ou fermée.",
+          "filtration_pump_power": "Indiquez la puissance nominale de la pompe de filtration. Avec une valeur non nulle, deux capteurs sont créés : puissance instantanée (W) et énergie cumulée (Wh), tous deux utilisables dans le tableau de bord énergétique."
         }
       }
     },

--- a/custom_components/vistapool/translations/it.json
+++ b/custom_components/vistapool/translations/it.json
@@ -80,7 +80,8 @@
           "use_aux3": "Abilita relè Aux3",
           "use_aux4": "Abilita relè Aux4",
           "unlock_advanced": "Sblocca opzioni avanzate",
-          "enable_backwash_option": "Abilita modalità 'Backwash'"
+          "enable_backwash_option": "Abilita modalità 'Backwash'",
+          "filtration_pump_power": "Potenza della pompa di filtrazione (W, 0 = disabilitato)"
         },
         "data_description": {
           "scan_interval": "Valori più bassi aumentano la reattività ma generano più traffico Modbus.",
@@ -96,7 +97,8 @@
           "use_aux3": "Crea entità interruttore e timer per questa uscita relè ausiliaria.",
           "use_aux4": "Crea entità interruttore e timer per questa uscita relè ausiliaria.",
           "unlock_advanced": "Inserire il codice di sblocco per accedere alle impostazioni avanzate (formato: prefisso_dispositivo + anno corrente).",
-          "enable_backwash_option": "Aggiunge 'Backwash' alla selezione della modalità di filtrazione. Solo per sistemi con valvola multivia manuale."
+          "enable_backwash_option": "Aggiunge 'Backwash' alla selezione della modalità di filtrazione. Solo per sistemi con valvola multivia manuale.",
+          "filtration_pump_power": "Specificare la potenza nominale della pompa di filtrazione. Con un valore diverso da zero vengono creati due sensori: potenza istantanea (W) ed energia cumulata (Wh), entrambi utilizzabili nel pannello energetico."
         }
       },
       "advanced": {

--- a/custom_components/vistapool/translations/it.json
+++ b/custom_components/vistapool/translations/it.json
@@ -32,7 +32,8 @@
           "use_filtration2": "Abilita il 2° timer di filtrazione per la modalità automatica",
           "use_filtration3": "Abilita il 3° timer di filtrazione per la modalità automatica",
           "use_light": "Abilita relè luce",
-          "use_cover_sensor": "Abilita sensore copertura piscina"
+          "use_cover_sensor": "Abilita sensore copertura piscina",
+          "filtration_pump_power": "Potenza della pompa di filtrazione (W, 0 = disabilitato)"
         },
         "data_description": {
           "name": "Usato come prefisso per tutti gli ID entità. Gli spazi diventano trattini bassi, es. 'Piscina Ovest' → sensor.piscina_ovest_measure_ph.",
@@ -45,7 +46,8 @@
           "use_filtration2": "Crea entità timer per configurare la programmazione automatica della filtrazione.",
           "use_filtration3": "Crea entità timer per configurare la programmazione automatica della filtrazione.",
           "use_light": "Crea entità per controllare e monitorare il relè luce della piscina.",
-          "use_cover_sensor": "Crea un sensore binario che indica se la copertura della piscina è aperta o chiusa."
+          "use_cover_sensor": "Crea un sensore binario che indica se la copertura della piscina è aperta o chiusa.",
+          "filtration_pump_power": "Specificare la potenza nominale della pompa di filtrazione. Con un valore diverso da zero vengono creati due sensori: potenza istantanea (W) ed energia cumulata (Wh), entrambi utilizzabili nel pannello energetico."
         }
       }
     },

--- a/custom_components/vistapool/translations/pl.json
+++ b/custom_components/vistapool/translations/pl.json
@@ -80,7 +80,8 @@
           "use_aux3": "Włącz przekaźnik Aux3",
           "use_aux4": "Włącz przekaźnik Aux4",
           "unlock_advanced": "Odblokuj opcje zaawansowane",
-          "enable_backwash_option": "Włącz tryb 'Backwash'"
+          "enable_backwash_option": "Włącz tryb 'Backwash'",
+          "filtration_pump_power": "Moc pompy filtracyjnej (W, 0 = wyłączone)"
         },
         "data_description": {
           "scan_interval": "Niższe wartości zwiększają responsywność, ale generują więcej ruchu Modbus.",
@@ -96,7 +97,8 @@
           "use_aux3": "Tworzy encje przełącznika i timera dla tego pomocniczego wyjścia przekaźnikowego.",
           "use_aux4": "Tworzy encje przełącznika i timera dla tego pomocniczego wyjścia przekaźnikowego.",
           "unlock_advanced": "Wprowadź kod odblokowujący, aby uzyskać dostęp do ustawień zaawansowanych (format: prefiks_urządzenia + bieżący rok).",
-          "enable_backwash_option": "Dodaje 'Backwash' do wyboru trybu filtracji. Tylko dla systemów z ręcznym zaworem wielodrożnym."
+          "enable_backwash_option": "Dodaje 'Backwash' do wyboru trybu filtracji. Tylko dla systemów z ręcznym zaworem wielodrożnym.",
+          "filtration_pump_power": "Podaj nominalną moc pompy filtracyjnej. Przy wartości różnej od zera tworzone są dwa czujniki: chwilowa moc (W) i skumulowana energia (Wh), oba możliwe do użycia na panelu energetycznym."
         }
       },
       "advanced": {

--- a/custom_components/vistapool/translations/pl.json
+++ b/custom_components/vistapool/translations/pl.json
@@ -32,7 +32,8 @@
           "use_filtration2": "Włącz 2. timer filtracji w trybie automatycznym",
           "use_filtration3": "Włącz 3. timer filtracji w trybie automatycznym",
           "use_light": "Włącz przekaźnik oświetlenia",
-          "use_cover_sensor": "Włącz czujnik przykrycia basenu"
+          "use_cover_sensor": "Włącz czujnik przykrycia basenu",
+          "filtration_pump_power": "Moc pompy filtracyjnej (W, 0 = wyłączone)"
         },
         "data_description": {
           "name": "Używana jako prefiks dla wszystkich ID encji. Spacje zamieniane są na podkreślenia, np. 'Basen Zachodni' → sensor.basen_zachodni_measure_ph.",
@@ -45,7 +46,8 @@
           "use_filtration2": "Tworzy encje timerów do konfiguracji automatycznego harmonogramu filtracji.",
           "use_filtration3": "Tworzy encje timerów do konfiguracji automatycznego harmonogramu filtracji.",
           "use_light": "Tworzy encje do sterowania i monitorowania przekaźnika oświetlenia basenu.",
-          "use_cover_sensor": "Tworzy czujnik binarny wskazujący, czy przykrycie basenu jest otwarte czy zamknięte."
+          "use_cover_sensor": "Tworzy czujnik binarny wskazujący, czy przykrycie basenu jest otwarte czy zamknięte.",
+          "filtration_pump_power": "Podaj nominalną moc pompy filtracyjnej. Przy wartości różnej od zera tworzone są dwa czujniki: chwilowa moc (W) i skumulowana energia (Wh), oba możliwe do użycia na panelu energetycznym."
         }
       }
     },

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1228,3 +1228,27 @@ async def test_filtration_energy_sensor_restore_ignores_invalid_float():
             await ent.async_added_to_hass()
 
     assert ent._total_wh == 0.0
+
+
+@pytest.mark.asyncio
+async def test_filtration_energy_sensor_restore_ignores_non_finite():
+    """Energy sensor ignores nan/inf/-inf and negative restored values."""
+    mock_coordinator = MagicMock()
+    mock_coordinator.config_entry.entry_id = "test_entry"
+    mock_coordinator.entry = mock_coordinator.config_entry
+    mock_coordinator.device_slug = "vistapool"
+    mock_coordinator.data = {}
+
+    for bad_value in ("nan", "inf", "-inf", "-1.0"):
+        ent = VistaPoolFiltrationEnergySensor(mock_coordinator, "test_entry", 570)
+        mock_state = MagicMock()
+        mock_state.state = bad_value
+
+        with patch(
+            "homeassistant.helpers.restore_state.RestoreEntity.async_added_to_hass",
+            return_value=None,
+        ):
+            with patch.object(ent, "async_get_last_state", return_value=mock_state):
+                await ent.async_added_to_hass()
+
+        assert ent._total_wh == 0.0, f"Expected 0.0 for state={bad_value!r}"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -20,6 +21,7 @@ from custom_components.vistapool.sensor import (
     FILTRATION_MODE_MAP,
     FILTRATION_SPEED_MAP,
     PH_STATUS_ALARM_MAP,
+    VistaPoolFiltrationEnergySensor,
     VistaPoolSensor,
     async_setup_entry,
 )
@@ -945,3 +947,258 @@ def test_sensor_filtration_remaining_none_when_idle():
 
     ent = VistaPoolSensor(mock_coordinator, "test_entry", "FILTRATION_REMAINING", {})
     assert ent.native_value is None
+
+
+@pytest.mark.asyncio
+async def test_filtration_power_sensor_created_when_nonzero():
+    """Power sensor is created as a VistaPoolSensor when filtration_pump_power > 0."""
+    from custom_components.vistapool.const import (
+        CONF_FILTRATION_PUMP_POWER,
+    )
+
+    class DummyEntry:
+        unique_id = None
+        entry_id = "test_entry"
+        options = {CONF_FILTRATION_PUMP_POWER: 570}
+
+    class DummyCoordinator:
+        data = {CONF_FILTRATION_PUMP_POWER: 570, "Filtration Pump": True}
+        config_entry = DummyEntry()
+        entry = config_entry
+        device_slug = "vistapool"
+
+    hass = MagicMock()
+    entry = DummyEntry()
+    entry.runtime_data = DummyCoordinator()
+    async_add_entities = MagicMock()
+    await async_setup_entry(hass, entry, async_add_entities)
+    entities = async_add_entities.call_args[0][0]
+    keys = [getattr(e, "_key", None) for e in entities]
+    assert CONF_FILTRATION_PUMP_POWER in keys
+
+
+@pytest.mark.asyncio
+async def test_filtration_power_sensor_skipped_when_zero():
+    """Power sensor is not created when filtration_pump_power is 0."""
+    from custom_components.vistapool.const import CONF_FILTRATION_PUMP_POWER
+
+    class DummyEntry:
+        unique_id = None
+        entry_id = "test_entry"
+        options = {CONF_FILTRATION_PUMP_POWER: 0}
+
+    class DummyCoordinator:
+        data = {CONF_FILTRATION_PUMP_POWER: 0}
+        config_entry = DummyEntry()
+        entry = config_entry
+        device_slug = "vistapool"
+
+    hass = MagicMock()
+    entry = DummyEntry()
+    entry.runtime_data = DummyCoordinator()
+    async_add_entities = MagicMock()
+    await async_setup_entry(hass, entry, async_add_entities)
+    entities = async_add_entities.call_args[0][0]
+    keys = [getattr(e, "_key", None) for e in entities]
+    assert CONF_FILTRATION_PUMP_POWER not in keys
+
+
+def test_filtration_power_sensor_native_value():
+    """Power sensor returns coordinator data value (set by coordinator based on pump state)."""
+    from custom_components.vistapool.const import (
+        CONF_FILTRATION_PUMP_POWER,
+        SENSOR_DEFINITIONS,
+    )
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.config_entry.entry_id = "test_entry"
+    mock_coordinator.config_entry.options = {CONF_FILTRATION_PUMP_POWER: 570}
+    mock_coordinator.entry = mock_coordinator.config_entry
+    mock_coordinator.device_slug = "vistapool"
+
+    ent = VistaPoolSensor(
+        mock_coordinator,
+        "test_entry",
+        CONF_FILTRATION_PUMP_POWER,
+        SENSOR_DEFINITIONS[CONF_FILTRATION_PUMP_POWER],
+    )
+    mock_coordinator.data = {CONF_FILTRATION_PUMP_POWER: 570}
+    assert ent.native_value == 570
+
+    mock_coordinator.data = {CONF_FILTRATION_PUMP_POWER: 0}
+    assert ent.native_value == 0
+
+
+@pytest.mark.asyncio
+async def test_filtration_energy_sensor_created_when_nonzero():
+    """Energy sensor (VistaPoolFiltrationEnergySensor) is created when pump_power > 0."""
+    from custom_components.vistapool.const import CONF_FILTRATION_PUMP_POWER
+
+    class DummyEntry:
+        unique_id = None
+        entry_id = "test_entry"
+        options = {CONF_FILTRATION_PUMP_POWER: 570}
+
+    class DummyCoordinator:
+        data = {CONF_FILTRATION_PUMP_POWER: 570}
+        config_entry = DummyEntry()
+        entry = config_entry
+        device_slug = "vistapool"
+
+    hass = MagicMock()
+    entry = DummyEntry()
+    entry.runtime_data = DummyCoordinator()
+    async_add_entities = MagicMock()
+    await async_setup_entry(hass, entry, async_add_entities)
+    entities = async_add_entities.call_args[0][0]
+    energy_entities = [
+        e for e in entities if isinstance(e, VistaPoolFiltrationEnergySensor)
+    ]
+    assert len(energy_entities) == 1
+
+
+@pytest.mark.asyncio
+async def test_filtration_energy_sensor_not_created_when_zero():
+    """Energy sensor is not created when pump_power is 0."""
+    from custom_components.vistapool.const import CONF_FILTRATION_PUMP_POWER
+
+    class DummyEntry:
+        unique_id = None
+        entry_id = "test_entry"
+        options = {CONF_FILTRATION_PUMP_POWER: 0}
+
+    class DummyCoordinator:
+        data = {}
+        config_entry = DummyEntry()
+        entry = config_entry
+        device_slug = "vistapool"
+
+    hass = MagicMock()
+    entry = DummyEntry()
+    entry.runtime_data = DummyCoordinator()
+    async_add_entities = MagicMock()
+    await async_setup_entry(hass, entry, async_add_entities)
+    entities = async_add_entities.call_args[0][0]
+    assert not any(isinstance(e, VistaPoolFiltrationEnergySensor) for e in entities)
+
+
+def test_filtration_energy_sensor_accumulates():
+    """Energy sensor accumulates Wh when pump runs between updates."""
+    from datetime import timezone
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.config_entry.entry_id = "test_entry"
+    mock_coordinator.entry = mock_coordinator.config_entry
+    mock_coordinator.device_slug = "vistapool"
+    mock_coordinator.data = {"Filtration Pump": True}
+
+    ent = VistaPoolFiltrationEnergySensor(mock_coordinator, "test_entry", 570)
+    ent.async_write_ha_state = MagicMock()
+
+    t0 = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t1 = datetime(2024, 1, 1, 13, 0, 0, tzinfo=timezone.utc)  # 1 hour later
+
+    with patch("custom_components.vistapool.sensor.dt_util.utcnow", return_value=t0):
+        ent._handle_coordinator_update()
+
+    assert ent.native_value == 0.0  # first call: no elapsed time
+
+    with patch("custom_components.vistapool.sensor.dt_util.utcnow", return_value=t1):
+        ent._handle_coordinator_update()
+
+    assert ent.native_value == pytest.approx(570.0)  # 570W * 1h = 570 Wh
+
+
+def test_filtration_energy_sensor_no_accumulation_when_off():
+    """Energy sensor does not accumulate when pump is off."""
+    from datetime import timezone
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.config_entry.entry_id = "test_entry"
+    mock_coordinator.entry = mock_coordinator.config_entry
+    mock_coordinator.device_slug = "vistapool"
+    mock_coordinator.data = {"Filtration Pump": False}
+
+    ent = VistaPoolFiltrationEnergySensor(mock_coordinator, "test_entry", 570)
+    ent.async_write_ha_state = MagicMock()
+
+    t0 = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t1 = datetime(2024, 1, 1, 13, 0, 0, tzinfo=timezone.utc)
+
+    with patch("custom_components.vistapool.sensor.dt_util.utcnow", return_value=t0):
+        ent._handle_coordinator_update()
+    with patch("custom_components.vistapool.sensor.dt_util.utcnow", return_value=t1):
+        ent._handle_coordinator_update()
+
+    assert ent.native_value == 0.0
+
+
+@pytest.mark.asyncio
+async def test_filtration_energy_sensor_restores_state():
+    """Energy sensor restores _total_wh from last HA state on async_added_to_hass."""
+    mock_coordinator = MagicMock()
+    mock_coordinator.config_entry.entry_id = "test_entry"
+    mock_coordinator.entry = mock_coordinator.config_entry
+    mock_coordinator.device_slug = "vistapool"
+    mock_coordinator.data = {}
+
+    ent = VistaPoolFiltrationEnergySensor(mock_coordinator, "test_entry", 570)
+
+    mock_state = MagicMock()
+    mock_state.state = "123.456"
+
+    with patch(
+        "homeassistant.helpers.restore_state.RestoreEntity.async_added_to_hass",
+        return_value=None,
+    ):
+        with patch.object(ent, "async_get_last_state", return_value=mock_state):
+            await ent.async_added_to_hass()
+
+    assert ent._total_wh == pytest.approx(123.456)
+
+
+@pytest.mark.asyncio
+async def test_filtration_energy_sensor_restore_ignores_unavailable():
+    """Energy sensor does not restore from 'unavailable' or 'unknown' states."""
+    mock_coordinator = MagicMock()
+    mock_coordinator.config_entry.entry_id = "test_entry"
+    mock_coordinator.entry = mock_coordinator.config_entry
+    mock_coordinator.device_slug = "vistapool"
+    mock_coordinator.data = {}
+
+    for bad_state in ("unavailable", "unknown", None):
+        ent = VistaPoolFiltrationEnergySensor(mock_coordinator, "test_entry", 570)
+        mock_state = MagicMock()
+        mock_state.state = bad_state
+
+        with patch(
+            "homeassistant.helpers.restore_state.RestoreEntity.async_added_to_hass",
+            return_value=None,
+        ):
+            with patch.object(ent, "async_get_last_state", return_value=mock_state):
+                await ent.async_added_to_hass()
+
+        assert ent._total_wh == 0.0
+
+
+@pytest.mark.asyncio
+async def test_filtration_energy_sensor_restore_ignores_invalid_float():
+    """Energy sensor handles ValueError gracefully when last state is not a float."""
+    mock_coordinator = MagicMock()
+    mock_coordinator.config_entry.entry_id = "test_entry"
+    mock_coordinator.entry = mock_coordinator.config_entry
+    mock_coordinator.device_slug = "vistapool"
+    mock_coordinator.data = {}
+
+    ent = VistaPoolFiltrationEnergySensor(mock_coordinator, "test_entry", 570)
+    mock_state = MagicMock()
+    mock_state.state = "not_a_number"
+
+    with patch(
+        "homeassistant.helpers.restore_state.RestoreEntity.async_added_to_hass",
+        return_value=None,
+    ):
+        with patch.object(ent, "async_get_last_state", return_value=mock_state):
+            await ent.async_added_to_hass()
+
+    assert ent._total_wh == 0.0

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1109,14 +1109,13 @@ async def test_filtration_energy_sensor_not_created_when_zero():
 
 
 def test_filtration_energy_sensor_accumulates():
-    """Energy sensor accumulates Wh when pump runs between updates."""
+    """Energy accumulates based on the pump state at the previous update (left Riemann sum)."""
     from datetime import timezone
 
     mock_coordinator = MagicMock()
     mock_coordinator.config_entry.entry_id = "test_entry"
     mock_coordinator.entry = mock_coordinator.config_entry
     mock_coordinator.device_slug = "vistapool"
-    mock_coordinator.data = {"Filtration Pump": True}
 
     ent = VistaPoolFiltrationEnergySensor(mock_coordinator, "test_entry", 570)
     ent.async_write_ha_state = MagicMock()
@@ -1124,11 +1123,14 @@ def test_filtration_energy_sensor_accumulates():
     t0 = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
     t1 = datetime(2024, 1, 1, 13, 0, 0, tzinfo=timezone.utc)  # 1 hour later
 
+    # t0: pump on — records state, no elapsed time yet
+    mock_coordinator.data = {"Filtration Pump": True}
     with patch("custom_components.vistapool.sensor.dt_util.utcnow", return_value=t0):
         ent._handle_coordinator_update()
 
     assert ent.native_value == 0.0  # first call: no elapsed time
 
+    # t1: pump still on — accumulates based on previous state (on)
     with patch("custom_components.vistapool.sensor.dt_util.utcnow", return_value=t1):
         ent._handle_coordinator_update()
 
@@ -1136,14 +1138,13 @@ def test_filtration_energy_sensor_accumulates():
 
 
 def test_filtration_energy_sensor_no_accumulation_when_off():
-    """Energy sensor does not accumulate when pump is off."""
+    """No energy accumulates when pump was off at the previous update."""
     from datetime import timezone
 
     mock_coordinator = MagicMock()
     mock_coordinator.config_entry.entry_id = "test_entry"
     mock_coordinator.entry = mock_coordinator.config_entry
     mock_coordinator.device_slug = "vistapool"
-    mock_coordinator.data = {"Filtration Pump": False}
 
     ent = VistaPoolFiltrationEnergySensor(mock_coordinator, "test_entry", 570)
     ent.async_write_ha_state = MagicMock()
@@ -1151,12 +1152,52 @@ def test_filtration_energy_sensor_no_accumulation_when_off():
     t0 = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
     t1 = datetime(2024, 1, 1, 13, 0, 0, tzinfo=timezone.utc)
 
+    # t0: pump off — records state
+    mock_coordinator.data = {"Filtration Pump": False}
     with patch("custom_components.vistapool.sensor.dt_util.utcnow", return_value=t0):
         ent._handle_coordinator_update()
+
+    # t1: pump on now, but previous state was off — no accumulation
+    mock_coordinator.data = {"Filtration Pump": True}
     with patch("custom_components.vistapool.sensor.dt_util.utcnow", return_value=t1):
         ent._handle_coordinator_update()
 
     assert ent.native_value == 0.0
+
+
+def test_filtration_energy_sensor_stops_on_pump_off():
+    """No energy accumulates for the interval where the pump turned off."""
+    from datetime import timezone
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.config_entry.entry_id = "test_entry"
+    mock_coordinator.entry = mock_coordinator.config_entry
+    mock_coordinator.device_slug = "vistapool"
+
+    ent = VistaPoolFiltrationEnergySensor(mock_coordinator, "test_entry", 570)
+    ent.async_write_ha_state = MagicMock()
+
+    t0 = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t1 = datetime(2024, 1, 1, 13, 0, 0, tzinfo=timezone.utc)
+    t2 = datetime(2024, 1, 1, 14, 0, 0, tzinfo=timezone.utc)
+
+    # t0: pump on
+    mock_coordinator.data = {"Filtration Pump": True}
+    with patch("custom_components.vistapool.sensor.dt_util.utcnow", return_value=t0):
+        ent._handle_coordinator_update()
+
+    # t1: pump turns off — interval [t0,t1] was on → 570 Wh accumulated
+    mock_coordinator.data = {"Filtration Pump": False}
+    with patch("custom_components.vistapool.sensor.dt_util.utcnow", return_value=t1):
+        ent._handle_coordinator_update()
+
+    assert ent.native_value == pytest.approx(570.0)
+
+    # t2: pump still off — interval [t1,t2] was off → no accumulation
+    with patch("custom_components.vistapool.sensor.dt_util.utcnow", return_value=t2):
+        ent._handle_coordinator_update()
+
+    assert ent.native_value == pytest.approx(570.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1003,6 +1003,32 @@ async def test_filtration_power_sensor_skipped_when_zero():
     assert CONF_FILTRATION_PUMP_POWER not in keys
 
 
+@pytest.mark.asyncio
+async def test_filtration_power_sensor_skipped_when_negative():
+    """Power sensor is not created when filtration_pump_power is negative."""
+    from custom_components.vistapool.const import CONF_FILTRATION_PUMP_POWER
+
+    class DummyEntry:
+        unique_id = None
+        entry_id = "test_entry"
+        options = {CONF_FILTRATION_PUMP_POWER: -100}
+
+    class DummyCoordinator:
+        data = {}
+        config_entry = DummyEntry()
+        entry = config_entry
+        device_slug = "vistapool"
+
+    hass = MagicMock()
+    entry = DummyEntry()
+    entry.runtime_data = DummyCoordinator()
+    async_add_entities = MagicMock()
+    await async_setup_entry(hass, entry, async_add_entities)
+    entities = async_add_entities.call_args[0][0]
+    keys = [getattr(e, "_key", None) for e in entities]
+    assert CONF_FILTRATION_PUMP_POWER not in keys
+
+
 def test_filtration_power_sensor_native_value():
     """Power sensor returns coordinator data value (set by coordinator based on pump state)."""
     from custom_components.vistapool.const import (


### PR DESCRIPTION
# feat(sensor): ✨ add filtration pump power and energy sensors

## 🎯 Motivation

Users with a known-wattage filtration pump had no built-in way to track its power consumption inside the integration. The workaround required manual `platform: integration` YAML sensors and a template sensor — this PR makes it a first-class, UI-configurable feature.

## 📦 What's new

### ⚙️ Configuration

- New option **`filtration_pump_power`** (integer, watts) added to both **Config Flow** (initial setup) and **Options Flow** (can be changed at any time).
- When set to `0` (default), no extra entities are created — the feature is fully opt-in.

### 📊 New entities (created only when wattage > 0)

| Entity                                 | Type   | Unit | HA class                      | Purpose                                                                              |
| -------------------------------------- | ------ | ---- | ----------------------------- | ------------------------------------------------------------------------------------ |
| `sensor.<name>_filtration_pump_power`  | sensor | W    | `power` / `measurement`       | Instantaneous consumption — usable in Energy dashboard **current consumption** graph |
| `sensor.<name>_filtration_pump_energy` | sensor | Wh   | `energy` / `total_increasing` | Cumulative energy — usable in Energy dashboard **individual devices** tracking       |

## 🏗️ Implementation

### Power sensor

No extra class. The coordinator writes `filtration_pump_power` into `coordinator.data` on every successful read — the configured wattage when `Filtration Pump` is `on`, `0` otherwise. `VistaPoolSensor` renders it as any other data-driven sensor from `SENSOR_DEFINITIONS`. Skipped via `_should_skip_sensor` when wattage is `0`.

### Energy sensor (`VistaPoolFiltrationEnergySensor`)

A single dedicated class with `RestoreEntity`. On each coordinator update it calculates elapsed time since the previous update and accumulates `Wh = power × elapsed_hours` when the pump is running. The total is restored from HA entity state on restart, so the counter survives reboots.

## 🌍 Translations

Option label and description added to all 7 supported languages: `en`, `cs`, `de`, `es`, `fr`, `it`, `pl`. Entity names (`Filtration Pump Power`, `Filtration Pump Energy`) translated in `en` and `cs`; other languages fall back to `en`.

## ✅ Tests

- 10 new tests covering: sensor created / skipped based on option, native value from coordinator data, energy accumulation over time, no accumulation when pump off, state restore (valid value, `unavailable`, `unknown`, invalid float).
- All 665 tests pass, `sensor.py` at **100% coverage**.

## 🔍 Files changed

| File                   | Change                                                                |
| ---------------------- | --------------------------------------------------------------------- |
| `const.py`             | `CONF_FILTRATION_PUMP_POWER` constant + entry in `SENSOR_DEFINITIONS` |
| `coordinator.py`       | Write computed power value into `data` after each successful read     |
| `sensor.py`            | Skip logic for power sensor; `VistaPoolFiltrationEnergySensor` class  |
| `config_flow.py`       | `filtration_pump_power` field in initial setup                        |
| `options_flow.py`      | `filtration_pump_power` field in options                              |
| `translations/*.json`  | 7 language files updated                                              |
| `tests/test_sensor.py` | 10 new tests                                                          |
