### PR TITLE
fix(translations): 🩹 align translation keys and add strings.json

### DIFF
--- a/custom_components/neopool/strings.json
+++ b/custom_components/neopool/strings.json
@@ -1,0 +1,654 @@
+{
+  "config": {
+    "step": {
+      "reconfigure": {
+        "title": "Reconfigure NeoPool Connection",
+        "description": "Update the connection settings for your NeoPool controller.",
+        "data": {
+          "host": "Modbus gateway IP address",
+          "port": "TCP port for Modbus (default: 502).",
+          "slave_id": "Modbus device address (default: 1).",
+          "modbus_framer": "Protocol framing: 'tcp' = Modbus TCP (MBAP header, for gateways with conversion), 'rtu' = RTU over TCP (for transparent TCP gateways)"
+        },
+        "data_description": {
+          "host": "Enter the IP address of the Modbus TCP gateway connected to your pool controller.",
+          "port": "Standard Modbus TCP port. Change only if your gateway uses a non-standard port.",
+          "slave_id": "The Modbus slave address of the pool controller. Most setups use 1.",
+          "modbus_framer": "Select 'tcp' for gateways that convert between TCP and RTU. Select 'rtu' for transparent gateways that forward raw RTU frames over TCP."
+        }
+      },
+      "user": {
+        "title": "NeoPool Connection",
+        "description": "Configure the connection to your NeoPool controller.",
+        "data": {
+          "name": "Device name (used as entity ID prefix).",
+          "name_default": "Pool",
+          "host": "Modbus gateway IP address",
+          "port": "TCP port for Modbus (default: 502).",
+          "scan_interval": "Data update interval (seconds)",
+          "slave_id": "Modbus device address (default: 1).",
+          "modbus_framer": "Protocol framing: 'tcp' = Modbus TCP (MBAP header, for gateways with conversion), 'rtu' = RTU over TCP (for transparent TCP gateways)",
+          "use_filtration1": "Enable 1st filtration timer for automatic mode",
+          "use_filtration2": "Enable 2nd filtration timer for automatic mode",
+          "use_filtration3": "Enable 3rd filtration timer for automatic mode",
+          "use_light": "Enable Light Relay",
+          "use_cover_sensor": "Enable Pool Cover Sensor",
+          "filtration_pump_power": "Filtration pump power (W, 0 = disabled)"
+        },
+        "data_description": {
+          "name": "Used as a prefix for all entity IDs. Spaces become underscores, e.g. 'Pool West' → sensor.pool_west_measure_ph.",
+          "host": "Enter the IP address of the Modbus TCP gateway connected to your pool controller.",
+          "port": "Standard Modbus TCP port. Change only if your gateway uses a non-standard port.",
+          "scan_interval": "How often the integration reads data from the pool controller.",
+          "slave_id": "The Modbus slave address of the pool controller. Most setups use 1.",
+          "modbus_framer": "Select 'tcp' for gateways that convert between TCP and RTU. Select 'rtu' for transparent gateways that forward raw RTU frames over TCP.",
+          "use_filtration1": "Creates timer entities for configuring automatic filtration schedule.",
+          "use_filtration2": "Creates timer entities for configuring automatic filtration schedule.",
+          "use_filtration3": "Creates timer entities for configuring automatic filtration schedule.",
+          "use_light": "Creates entities to control and monitor the pool light relay.",
+          "use_cover_sensor": "Creates a binary sensor indicating whether the pool cover is open or closed.",
+          "filtration_pump_power": "Set the rated wattage of the filtration pump. When non-zero, two sensors are created: instantaneous power (W) and cumulative energy (Wh), both usable in the Energy dashboard."
+        }
+      },
+      "import_from_vistapool": {
+        "title": "Import from existing VistaPool integration",
+        "description": "Detected an existing VistaPool integration entry **{entry_title}** (legacy `vistapool` domain).\n\nClick **Submit** to migrate it to the new `neopool` domain in one step:\n\n- All entity IDs, history and customizations are preserved\n- Connection settings (host, port, slave ID, options) are copied automatically\n- Device area assignment, custom name and labels are restored\n- The leftover `custom_components/vistapool/` folder is cleaned up\n\nIf you instead want to add a *separate* NeoPool device, cancel and first remove the legacy VistaPool integration manually."
+      }
+    },
+    "error": {
+      "cannot_connect": "Cannot connect to the specified address and port.",
+      "cannot_read_modbus": "Connected, but cannot read from the Modbus device. Check slave ID and framer settings.",
+      "serial_mismatch": "The device at this address has a different serial number than the one originally configured.",
+      "name_already_used": "This device name is already in use. Please choose a different name."
+    },
+    "abort": {
+      "already_configured": "This device is already configured.",
+      "entry_not_found": "The integration entry could not be found.",
+      "reconfigure_successful": "Connection settings updated successfully.",
+      "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
+      "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "NeoPool Settings",
+        "description": "WARNING: Changing enabled relays will automatically reload the integration! Changes take effect immediately.",
+        "data": {
+          "scan_interval": "Data update interval (seconds)",
+          "timer_resolution": "Timer adjustment step (minutes)",
+          "measure_when_filtration_off": "Measure values even when filtration is off",
+          "use_filtration1": "Enable 1st filtration timer for automatic mode",
+          "use_filtration2": "Enable 2nd filtration timer for automatic mode",
+          "use_filtration3": "Enable 3rd filtration timer for automatic mode",
+          "use_light": "Enable Light Relay",
+          "use_cover_sensor": "Enable Pool Cover Sensor",
+          "use_aux1": "Enable Aux1 Relay",
+          "use_aux2": "Enable Aux2 Relay",
+          "use_aux3": "Enable Aux3 Relay",
+          "use_aux4": "Enable Aux4 Relay",
+          "unlock_advanced": "Unlock advanced options",
+          "enable_backwash_option": "Enable 'Backwash' mode",
+          "filtration_pump_power": "Filtration pump power (W, 0 = disabled)"
+        },
+        "data_description": {
+          "scan_interval": "Lower values increase responsiveness but generate more Modbus traffic.",
+          "timer_resolution": "Determines the granularity of time selections in timer entities.",
+          "measure_when_filtration_off": "When disabled, chemical measurements (pH, ORP, etc.) are only taken while the filtration pump is running.",
+          "use_filtration1": "Creates timer entities for configuring automatic filtration schedule.",
+          "use_filtration2": "Creates timer entities for configuring automatic filtration schedule.",
+          "use_filtration3": "Creates timer entities for configuring automatic filtration schedule.",
+          "use_light": "Creates entities to control and monitor the pool light relay.",
+          "use_cover_sensor": "Creates a binary sensor and enables cover-related entities (hydrolysis cover reduction, shutdown temperature).",
+          "use_aux1": "Creates switch and timer entities for this auxiliary relay output.",
+          "use_aux2": "Creates switch and timer entities for this auxiliary relay output.",
+          "use_aux3": "Creates switch and timer entities for this auxiliary relay output.",
+          "use_aux4": "Creates switch and timer entities for this auxiliary relay output.",
+          "unlock_advanced": "Enter the unlock code to access advanced settings (format: device_prefix + current year).",
+          "enable_backwash_option": "Adds 'Backwash' to the filtration mode select. Only for systems with manual multi-way valves.",
+          "filtration_pump_power": "Set the rated wattage of the filtration pump. When non-zero, two sensors are created: instantaneous power (W) and cumulative energy (Wh), both usable in the Energy dashboard."
+        }
+      },
+      "advanced": {
+        "title": "Advanced Settings",
+        "description": "⚠️ WARNING: Incorrect use may damage filtration!",
+        "data": {
+          "enable_backwash_option": "Enable ‘Backwash’ mode",
+          "dev_overrides_enabled": "Enable developer overrides",
+          "dev_overrides": "Developer overrides (JSON object of \"key\":value)"
+        },
+        "data_description": {
+          "enable_backwash_option": "Adds 'Backwash' to the filtration mode select. Use with caution — improper use may damage your filtration system.",
+          "dev_overrides_enabled": "When enabled, values from the override JSON are injected into coordinator data for testing.",
+          "dev_overrides": "A JSON object where each key is a Modbus register name and each value overrides the actual reading."
+        }
+      }
+    },
+    "error": {
+      "unlock_advanced_error": "Invalid password. Try again or remove the password."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "ion_current": { "name": "Ionization Level" },
+      "hidro_current": { "name": "Hydrolysis Intensity" },
+      "measure_ph": { "name": "pH Level" },
+      "measure_rx": { "name": "Redox Potential" },
+      "measure_cl": { "name": "Salt Level" },
+      "measure_conductivity": { "name": "Conductivity Level" },
+      "measure_temperature": { "name": "Water Temperature" },
+      "hidro_voltage": { "name": "Hydrolysis Voltage" },
+      "device_time": { "name": "Device Time" },
+      "ph_status_alarm": {
+        "name": "pH Alarm",
+        "state": {
+          "ok": "OK",
+          "ph_high": "pH too high",
+          "ph_low": "pH too low",
+          "pump_stopped": "Pump stopped (exceeded working time)",
+          "ph_over": "pH higher than the set point",
+          "ph_under": "pH lower than the set point",
+          "tank_level": "Tank level alarm"
+        }
+      },
+      "hidro_polarity": {
+        "name": "Hydrolysis Polarity",
+        "state": {
+          "pol1": "Polarity 1",
+          "pol2": "Polarity 2",
+          "dead_time": "Dead Time",
+          "no_flow": "No Flow",
+          "off": "Off"
+        }
+      },
+      "ph_pump_status": {
+        "name": "pH Pump Status",
+        "state": {
+          "off": "Off",
+          "idle": "Idle",
+          "acid": "Acid Pump",
+          "base": "Base Pump",
+          "both": "Both Pumps"
+        }
+      },
+      "ion_polarity": {
+        "name": "Ionizer Polarity",
+        "state": {
+          "pol1": "Polarity 1",
+          "pol2": "Polarity 2",
+          "dead_time": "Dead Time",
+          "off": "Off"
+        }
+      },
+      "filt_mode": {
+        "name": "Filtration Mode",
+        "state": {
+          "manual": "Manual",
+          "auto": "Automatic",
+          "heating": "Heating",
+          "smart": "Smart",
+          "intelligent": "Intelligent",
+          "backwash": "Backwash"
+        }
+      },
+      "filtration_speed": {
+        "name": "Current filtration speed",
+        "state": {
+          "off": "Off",
+          "low": "Low",
+          "mid": "Medium",
+          "high": "High"
+        }
+      },
+      "intelligent_intervals": {
+        "name": "Intelligent Mode Intervals"
+      },
+      "intelligent_tt_next_interval": {
+        "name": "Intelligent Mode Next Interval Start"
+      },
+      "filtvalve_remaining": {
+        "name": "Backwash Time Remaining"
+      },
+      "filtration_remaining": {
+        "name": "Filtration Time Remaining"
+      },
+      "filtration_pump_power": {
+        "name": "Filtration Pump Power"
+      },
+      "filtration_pump_energy": {
+        "name": "Filtration Pump Energy"
+      }
+    },
+    "binary_sensor": {
+      "ph_acid_pump": { "name": "pH Acid Pump" },
+      "filtration_pump": { "name": "Filtration Active" },
+      "pool_light": { "name": "Pool Light" },
+      "ph_module_control_status": { "name": "pH Flow Detection Control" },
+      "ph_control_module": { "name": "pH Regulation Active" },
+      "ph_measurement_active": { "name": "pH Measurement" },
+      "redox_pump_active": { "name": "Redox Pump Active" },
+      "redox_control_module": { "name": "Redox Regulation Active" },
+      "redox_measurement_active": { "name": "Redox Measurement" },
+      "chlorine_flow_sensor_problem": { "name": "Chlorine Flow Sensor" },
+      "chlorine_pump_active": { "name": "Chlorine Pump Active" },
+      "chlorine_control_module": { "name": "Chlorine Regulation Active" },
+      "chlorine_measurement_active": { "name": "Chlorine Measurement" },
+      "conductivity_pump_active": { "name": "Conductivity Pump Active" },
+      "conductivity_control_module": { "name": "Conductivity Regulation Active" },
+      "conductivity_measurement_active": { "name": "Conductivity Measurement" },
+      "ion_on_target": { "name": "Ionizer On Target" },
+      "ion_low_flow": { "name": "Ionizer Production Problem" },
+      "ion_program_time_exceeded": { "name": "Ionizer Program Time Exceeded" },
+      "hidro_low_flow": { "name": "Hydrolysis Production Problem" },
+      "pool_cover": { "name": "Pool Cover" },
+      "hidro_module_active": { "name": "Hydrolysis Enabled" },
+      "hidro_module_regulated": { "name": "Hydrolysis Regulation Active" },
+      "hidro_activated_by_the_rx_module": { "name": "Hydrolysis Activated by Redox Module" },
+      "hidro_chlorine_shock_mode": { "name": "Hydrolysis Chlorine Shock Mode (Boost)" },
+      "hidro_activated_by_the_cl_module": { "name": "Hydrolysis Activated by Chlorine Module" },
+      "heating": { "name": "Heating" },
+      "uv_lamp": { "name": "UV Lamp" },
+      "device_time_out_of_sync": { "name": "Device Time Sync" },
+      "aux1": { "name": "Relay Aux1" },
+      "aux2": { "name": "Relay Aux2" },
+      "aux3": { "name": "Relay Aux3" },
+      "aux4": { "name": "Relay Aux4" }
+    },
+    "number": {
+      "hidro": { "name": "Hydrolisis Target Production Level" },
+      "ph1": { "name": "pH Max Limit" },
+      "ph2": { "name": "pH Min Limit" },
+      "rx1": { "name": "Redox Setpoint" },
+      "cl1": { "name": "Chlorine Setpoint" },
+      "heating_temp": { "name": "Temperature Setpoint" },
+      "smart_temp_high": { "name": "Smart upper temperature" },
+      "smart_temp_low": { "name": "Smart lower temperature" },
+      "hidro_cover_reduction": { "name": "Cover Reduction (when covered)" },
+      "hidro_shutdown_temperature": { "name": "Hydrolysis Shutdown Temp. Threshold" }
+    },
+    "switch": {
+      "winter_mode": { "name": "Winter Mode" },
+      "filt_manual_state": { "name": "Manual Filtration" },
+      "time_auto_sync": { "name": "Time Auto Sync" },
+      "clima_onoff": { "name": "Climate mode for heating" },
+      "smart_anti_freeze": { "name": "Smart antifreeze" },
+      "aux1": { "name": "Relay Aux1" },
+      "aux2": { "name": "Relay Aux2" },
+      "aux3": { "name": "Relay Aux3" },
+      "aux4": { "name": "Relay Aux4" },
+      "hidro_cover_enable": { "name": "Enable cover reduction (when covered)" },
+      "hidro_temp_shutdown": { "name": "Enable hydrolysis shutdown on high temperature" },
+      "uv_mode": { "name": "UV Mode" }
+    },
+    "light": {
+      "light": { "name": "Pool Light" }
+    },
+    "button": {
+      "sync_time": { "name": "Synchronize Device Time" },
+      "escape": { "name": "Clear Error Messages" },
+      "backwash": { "name": "Start Backwash" }
+    },
+    "select": {
+      "filtration1_start": { "name": "Timer 1 - Filtration Start" },
+      "filtration1_stop": { "name": "Timer 1 - Filtration Stop" },
+      "filtration1_speed": {
+        "name": "Timer 1 - Filtration Speed",
+        "state": { "low": "Low", "mid": "Medium", "high": "High" }
+      },
+      "filtration2_start": { "name": "Timer 2 - Filtration Start" },
+      "filtration2_stop": { "name": "Timer 2 - Filtration Stop" },
+      "filtration2_speed": {
+        "name": "Timer 2 - Filtration Speed",
+        "state": { "low": "Low", "mid": "Medium", "high": "High" }
+      },
+      "filtration3_start": { "name": "Timer 3 - Filtration Start" },
+      "filtration3_stop": { "name": "Timer 3 - Filtration Stop" },
+      "filtration3_speed": {
+        "name": "Timer 3 - Filtration Speed",
+        "state": { "low": "Low", "mid": "Medium", "high": "High" }
+      },
+      "relay_aux1_start": { "name": "Timer Aux1 (1) - Start" },
+      "relay_aux1_stop": { "name": "Timer Aux1 (1) - Stop" },
+      "relay_aux1b_start": { "name": "Timer Aux1 (2) - Start" },
+      "relay_aux1b_stop": { "name": "Timer Aux1 (2) - Stop" },
+      "relay_aux2_start": { "name": "Timer Aux2 (1) - Start" },
+      "relay_aux2_stop": { "name": "Timer Aux2 (1) - Stop" },
+      "relay_aux2b_start": { "name": "Timer Aux2 (2) - Start" },
+      "relay_aux2b_stop": { "name": "Timer Aux2 (2) - Stop" },
+      "relay_aux3_start": { "name": "Timer Aux3 (1) - Start" },
+      "relay_aux3_stop": { "name": "Timer Aux3 (1) - Stop" },
+      "relay_aux3b_start": { "name": "Timer Aux3 (2) - Start" },
+      "relay_aux3b_stop": { "name": "Timer Aux3 (2) - Stop" },
+      "relay_aux4_start": { "name": "Timer Aux4 (1) - Start" },
+      "relay_aux4_stop": { "name": "Timer Aux4 (1) - Stop" },
+      "relay_aux4b_start": { "name": "Timer Aux4 (2) - Start" },
+      "relay_aux4b_stop": { "name": "Timer Aux4 (2) - Stop" },
+      "relay_light_start": { "name": "Light Timer - Start" },
+      "relay_light_stop": { "name": "Light Timer - Stop" },
+      "relay_aux1_period": {
+        "name": "Timer Aux1 (1) - Interval",
+        "state": {
+          "1_day": "1 day",
+          "2_days": "2 days",
+          "3_days": "3 days",
+          "4_days": "4 days",
+          "5_days": "5 days",
+          "1_week": "1 week",
+          "2_weeks": "2 weeks",
+          "3_weeks": "3 weeks",
+          "4_weeks": "4 weeks"
+        }
+      },
+      "relay_aux1b_period": {
+        "name": "Timer Aux1 (2) - Interval",
+        "state": {
+          "1_day": "1 day",
+          "2_days": "2 days",
+          "3_days": "3 days",
+          "4_days": "4 days",
+          "5_days": "5 days",
+          "1_week": "1 week",
+          "2_weeks": "2 weeks",
+          "3_weeks": "3 weeks",
+          "4_weeks": "4 weeks"
+        }
+      },
+      "relay_aux2_period": {
+        "name": "Timer Aux2 (1) - Interval",
+        "state": {
+          "1_day": "1 day",
+          "2_days": "2 days",
+          "3_days": "3 days",
+          "4_days": "4 days",
+          "5_days": "5 days",
+          "1_week": "1 week",
+          "2_weeks": "2 weeks",
+          "3_weeks": "3 weeks",
+          "4_weeks": "4 weeks"
+        }
+      },
+      "relay_aux2b_period": {
+        "name": "Timer Aux2 (2) - Interval",
+        "state": {
+          "1_day": "1 day",
+          "2_days": "2 days",
+          "3_days": "3 days",
+          "4_days": "4 days",
+          "5_days": "5 days",
+          "1_week": "1 week",
+          "2_weeks": "2 weeks",
+          "3_weeks": "3 weeks",
+          "4_weeks": "4 weeks"
+        }
+      },
+      "relay_aux3_period": {
+        "name": "Timer Aux3 (1) - Interval",
+        "state": {
+          "1_day": "1 day",
+          "2_days": "2 days",
+          "3_days": "3 days",
+          "4_days": "4 days",
+          "5_days": "5 days",
+          "1_week": "1 week",
+          "2_weeks": "2 weeks",
+          "3_weeks": "3 weeks",
+          "4_weeks": "4 weeks"
+        }
+      },
+      "relay_aux3b_period": {
+        "name": "Timer Aux3 (2) - Interval",
+        "state": {
+          "1_day": "1 day",
+          "2_days": "2 days",
+          "3_days": "3 days",
+          "4_days": "4 days",
+          "5_days": "5 days",
+          "1_week": "1 week",
+          "2_weeks": "2 weeks",
+          "3_weeks": "3 weeks",
+          "4_weeks": "4 weeks"
+        }
+      },
+      "relay_aux4_period": {
+        "name": "Timer Aux4 (1) - Interval",
+        "state": {
+          "1_day": "1 day",
+          "2_days": "2 days",
+          "3_days": "3 days",
+          "4_days": "4 days",
+          "5_days": "5 days",
+          "1_week": "1 week",
+          "2_weeks": "2 weeks",
+          "3_weeks": "3 weeks",
+          "4_weeks": "4 weeks"
+        }
+      },
+      "relay_aux4b_period": {
+        "name": "Timer Aux4 (2) - Interval",
+        "state": {
+          "1_day": "1 day",
+          "2_days": "2 days",
+          "3_days": "3 days",
+          "4_days": "4 days",
+          "5_days": "5 days",
+          "1_week": "1 week",
+          "2_weeks": "2 weeks",
+          "3_weeks": "3 weeks",
+          "4_weeks": "4 weeks"
+        }
+      },
+      "relay_light_period": {
+        "name": "Light Timer - Interval",
+        "state": {
+          "1_day": "1 day",
+          "2_days": "2 days",
+          "3_days": "3 days",
+          "4_days": "4 days",
+          "5_days": "5 days",
+          "1_week": "1 week",
+          "2_weeks": "2 weeks",
+          "3_weeks": "3 weeks",
+          "4_weeks": "4 weeks"
+        }
+      },
+      "relay_aux1_mode": {
+        "name": "Relay Aux1 Mode",
+        "state": {
+          "disabled": "Disabled",
+          "auto": "Automatic",
+          "auto_linked": "Automatic (linked)",
+          "on": "On",
+          "off": "Off"
+        }
+      },
+      "relay_aux2_mode": {
+        "name": "Relay Aux2 Mode",
+        "state": {
+          "disabled": "Disabled",
+          "auto": "Automatic",
+          "auto_linked": "Automatic (linked)",
+          "on": "On",
+          "off": "Off"
+        }
+      },
+      "relay_aux3_mode": {
+        "name": "Relay Aux3 Mode",
+        "state": {
+          "disabled": "Disabled",
+          "auto": "Automatic",
+          "auto_linked": "Automatic (linked)",
+          "on": "On",
+          "off": "Off"
+        }
+      },
+      "relay_aux4_mode": {
+        "name": "Relay Aux4 Mode",
+        "state": {
+          "disabled": "Disabled",
+          "auto": "Automatic",
+          "auto_linked": "Automatic (linked)",
+          "on": "On",
+          "off": "Off"
+        }
+      },
+      "relay_light_mode": {
+        "name": "Light Mode",
+        "state": {
+          "disabled": "Disabled",
+          "auto": "Automatic",
+          "on": "On",
+          "off": "Off"
+        }
+      },
+      "filt_mode": {
+        "name": "Filtration Mode",
+        "state": {
+          "manual": "Manual",
+          "auto": "Automatic",
+          "heating": "Heating",
+          "smart": "Smart",
+          "intelligent": "Intelligent",
+          "backwash": "Backwash"
+        }
+      },
+      "filtration_speed": {
+        "name": "Filtration speed",
+        "state": {
+          "low": "Low",
+          "mid": "Medium",
+          "high": "High"
+        }
+      },
+      "cell_boost": {
+        "name": "Boost Mode",
+        "state": {
+          "inactive": "Inactive",
+          "active": "Active",
+          "active_redox": "Active (Redox control)"
+        }
+      },
+      "relay_activation_delay": {
+        "name": "pH pump activation delay",
+        "state": {
+          "10": "10 seconds",
+          "20": "20 seconds",
+          "30": "30 seconds",
+          "40": "40 seconds",
+          "50": "50 seconds",
+          "60": "1 minute",
+          "120": "2 minutes",
+          "180": "3 minutes",
+          "300": "5 minutes",
+          "900": "15 minutes",
+          "1800": "30 minutes",
+          "3600": "1 hour",
+          "10800": "3 hours"
+        }
+      },
+      "intelligent_filt_min_time": { "name": "Intelligent: Minimum Filtration Time" },
+      "filtvalve_period_minutes": {
+        "name": "Backwash Repeat Interval",
+        "state": {
+          "1_day": "1 day",
+          "2_days": "2 days",
+          "3_days": "3 days",
+          "4_days": "4 days",
+          "5_days": "5 days",
+          "1_week": "1 week",
+          "2_weeks": "2 weeks",
+          "3_weeks": "3 weeks",
+          "4_weeks": "4 weeks"
+        }
+      },
+      "filtvalve_mode": {
+        "name": "Backwash Valve Mode",
+        "state": {
+          "enabled": "Automatic",
+          "always_on": "Always On",
+          "always_off": "Always Off"
+        }
+      }
+    }
+  },
+  "services": {
+    "set_timer": {
+      "name": "Set timer",
+      "description": "Set or update a timer on the pool controller.",
+      "fields": {
+        "entry_id": {
+          "name": "Entry ID",
+          "description": "The unique ID of the integration entry. Optional."
+        },
+        "timer": {
+          "name": "Timer name",
+          "description": "The timer identifier (e.g., filtration1, filtration2, etc.)."
+        },
+        "start": {
+          "name": "Start time",
+          "description": "Start time in HH:MM format (e.g., 08:00)."
+        },
+        "stop": {
+          "name": "Stop time",
+          "description": "Stop time in HH:MM format (e.g., 16:00)."
+        },
+        "period": {
+          "name": "Repeat interval",
+          "description": "Repeat interval in seconds for AUX/Light timers (e.g., 86400 = every day). Not used for filtration timers."
+        }
+      }
+    },
+    "write_register": {
+      "name": "Write register",
+      "description": "Write a value to a Modbus holding register using FC16 with read-back verification.",
+      "fields": {
+        "entry_id": {
+          "name": "Entry ID",
+          "description": "The unique ID of the integration entry. Optional."
+        },
+        "address": {
+          "name": "Register address",
+          "description": "Modbus register address (decimal or hex, e.g. 1539 or 0x0603)."
+        },
+        "value": {
+          "name": "Value",
+          "description": "Value to write (0-65535, decimal or hex)."
+        },
+        "apply": {
+          "name": "Apply",
+          "description": "Save to EEPROM and execute after write (default: true)."
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "entry_not_found": { "message": "No NeoPool config entry found for entry_id {entry_id}" },
+    "no_loaded_entry": { "message": "No loaded NeoPool config entry available" },
+    "no_coordinator": { "message": "No NeoPool coordinator found for entry_id {entry_id}" },
+    "missing_parameter": { "message": "Missing required parameter {parameter}" },
+    "invalid_timer": { "message": "Invalid timer name {timer_name}. Valid timers: {valid_timers}" },
+    "timer_failed": { "message": "Timer setting failed: {error}" },
+    "invalid_apply": { "message": "Invalid apply {apply}: must be a boolean (true/false)" },
+    "write_failed": { "message": "Write to register {address} failed" },
+    "write_verification_failed": {
+      "message": "Write verification failed at {address}: wrote {value}, read back {confirmed}"
+    },
+    "register_write_failed": { "message": "Register write failed at {address}: {error}" },
+    "invalid_register_type": { "message": "Invalid {name} {value}: use a decimal number or hex (0x…)" },
+    "invalid_register_float": { "message": "Invalid {name} {value}: use an integer, not a float" },
+    "register_out_of_range": { "message": "{name} {value} out of range (0-65535)" }
+  },
+  "issues": {
+    "corrupted_gpio": {
+      "title": "Corrupted GPIO register(s) detected",
+      "description": "The following GPIO register(s) on your pool controller contain invalid values:\n\n{details}\n\nThis typically happens when the Modbus gateway framing mode does not match the integration's framer setting. The affected function(s) will not work correctly until the register(s) are restored to valid values.\n\nSee the integration documentation for repair instructions."
+    },
+    "domain_renamed": {
+      "title": "Integration domain migrated to neopool",
+      "description": "The integration domain has been renamed from `vistapool` to `neopool` to avoid a clash with the new core `vistapool` integration introduced in Home Assistant 2026.6.\n\n**{entries} config entr(ies)** and **{entities} entit(ies)** were migrated automatically. Your `entity_id`s, history, automations and dashboards continue to work without changes.\n\n**Old folder cleanup:** `{folder_cleaned}` (if `no`, please remove `custom_components/vistapool/` manually).\n\n**Please restart Home Assistant** to complete the migration."
+    },
+    "domain_rename_partial_failure": {
+      "title": "Migration to neopool partially failed",
+      "description": "Some VistaPool config entries could not be migrated to the new `neopool` domain:\n\n```\n{errors}\n```\n\nIf your pool controller is offline, deferred entries will retry on the next Home Assistant restart. Other failures should be investigated in the logs and reported on GitHub."
+    }
+  }
+}

--- a/custom_components/neopool/translations/cs.json
+++ b/custom_components/neopool/translations/cs.json
@@ -590,6 +590,10 @@
         "stop": {
           "name": "Čas konce",
           "description": "Čas konce ve formátu HH:MM (například 16:00)."
+        },
+        "period": {
+          "name": "Interval opakování",
+          "description": "Interval opakování v sekundách pro AUX/Light časovače (např. 86400 = každý den). Nepoužívá se pro filtrační časovače."
         }
       }
     },

