### PR TITLE
fix(config): 🐛 advanced options unlock password not matching device name

### DIFF
--- a/custom_components/vistapool/options_flow.py
+++ b/custom_components/vistapool/options_flow.py
@@ -54,7 +54,7 @@ class VistaPoolOptionsFlowHandler(config_entries.OptionsFlow):
         options = dict(self.config_entry.options)
         already_enabled = options.get("enable_backwash_option", False)
 
-        device_slug = self.config_entry.unique_id or slugify(
+        device_slug = slugify(
             self.config_entry.data.get(CONF_NAME) or self.config_entry.title
         )
         expected = f"{device_slug}{date.today().year}"

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -21,6 +21,12 @@ from custom_components.vistapool.options_flow import VistaPoolOptionsFlowHandler
 
 def make_flow(mock_config_entry):
     """Create a VistaPoolOptionsFlowHandler with a properly mocked config_entry."""
+    # Provide sensible string defaults so slugify() (used for password derivation)
+    # never receives a MagicMock. Tests can override data/title before calling.
+    if not isinstance(mock_config_entry.data, dict):
+        mock_config_entry.data = {"name": "Pool"}
+    if not isinstance(mock_config_entry.title, str):
+        mock_config_entry.title = "Pool"
     flow = VistaPoolOptionsFlowHandler()
     flow.hass = MagicMock()
     flow.hass.async_create_task = MagicMock()
@@ -57,13 +63,15 @@ async def test_options_unlock_advanced_correct(monkeypatch):
     """Test entering correct unlock_advanced advances to advanced step."""
     mock_config_entry = MagicMock()
     mock_config_entry.options = {}
-    mock_config_entry.unique_id = "pool"
+    mock_config_entry.unique_id = "neopool_ABC123"
+    mock_config_entry.data = {"name": "Pool"}
     flow = make_flow(mock_config_entry)
 
     with patch("custom_components.vistapool.options_flow.date") as mock_date:
         mock_today = MagicMock()
         mock_today.year = 2025
         mock_date.today.return_value = mock_today
+        # Password is derived from slugified name, NOT from unique_id
         user_input = {"unlock_advanced": "pool2025"}
         flow.async_step_advanced = AsyncMock(return_value="advanced_step_called")
         result = await flow.async_step_init(user_input=user_input)
@@ -76,7 +84,8 @@ async def test_options_unlock_advanced_wrong(monkeypatch, caplog):
     """Test entering incorrect unlock_advanced shows error and logs warning."""
     mock_config_entry = MagicMock()
     mock_config_entry.options = {}
-    mock_config_entry.unique_id = "pool"
+    mock_config_entry.unique_id = "neopool_ABC123"
+    mock_config_entry.data = {"name": "Pool"}
     flow = make_flow(mock_config_entry)
 
     with patch("custom_components.vistapool.options_flow.date") as mock_date:
@@ -92,7 +101,7 @@ async def test_options_unlock_advanced_wrong(monkeypatch, caplog):
 
 @pytest.mark.asyncio
 async def test_options_unlock_advanced_correct_slug_fallback(monkeypatch):
-    """Test unlock_advanced with unique_id=None falls back to slugified name for password."""
+    """Test unlock_advanced uses slugified name for password regardless of unique_id."""
     mock_config_entry = MagicMock()
     mock_config_entry.options = {}
     mock_config_entry.unique_id = None
@@ -113,7 +122,7 @@ async def test_options_unlock_advanced_correct_slug_fallback(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_options_unlock_advanced_wrong_slug_fallback(monkeypatch, caplog):
-    """Test unlock_advanced with unique_id=None shows error when password doesn't match slug."""
+    """Test unlock_advanced shows error when password doesn't match slugified name."""
     mock_config_entry = MagicMock()
     mock_config_entry.options = {}
     mock_config_entry.unique_id = None
@@ -131,7 +140,7 @@ async def test_options_unlock_advanced_wrong_slug_fallback(monkeypatch, caplog):
 
 @pytest.mark.asyncio
 async def test_options_unlock_advanced_title_fallback(monkeypatch):
-    """Test unlock_advanced falls back to config_entry.title when unique_id and CONF_NAME are missing."""
+    """Test unlock_advanced falls back to config_entry.title when CONF_NAME is missing."""
     mock_config_entry = MagicMock()
     mock_config_entry.options = {}
     mock_config_entry.unique_id = None


### PR DESCRIPTION
# fix advanced options unlock password not matching device name

## 🐞 Problem

The advanced options unlock password no longer matches what is documented in README, the in-app translations, and the hint shown directly in the form.

After installing the integration with the default Czech name (`Bazén`), the user expected the password `bazen2026` (per the documented format `<device_prefix><current_year>`). It did not work because the actual password the integration computed was `neopool_<serial>2026`.

## 🔍 Root cause

This is a regression introduced in [PR #146](https://github.com/svasek/homeassistant-vistapool-modbus/pull/146) (_stable device identity based on hardware serial number_). That PR repurposed `config_entry.unique_id` to a serial-based form (`neopool_<serial>`) for stable device tracking. However, `options_flow.py` was still using `config_entry.unique_id` as the `device_slug` when building the unlock password:

```python
device_slug = self.config_entry.unique_id or slugify(
    self.config_entry.data.get(CONF_NAME) or self.config_entry.title
)
```

For all installations created after PR #146 (config entry version 2), `unique_id` is non-`None`, so the `slugify(name)` fallback was never executed and the password silently changed to `neopool_<serial><year>`.

The README, all translation files, and the form's `data_description` text continue to describe the password as _"device_prefix + current year"_, so the UI promised one thing and the code did another.

## ✅ Fix

Always derive the unlock `device_slug` from the user-facing name (or `title` fallback):

```python
device_slug = slugify(
    self.config_entry.data.get(CONF_NAME) or self.config_entry.title
)
```

This restores the documented behaviour: the password is `<entity_prefix><current_year>` — exactly what the user sees as the prefix in entity IDs.

## 🧪 Tests

- Updated `test_options_unlock_advanced_correct` and `test_options_unlock_advanced_wrong` to reflect that `unique_id` no longer participates in the password derivation.
- Hardened `make_flow()` test helper so `slugify()` never receives a `MagicMock` — it now provides string defaults for `data` and `title` while still letting individual tests override them.
- All 671 tests pass; 100% coverage maintained.

## 📋 Files changed

| File                                          | Change                                         |
| --------------------------------------------- | ---------------------------------------------- |
| `custom_components/vistapool/options_flow.py` | Drop `unique_id` from `device_slug` derivation |
| `tests/test_options_flow.py`                  | Update tests + harden `make_flow()` helper     |

## 🔗 Related

- Reverts behavioural change accidentally introduced by [#146](https://github.com/svasek/homeassistant-vistapool-modbus/pull/146)
- Restores agreement between code and existing documentation/translations (no doc/translation changes needed)