--- a/custom_components/neopool/translations/de.json
+++ b/custom_components/neopool/translations/de.json
@@ -211,6 +211,12 @@
       },
       "filtration_remaining": {
         "name": "Verbleibende Filtrationszeit"
+      },
+      "filtration_pump_power": {
+        "name": "Leistung der Filtrationspumpe"
+      },
+      "filtration_pump_energy": {
+        "name": "Energie der Filtrationspumpe"
       }
     },
     "binary_sensor": {
@@ -584,6 +590,10 @@
         "stop": {
           "name": "Stoppzeit",
           "description": "Stoppzeit im HH:MM-Format (z. B. 16:00)."
+        },
+        "period": {
+          "name": "Wiederholungsintervall",
+          "description": "Wiederholungsintervall in Sekunden für AUX/Licht-Timer (z. B. 86400 = täglich). Wird nicht für Filtrationstimer verwendet."
         }
       }
     },

--- a/custom_components/neopool/translations/en.json
+++ b/custom_components/neopool/translations/en.json
@@ -590,6 +590,10 @@
         "stop": {
           "name": "Stop time",
           "description": "Stop time in HH:MM format (e.g., 16:00)."
+        },
+        "period": {
+          "name": "Repeat interval",
+          "description": "Repeat interval in seconds for AUX/Light timers (e.g., 86400 = every day). Not used for filtration timers."
         }
       }
     },

--- a/custom_components/neopool/translations/es.json
+++ b/custom_components/neopool/translations/es.json
@@ -211,6 +211,12 @@
       },
       "filtration_remaining": {
         "name": "Tiempo restante de filtración"
+      },
+      "filtration_pump_power": {
+        "name": "Potencia de la bomba de filtración"
+      },
+      "filtration_pump_energy": {
+        "name": "Energía de la bomba de filtración"
       }
     },
     "binary_sensor": {
@@ -275,7 +281,7 @@
       "uv_mode": { "name": "Modo UV" }
     },
     "light": {
-      "pool_light": { "name": "Luz de la piscina" }
+      "light": { "name": "Luz de la piscina" }
     },
     "button": {
       "sync_time": { "name": "Sincronizar hora del dispositivo" },
@@ -584,6 +590,10 @@
         "stop": {
           "name": "Hora de finalización",
           "description": "Hora de finalización en formato HH:MM (por ejemplo, 16:00)."
+        },
+        "period": {
+          "name": "Intervalo de repetición",
+          "description": "Intervalo de repetición en segundos para los temporizadores AUX/Luz (por ejemplo, 86400 = cada día). No se utiliza para los temporizadores de filtración."
         }
       }
     },

--- a/custom_components/neopool/translations/fr.json
+++ b/custom_components/neopool/translations/fr.json
@@ -211,6 +211,12 @@
       },
       "filtration_remaining": {
         "name": "Temps restant de filtration"
+      },
+      "filtration_pump_power": {
+        "name": "Puissance de la pompe de filtration"
+      },
+      "filtration_pump_energy": {
+        "name": "Énergie de la pompe de filtration"
       }
     },
     "binary_sensor": {
@@ -585,6 +591,10 @@
         "stop": {
           "name": "Heure de fin",
           "description": "Heure de fin au format HH:MM (par ex. 16:00)."
+        },
+        "period": {
+          "name": "Intervalle de répétition",
+          "description": "Intervalle de répétition en secondes pour les minuteurs AUX/Lumière (par ex. 86400 = tous les jours). Non utilisé pour les minuteurs de filtration."
         }
       }
     },

--- a/custom_components/neopool/translations/it.json
+++ b/custom_components/neopool/translations/it.json
@@ -211,6 +211,12 @@
       },
       "filtration_remaining": {
         "name": "Tempo rimanente di filtrazione"
+      },
+      "filtration_pump_power": {
+        "name": "Potenza della pompa di filtrazione"
+      },
+      "filtration_pump_energy": {
+        "name": "Energia della pompa di filtrazione"
       }
     },
     "binary_sensor": {
@@ -584,6 +590,10 @@
         "stop": {
           "name": "Ora di fine",
           "description": "Ora di fine nel formato HH:MM (ad es. 16:00)."
+        },
+        "period": {
+          "name": "Intervallo di ripetizione",
+          "description": "Intervallo di ripetizione in secondi per i timer AUX/Luce (ad es. 86400 = ogni giorno). Non utilizzato per i timer di filtrazione."
         }
       }
     },

--- a/custom_components/neopool/translations/pl.json
+++ b/custom_components/neopool/translations/pl.json
@@ -211,6 +211,12 @@
       },
       "filtration_remaining": {
         "name": "Pozostały czas filtracji"
+      },
+      "filtration_pump_power": {
+        "name": "Moc pompy filtracyjnej"
+      },
+      "filtration_pump_energy": {
+        "name": "Energia pompy filtracyjnej"
       }
     },
     "binary_sensor": {
@@ -275,7 +281,7 @@
       "uv_mode": { "name": "Tryb UV" }
     },
     "light": {
-      "pool_light": { "name": "Oświetlenie basenu" }
+      "light": { "name": "Oświetlenie basenu" }
     },
     "button": {
       "sync_time": { "name": "Synchronizuj czas urządzenia" },
@@ -584,6 +590,10 @@
         "stop": {
           "name": "Czas zakończenia",
           "description": "Czas zakończenia w formacie HH:MM (np. 16:00)."
+        },
+        "period": {
+          "name": "Interwał powtarzania",
+          "description": "Interwał powtarzania w sekundach dla timerów AUX/Światło (np. 86400 = codziennie). Nie jest używany dla timerów filtracji."
         }
       }
     },


### PR DESCRIPTION
## 🎯 Summary

Fixes several mismatches across translation files and introduces `strings.json` as a single source of truth for the default (English) strings.

## ✨ Changes

### New file
- 📄 `custom_components/neopool/strings.json` — mirror of `translations/en.json`. Centralizes the default English strings.

### Translation fixes (sync with sources of truth)

Found and fixed several mismatches across all 7 language files:

- 🌐 **`services.set_timer.fields.period`** — was defined in `services.yaml` but missing from every translation. Added in en, cs, de, es, fr, it, pl.
- 🌐 **`entity.sensor.filtration_pump_power` / `filtration_pump_energy`** — were missing from de, es, fr, it, pl.
- 🐛 **`entity.light.pool_light` → `entity.light.light`** — orphan key in es, pl (the entity's `translation_key` is `light`, not `pool_light` — `pool_light` is a binary sensor).

After these fixes, all 7 language files have **identical key structure** as `en.json` (657 keys each).

## ✅ Verification

- 🟢 **JSON validity**: all 8 files parse cleanly (`python -m json.tool`)
- 🟢 **Key structure alignment**: every translation has the same set of 657 keys as `en.json`
- 🟢 **`strings.json == translations/en.json`**: ✓
- 🟢 **`ruff check`**: All checks passed
- 🟢 **`ruff format --check`**: 31 files already formatted
- 🟢 **`basedpyright`**: 0 errors, 0 warnings
- 🟢 **`pytest`**: 568 passed
- 🟢 **Coverage**: 100%