### PR TITLE
chore: 🎨 improve lint compliance and code style

### DIFF
--- a/custom_components/neopool/__init__.py
+++ b/custom_components/neopool/__init__.py
@@ -30,8 +30,9 @@ from .coordinator import NeoPoolCoordinator
 
 # Re-exported for Home Assistant — HA calls async_migrate_entry(hass, entry)
 # from the integration's __init__ module when config entry version changes.
-from .migration import async_cleanup_legacy_files
-from .migration import async_migrate_entry as async_migrate_entry
+from .migration import async_cleanup_legacy_files, async_migrate_entry
+
+__all__ = ["async_migrate_entry"]
 
 type NeoPoolConfigEntry = ConfigEntry[NeoPoolCoordinator]
 

--- a/custom_components/neopool/__init__.py
+++ b/custom_components/neopool/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool Integration for Home Assistant"""
+"""NeoPool integration for Home Assistant."""
 
 import logging
 

--- a/custom_components/neopool/__init__.py
+++ b/custom_components/neopool/__init__.py
@@ -30,7 +30,8 @@ from .coordinator import NeoPoolCoordinator
 
 # Re-exported for Home Assistant — HA calls async_migrate_entry(hass, entry)
 # from the integration's __init__ module when config entry version changes.
-from .migration import async_migrate_entry as async_migrate_entry  # noqa: F401
+from .migration import async_cleanup_legacy_files
+from .migration import async_migrate_entry as async_migrate_entry
 
 type NeoPoolConfigEntry = ConfigEntry[NeoPoolCoordinator]
 
@@ -91,8 +92,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: NeoPoolConfigEntry) -> b
 
     # Remove .py modules whose implementation moved to the neopool-modbus
     # PyPI library; HACS does not prune deleted files on upgrade.
-    from .migration import async_cleanup_legacy_files
-
     await async_cleanup_legacy_files(hass)
 
     # Forward entities setup to Home Assistant

--- a/custom_components/neopool/binary_sensor.py
+++ b/custom_components/neopool/binary_sensor.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool Integration for Home Assistant - Binary Sensor Module"""
+"""NeoPool integration for Home Assistant - Binary Sensor module."""
 
 import logging
 from collections.abc import Mapping

--- a/custom_components/neopool/button.py
+++ b/custom_components/neopool/button.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool Integration for Home Assistant - Button Module"""
+"""NeoPool integration for Home Assistant - Button module."""
 
 import logging
 from typing import Any

--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -22,7 +22,8 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
-from homeassistant.helpers import device_registry as dr, translation as ha_translation
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import translation as ha_translation
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 from homeassistant.util import slugify
 from neopool_modbus.registers import DEFAULT_MODBUS_FRAMER

--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -391,4 +391,5 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> NeoPoolOptionsFlowHandler:
+        """Return the options flow handler for this entry."""
         return NeoPoolOptionsFlowHandler()

--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -83,6 +83,8 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
             key = f"component.{DOMAIN}.config.step.user.data.name_default"
             return t.get(key) or DEFAULT_NAME
         except Exception:  # noqa: BLE001
+            # Translation lookup is best-effort; on any failure we fall
+            # back to the literal English default so the form still opens.
             return DEFAULT_NAME
 
     async def async_step_user(
@@ -299,6 +301,12 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
         try:
             await migrate_single_entry_cross_domain(self.hass, legacy_entry)
         except Exception as exc:
+            # Intentionally broad: migration walks entity / device / config
+            # registries and the Modbus probe, so it can surface anything
+            # from HomeAssistantError to RuntimeError / OSError / NeoPoolError
+            # / ValueError. We never want a config-flow step to crash with a
+            # traceback — surface the message via abort(migration_failed)
+            # and let the user retry.
             _LOGGER.exception(
                 "Cross-domain migration failed for %s",
                 legacy_entry.entry_id,

--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -16,16 +16,13 @@
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
-
-if TYPE_CHECKING:
-    from .options_flow import NeoPoolOptionsFlowHandler
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
-from homeassistant.helpers import translation as ha_translation
+from homeassistant.helpers import device_registry as dr, translation as ha_translation
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 from homeassistant.util import slugify
 from neopool_modbus.registers import DEFAULT_MODBUS_FRAMER
@@ -40,6 +37,8 @@ from .const import (
     DOMAIN,
 )
 from .helpers import async_get_device_serial
+from .migration import async_cleanup_old_folder, migrate_single_entry_cross_domain
+from .options_flow import NeoPoolOptionsFlowHandler
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -250,11 +249,6 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
           - Fall through to the regular `async_step_user` form so the user
             can manually configure a fresh, unrelated neopool entry.
         """
-        from .migration import (
-            async_cleanup_old_folder,
-            migrate_single_entry_cross_domain,
-        )
-
         # The legacy entry might have been removed between async_step_user
         # detecting it and the user clicking Submit — re-resolve to be safe.
         legacy_entry = self.hass.config_entries.async_get_entry(self._legacy_entry_id)
@@ -278,8 +272,6 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
         # area_id, name_by_user, or labels. We capture them here keyed by
         # the device's serial-based identifier so we can match them onto the
         # new device after migration.
-        from homeassistant.helpers import device_registry as dr
-
         device_registry = dr.async_get(self.hass)
         snapshots: dict[str, dict[str, Any]] = {}
         for device in dr.async_entries_for_config_entry(
@@ -398,7 +390,5 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
     @staticmethod
     def async_get_options_flow(
         config_entry: ConfigEntry,
-    ) -> "NeoPoolOptionsFlowHandler":
-        from .options_flow import NeoPoolOptionsFlowHandler
-
+    ) -> NeoPoolOptionsFlowHandler:
         return NeoPoolOptionsFlowHandler()

--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool Integration for Home Assistant - Config Flow"""
+"""NeoPool integration for Home Assistant - Config flow."""
 
 import asyncio
 import logging

--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -298,7 +298,7 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
         # ── Run the cross-domain migration ───────────────────────────────
         try:
             await migrate_single_entry_cross_domain(self.hass, legacy_entry)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             _LOGGER.exception(
                 "Cross-domain migration failed for %s",
                 legacy_entry.entry_id,

--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -44,13 +44,15 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def is_host_port_open(host: str, port: int, timeout: int = 3) -> bool:
+    """Return True if a TCP connection to host:port can be established."""
     try:
         _, writer = await asyncio.wait_for(asyncio.open_connection(host, port), timeout)
         writer.close()
         await writer.wait_closed()
-        return True
-    except Exception:
+    except (TimeoutError, OSError):
         return False
+    else:
+        return True
 
 
 class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]

--- a/custom_components/neopool/const.py
+++ b/custom_components/neopool/const.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-NeoPool Integration for Home Assistant - Constants
+"""NeoPool integration for Home Assistant - constants.
 
 This file contains metadata about the integration such as name, version, domain, etc.
 The manifest file is loaded to get the integration name and version

--- a/custom_components/neopool/const.py
+++ b/custom_components/neopool/const.py
@@ -674,9 +674,9 @@ SELECT_DEFINITIONS = {
         "name": "Backwash Valve Mode",
         "entity_category": EntityCategory.CONFIG,
         "options_map": {
-            # 0: "disabled",     # valve disabled – hidden (covered by MBF_PAR_FILTVALVE_ENABLE)
+            # 0: "disabled",     # valve disabled - hidden (covered by MBF_PAR_FILTVALVE_ENABLE)
             1: "enabled",  # timer-controlled (MBV_PAR_CTIMER_ENABLED)
-            # 2: "auto_linked",  # linked to parent relay – not applicable for filtvalve
+            # 2: "auto_linked",  # linked to parent relay - not applicable for filtvalve
             3: "always_on",  # MBV_PAR_CTIMER_ALWAYS_ON
             4: "always_off",  # MBV_PAR_CTIMER_ALWAYS_OFF
         },

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -134,7 +134,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _check_gpio_registers(self, data: dict) -> None:
         """Validate GPIO register values after first successful read.
 
-        GPIO registers assign physical relay outputs (valid range 0–MAX_RELAY_GPIO).
+        GPIO registers assign physical relay outputs (valid range 0-MAX_RELAY_GPIO).
         A value outside this range indicates register corruption, which can happen
         when the Modbus gateway framing mode does not match the integration's framer
         setting (e.g. transparent gateway with TCP framer).
@@ -146,7 +146,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 corrupted.append((key, label, value))
                 _LOGGER.error(
                     "Corrupted GPIO register %s (%s): value %d (0x%04X) is outside "
-                    "valid range 0–%d. The pool controller may malfunction",
+                    "valid range 0-%d. The pool controller may malfunction",
                     key,
                     label,
                     value,
@@ -159,7 +159,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         if corrupted:
             details = "\n".join(
-                f"- **{label}** (`{key}`): value **{value}** (expected 0–{MAX_RELAY_GPIO})"
+                f"- **{label}** (`{key}`): value **{value}** (expected 0-{MAX_RELAY_GPIO})"
                 for key, label, value in corrupted
             )
             ir.async_create_issue(
@@ -179,7 +179,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _async_update_data(self) -> dict[str, Any]:
         # Winter mode: skip all Modbus communication; entities remain but show unknown values
         if self.winter_mode:
-            _LOGGER.debug("Winter mode active – skipping Modbus communication")
+            _LOGGER.debug("Winter mode active - skipping Modbus communication")
             return self.data if self.data is not None else self._capability_snapshot
 
         try:
@@ -400,7 +400,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 raise ConfigEntryNotReady(f"Error fetching data: {err}") from err
             # Raise UpdateFailed so the coordinator marks last_update_success=False.
             # All entities (except winter_mode and auto_time_sync switches) become unavailable.
-            _LOGGER.warning("Modbus error – marking all entities unavailable")
+            _LOGGER.warning("Modbus error - marking all entities unavailable")
             raise UpdateFailed(f"Modbus communication error: {err}") from err
 
     async def set_auto_time_sync(self, enabled: bool):

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -377,7 +377,9 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 options = dict(self.entry.options)
                 options["_capabilities"] = new_snapshot
                 self.hass.config_entries.async_update_entry(self.entry, options=options)
-            return data
+            # The except clause below always re-raises, so returning here
+            # rather than from an `else:` block keeps the happy path obvious.
+            return data  # noqa: TRY300
 
         except Exception as err:
             self._consecutive_errors += 1

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool Integration for Home Assistant - Coordinator Module"""
+"""NeoPool integration for Home Assistant - Coordinator module."""
 
 import json
 import logging

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -286,7 +286,11 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         _LOGGER.debug("Applied dev overrides: %s", overrides)
                     else:  # pragma: no cover
                         _LOGGER.warning("dev_overrides must be a JSON object (dict)")
-            except (json.JSONDecodeError, TypeError, ValueError) as dev_err:  # pragma: no cover
+            except (
+                json.JSONDecodeError,
+                TypeError,
+                ValueError,
+            ) as dev_err:  # pragma: no cover
                 _LOGGER.warning("Failed to apply dev_overrides: %s", dev_err)
 
             # Keep heating and intelligent setpoints synchronized based on the last change.
@@ -367,7 +371,13 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                             data["MBF_PAR_HEATING_TEMP"],
                             data["MBF_PAR_INTELLIGENT_TEMP"],
                         )
-            except (NeoPoolError, OSError, KeyError, TypeError, ValueError) as sync_err:  # pragma: no cover
+            except (
+                NeoPoolError,
+                OSError,
+                KeyError,
+                TypeError,
+                ValueError,
+            ) as sync_err:  # pragma: no cover
                 _LOGGER.debug("Setpoint auto-sync skipped due to error: %s", sync_err)
             # Keep capability snapshot up-to-date after every successful read and
             # persist it to options so it survives HA restarts while Modbus is down.
@@ -389,9 +399,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             # Exponential backoff: double the interval, but never more than max
             current_interval = self.update_interval or self.normal_update_interval
-            next_interval = current_interval * 2
-            if next_interval > self.max_update_interval:  # pragma: no cover
-                next_interval = self.max_update_interval
+            next_interval = min(current_interval * 2, self.max_update_interval)
             if self.update_interval != next_interval:
                 _LOGGER.warning(
                     "Increasing update interval to %s seconds due to communication errors.",

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -391,7 +391,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # rather than from an `else:` block keeps the happy path obvious.
             return data  # noqa: TRY300
 
-        except Exception as err:
+        except (NeoPoolError, OSError, TimeoutError) as err:
             self._consecutive_errors += 1
             _LOGGER.error(
                 "Modbus communication error: %s (%s)", err, type(err).__name__

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -66,6 +66,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         entry: ConfigEntry,
         entry_id: str,
     ) -> None:
+        """Initialise the NeoPool data update coordinator."""
         # Store normal and maximal intervals
         self.normal_update_interval = timedelta(
             seconds=entry.options.get("scan_interval", DEFAULT_SCAN_INTERVAL)
@@ -404,6 +405,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise UpdateFailed(f"Modbus communication error: {err}") from err
 
     async def set_auto_time_sync(self, enabled: bool):
+        """Persist the auto_time_sync flag and refresh the entry options."""
         self.auto_time_sync = enabled
         # Update the entry options to reflect the change
         # This is necessary to persist the setting across restarts
@@ -414,6 +416,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.hass.config_entries.async_update_entry(self.entry, options=options)
 
     async def set_winter_mode(self, enabled: bool):
+        """Toggle winter mode and persist the capability snapshot."""
         self.winter_mode = enabled
         options = dict(self.entry.options)
         options["winter_mode"] = enabled
@@ -431,12 +434,15 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     @property
     def firmware(self) -> str:
+        """Return the device firmware version string."""
         return self._firmware
 
     @property
     def model(self) -> str:
+        """Return the device model string."""
         return self._model
 
     @property
     def device_slug(self) -> str:  # pragma: no cover
+        """Return the slugified device name used as object_id prefix."""
         return slugify(self.device_name)

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -30,6 +30,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util import slugify
 from neopool_modbus import NeoPoolModbusClient
 from neopool_modbus.decoders import parse_version
+from neopool_modbus.exceptions import NeoPoolError
 from neopool_modbus.registers import (
     HEATING_SETPOINT_REGISTER,
     INTELLIGENT_SETPOINT_REGISTER,
@@ -285,7 +286,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         _LOGGER.debug("Applied dev overrides: %s", overrides)
                     else:  # pragma: no cover
                         _LOGGER.warning("dev_overrides must be a JSON object (dict)")
-            except Exception as dev_err:  # pragma: no cover
+            except (json.JSONDecodeError, TypeError, ValueError) as dev_err:  # pragma: no cover
                 _LOGGER.warning("Failed to apply dev_overrides: %s", dev_err)
 
             # Keep heating and intelligent setpoints synchronized based on the last change.
@@ -366,7 +367,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                             data["MBF_PAR_HEATING_TEMP"],
                             data["MBF_PAR_INTELLIGENT_TEMP"],
                         )
-            except Exception as sync_err:  # pragma: no cover
+            except (NeoPoolError, OSError, KeyError, TypeError, ValueError) as sync_err:  # pragma: no cover
                 _LOGGER.debug("Setpoint auto-sync skipped due to error: %s", sync_err)
             # Keep capability snapshot up-to-date after every successful read and
             # persist it to options so it survives HA restarts while Modbus is down.

--- a/custom_components/neopool/diagnostics.py
+++ b/custom_components/neopool/diagnostics.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool Integration for Home Assistant - Diagnostics Module"""
+"""NeoPool integration for Home Assistant - Diagnostics module."""
 
 from __future__ import annotations
 

--- a/custom_components/neopool/entity.py
+++ b/custom_components/neopool/entity.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-NeoPool Integration for Home Assistant - Entity Module
+"""NeoPool integration for Home Assistant - Entity module.
 
 This module defines the base entity class for the NeoPool integration.
 It provides common functionality for all entities, including device information,

--- a/custom_components/neopool/entity.py
+++ b/custom_components/neopool/entity.py
@@ -39,6 +39,7 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
     _winter_mode_active: bool = True
 
     def __init__(self, coordinator: NeoPoolCoordinator, entry_id: str) -> None:
+        """Initialise the base NeoPool entity."""
         super().__init__(coordinator)
         self._entry_id = entry_id
 

--- a/custom_components/neopool/entity.py
+++ b/custom_components/neopool/entity.py
@@ -69,7 +69,7 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
         machine_type = (get_machine_name(data) or "").strip()
         model_prefix = "NeoPool Compatible: " if machine_type else "NeoPool Compatible"
 
-        info = {
+        return {
             "identifiers": {(DOMAIN, hw_identifier)},
             "name": getattr(self.coordinator, "device_name", NAME),
             "model": f"{model_prefix}{machine_type}".strip(),
@@ -78,7 +78,6 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
             "sw_version": f"v{self.coordinator.firmware} (v{parse_version(data.get('MBF_PAR_VERSION'))})",
             "serial_number": serial_number,
         }
-        return info
 
     # Generate a unique object ID for the entity to use in Home Assistant
     # This remove the prefix "mbf_" and "par_" from the key and replaces spaces, dashes, and dots with underscores

--- a/custom_components/neopool/helpers.py
+++ b/custom_components/neopool/helpers.py
@@ -161,12 +161,12 @@ def parse_register_int(raw: int | str, name: str) -> int:
         )
     try:
         val = int(raw, 0) if isinstance(raw, str) else int(raw)
-    except (ValueError, TypeError):
+    except (ValueError, TypeError) as err:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="invalid_register_type",
             translation_placeholders={"name": name, "value": str(raw)},
-        )
+        ) from err
     if not 0 <= val <= 65535:
         raise ServiceValidationError(
             translation_domain=DOMAIN,

--- a/custom_components/neopool/helpers.py
+++ b/custom_components/neopool/helpers.py
@@ -30,7 +30,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from neopool_modbus import async_probe_serial
 from neopool_modbus.exceptions import NeoPoolError
-from neopool_modbus.registers import DEFAULT_MODBUS_FRAMER
+from neopool_modbus.registers import DEFAULT_MODBUS_FRAMER, is_valid_relay_gpio
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -138,8 +140,6 @@ def has_filtvalve(data: dict) -> bool:
     for cases where GPIO is 0 but the feature flag is explicitly set.
     Values outside the valid relay range (1-7) are treated as not present.
     """
-    from neopool_modbus.registers import is_valid_relay_gpio
-
     gpio = data.get("MBF_PAR_FILTVALVE_GPIO") or 0
     enable = data.get("MBF_PAR_FILTVALVE_ENABLE") or 0
     return is_valid_relay_gpio(gpio) or enable != 0
@@ -147,8 +147,6 @@ def has_filtvalve(data: dict) -> bool:
 
 def parse_register_int(raw: int | str, name: str) -> int:
     """Parse an integer from decimal or hex string (e.g. '1539' or '0x0603')."""
-    from .const import DOMAIN
-
     if isinstance(raw, bool):
         raise ServiceValidationError(
             translation_domain=DOMAIN,

--- a/custom_components/neopool/helpers.py
+++ b/custom_components/neopool/helpers.py
@@ -54,17 +54,15 @@ def get_device_time(
         # WORKAROUND: This is the naive datetime object, without timezone info
         dt_naive = datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=unix_ts)
         dt_local = dt_naive.replace(tzinfo=local_tz)
-        dt_utc = dt_local.astimezone(datetime.timezone.utc)
-        return dt_utc
-    else:
-        return datetime.datetime.fromtimestamp(unix_ts, tz=datetime.timezone.utc)
+        return dt_local.astimezone(datetime.timezone.utc)
+    return datetime.datetime.fromtimestamp(unix_ts, tz=datetime.timezone.utc)
 
 
 # This function prepares the device time for writing to the device
 # It takes the current time in the local timezone and converts it to a format suitable for the device
 def prepare_device_time(hass: HomeAssistant | None = None) -> list[int]:
-    """
-    Prepare device time for writing to the device.
+    """Prepare device time for writing to the device.
+
     Returns a list of two integers representing the low and high parts of the time.
     """
     if hass:

--- a/custom_components/neopool/helpers.py
+++ b/custom_components/neopool/helpers.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-NeoPool Integration for Home Assistant - Helpers Module
+"""NeoPool integration for Home Assistant - Helpers module.
 
 This module contains helper functions for the NeoPool integration.
 It includes functions to handle device time, prepare data for writing to the device,

--- a/custom_components/neopool/helpers.py
+++ b/custom_components/neopool/helpers.py
@@ -51,8 +51,9 @@ def get_device_time(
     unix_ts = (high << 16) | low
     if hass:
         local_tz = dt_util.get_time_zone(hass.config.time_zone)
-        # WORKAROUND: This is the naive datetime object, without timezone info
-        dt_naive = datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=unix_ts)
+        # The naive datetime is intentional: we localise it to the HA timezone
+        # below before converting to UTC, since the device clock has no tz info.
+        dt_naive = datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=unix_ts)  # noqa: DTZ001
         dt_local = dt_naive.replace(tzinfo=local_tz)
         return dt_local.astimezone(datetime.timezone.utc)
     return datetime.datetime.fromtimestamp(unix_ts, tz=datetime.timezone.utc)
@@ -72,7 +73,9 @@ def prepare_device_time(hass: HomeAssistant | None = None) -> list[int]:
         epoch_local = datetime.datetime(1970, 1, 1, tzinfo=ha_tz)
         unix_time_local = int((now_local - epoch_local).total_seconds())
     else:  # pragma: no cover
-        unix_time_local = int(datetime.datetime.now().timestamp())
+        # No hass available (unit tests / standalone helpers): fall back to the
+        # host clock. The device protocol expects local epoch seconds, not UTC.
+        unix_time_local = int(datetime.datetime.now().timestamp())  # noqa: DTZ005
     low = unix_time_local & 0xFFFF
     high = (unix_time_local >> 16) & 0xFFFF
     return [low, high]

--- a/custom_components/neopool/light.py
+++ b/custom_components/neopool/light.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool Integration for Home Assistant - Light Module"""
+"""NeoPool integration for Home Assistant - Light module."""
 
 import logging
 from typing import Any

--- a/custom_components/neopool/migration.py
+++ b/custom_components/neopool/migration.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool Integration for Home Assistant - Config Entry Migration"""
+"""NeoPool integration for Home Assistant - Config entry migration."""
 
 import asyncio
 import json

--- a/custom_components/neopool/migration.py
+++ b/custom_components/neopool/migration.py
@@ -206,6 +206,9 @@ async def _migrate_v1_to_v2(
                         rb_entity_id, new_unique_id=rb_old_uid
                     )
                 except Exception as rb_err:  # noqa: BLE001
+                    # Best-effort: if a single entry can't be restored we log
+                    # it and keep going with the rest, then raise the original
+                    # migration failure to the caller.
                     _LOGGER.error(
                         "Rollback failed for entity %s: %s", rb_entity_id, rb_err
                     )
@@ -309,6 +312,11 @@ async def async_migrate_from_vistapool(hass: HomeAssistant) -> dict:
                 f"{old_entry.title}: deferred (controller offline)"
             )
         except Exception as err:
+            # Intentionally broad: this loop processes every legacy vistapool
+            # entry independently and a single bad one must not abort the
+            # rest. Anything raised by migrate_single_entry_cross_domain
+            # (HomeAssistantError, RuntimeError, OSError, NeoPoolError, …)
+            # is logged and counted as a failure for this entry.
             _LOGGER.exception(
                 "Cross-domain migration failed for vistapool entry %s",
                 old_entry.entry_id,
@@ -500,6 +508,10 @@ async def migrate_single_entry_cross_domain(
                             new_config_entry_id=old_entry.entry_id,
                         )
                     except Exception:
+                        # Best-effort: if this entity can't be restored we
+                        # log and continue with the rest, then re-raise the
+                        # original ValueError so the caller surfaces the
+                        # migration failure.
                         _LOGGER.exception("Rollback failed for %s", ent_id)
                 raise
 
@@ -661,6 +673,8 @@ async def async_cleanup_old_folder(hass: HomeAssistant) -> bool:
     try:
         manifest = await hass.async_add_executor_job(_read_manifest_json, manifest_path)
     except Exception as err:  # noqa: BLE001
+        # Anything from JSONDecodeError to OSError counts as "manifest
+        # unreadable"; we refuse to delete a folder we can't identify.
         _LOGGER.warning(
             "Cannot read legacy manifest %s: %s — refusing to delete",
             manifest_path,
@@ -683,6 +697,9 @@ async def async_cleanup_old_folder(hass: HomeAssistant) -> bool:
     try:
         await hass.async_add_executor_job(shutil.rmtree, str(config_dir))
     except Exception as err:  # noqa: BLE001
+        # rmtree can raise PermissionError, OSError, or sub-classes thereof
+        # depending on the platform. We log and ask the user to remove the
+        # folder by hand rather than crashing the integration.
         _LOGGER.error(
             "Failed to delete legacy folder %s: %s — please remove it manually",
             config_dir,

--- a/custom_components/neopool/migration.py
+++ b/custom_components/neopool/migration.py
@@ -704,8 +704,7 @@ def _read_manifest_json(path: Path) -> dict:
 
 
 async def async_cleanup_legacy_files(hass: HomeAssistant) -> None:
-    """Remove .py modules whose implementation moved to the neopool-modbus
-    PyPI library.
+    """Remove .py modules whose implementation moved to the neopool-modbus PyPI library.
 
     HACS extracts ZIP releases on top of the existing
     `custom_components/neopool/` directory without deleting files that no

--- a/custom_components/neopool/migration.py
+++ b/custom_components/neopool/migration.py
@@ -308,7 +308,7 @@ async def async_migrate_from_vistapool(hass: HomeAssistant) -> dict:
             summary["errors"].append(
                 f"{old_entry.title}: deferred (controller offline)"
             )
-        except Exception as err:  # noqa: BLE001
+        except Exception as err:
             _LOGGER.exception(
                 "Cross-domain migration failed for vistapool entry %s",
                 old_entry.entry_id,
@@ -499,7 +499,7 @@ async def migrate_single_entry_cross_domain(
                             OLD_DOMAIN,
                             new_config_entry_id=old_entry.entry_id,
                         )
-                    except Exception:  # noqa: BLE001
+                    except Exception:
                         _LOGGER.exception("Rollback failed for %s", ent_id)
                 raise
 
@@ -581,11 +581,9 @@ def _register_entry_without_setup(hass: HomeAssistant, entry: ConfigEntry) -> No
     so an aborted migration leaves no stale row in
     `.storage/core.config_entries`.
     """
-    hass.config_entries._entries[entry.entry_id] = entry  # noqa: SLF001
+    hass.config_entries._entries[entry.entry_id] = entry
     hass.config_entries.async_update_issues()
-    hass.config_entries._async_dispatch(  # noqa: SLF001
-        ConfigEntryChange.ADDED, entry
-    )
+    hass.config_entries._async_dispatch(ConfigEntryChange.ADDED, entry)
 
 
 def _unregister_entry_without_save(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -609,13 +607,11 @@ def _unregister_entry_without_save(hass: HomeAssistant, entry: ConfigEntry) -> N
     Idempotent — silent if the entry is already gone (e.g. test mocks
     that didn't actually populate `_entries`).
     """
-    if hass.config_entries._entries.get(entry.entry_id) is None:  # noqa: SLF001
+    if hass.config_entries._entries.get(entry.entry_id) is None:
         return
-    del hass.config_entries._entries[entry.entry_id]  # noqa: SLF001
+    del hass.config_entries._entries[entry.entry_id]
     hass.config_entries.async_update_issues()
-    hass.config_entries._async_dispatch(  # noqa: SLF001
-        ConfigEntryChange.REMOVED, entry
-    )
+    hass.config_entries._async_dispatch(ConfigEntryChange.REMOVED, entry)
 
 
 async def _setup_registered_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -627,7 +623,7 @@ async def _setup_registered_entry(hass: HomeAssistant, entry: ConfigEntry) -> No
     first will fail inside `async_setup`.
     """
     await hass.config_entries.async_setup(entry.entry_id)
-    hass.config_entries._async_schedule_save()  # noqa: SLF001
+    hass.config_entries._async_schedule_save()
 
 
 async def async_cleanup_old_folder(hass: HomeAssistant) -> bool:

--- a/custom_components/neopool/migration.py
+++ b/custom_components/neopool/migration.py
@@ -26,6 +26,7 @@ from homeassistant.config_entries import (
     ConfigEntryChange,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
@@ -195,7 +196,7 @@ async def _migrate_v1_to_v2(
         try:
             entity_registry.async_update_entity(entity_id, new_unique_id=new_uid)
             applied.append((entity_id, old_uid, new_uid))
-        except Exception as err:
+        except (HomeAssistantError, ValueError, KeyError) as err:
             _LOGGER.error("Failed to migrate entity %s: %s", entity_id, err)
             # Roll back already-applied changes
             rollback_failed = False

--- a/custom_components/neopool/number.py
+++ b/custom_components/neopool/number.py
@@ -273,7 +273,7 @@ class NeoPoolNumber(NeoPoolEntity, NumberEntity):  # type: ignore[reportIncompat
         if (
             self.suggested_display_precision == 0 and raw is not None
         ):  # pragma: no cover
-            return int(round(raw))
+            return round(raw)
         if raw is None:
             return self._attr_native_value  # fallback if coordinator is not updated yet
         return round(raw, 2)

--- a/custom_components/neopool/number.py
+++ b/custom_components/neopool/number.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool Integration for Home Assistant - Number Module"""
+"""NeoPool integration for Home Assistant - Number module."""
 
 import asyncio
 import logging

--- a/custom_components/neopool/options_flow.py
+++ b/custom_components/neopool/options_flow.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool Integration for Home Assistant - Options Flow Module"""
+"""NeoPool integration for Home Assistant - Options flow module."""
 
 import logging
 from datetime import date

--- a/custom_components/neopool/options_flow.py
+++ b/custom_components/neopool/options_flow.py
@@ -15,7 +15,6 @@
 """NeoPool integration for Home Assistant - Options flow module."""
 
 import logging
-from datetime import date
 from typing import Any
 
 import voluptuous as vol
@@ -23,6 +22,7 @@ from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
+from homeassistant.util import dt as dt_util
 from homeassistant.util import slugify
 
 from .const import (
@@ -57,7 +57,7 @@ class NeoPoolOptionsFlowHandler(config_entries.OptionsFlow):
         device_slug = slugify(
             self.config_entry.data.get(CONF_NAME) or self.config_entry.title
         )
-        expected = f"{device_slug}{date.today().year}"
+        expected = f"{device_slug}{dt_util.now().year}"
 
         schema_dict = {
             vol.Optional(

--- a/custom_components/neopool/select.py
+++ b/custom_components/neopool/select.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool Integration for Home Assistant - Select Module"""
+"""NeoPool integration for Home Assistant - Select module."""
 
 import asyncio
 import logging

--- a/custom_components/neopool/select.py
+++ b/custom_components/neopool/select.py
@@ -335,7 +335,8 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):  # type: ignore[reportIncompat
             await client.async_write_register(self._register, value)
             if self._key == "MBF_PAR_FILT_MODE" and option == "backwash":
                 _LOGGER.info(
-                    f'Your pool "{NeoPoolEntity.slugify(self.coordinator.device_name)}" has been switched to the BACKWASH mode!'
+                    'Your pool "%s" has been switched to the BACKWASH mode!',
+                    NeoPoolEntity.slugify(self.coordinator.device_name),
                 )
 
             # Optimistic update + schedule follow-up
@@ -422,7 +423,7 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):  # type: ignore[reportIncompat
             if value is not None:
                 current_hhmm = seconds_to_hhmm(value)
                 if current_hhmm not in options_list:  # pragma: no cover
-                    return [current_hhmm] + options_list
+                    return [current_hhmm, *options_list]
             return options_list
 
         # Handle Timer Period options
@@ -443,9 +444,9 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):  # type: ignore[reportIncompat
             value = self.coordinator.data.get(f"{timer_name}_enable")
             # Dynamically add "disabled" at the beginning if enable==0
             if value == 0 and "disabled" not in options:
-                options = ["disabled"] + options
+                options = ["disabled", *options]
             if value == 2 and "auto_linked" not in options:  # pragma: no cover
-                options = ["auto_linked"] + options
+                options = ["auto_linked", *options]
             return options
 
         # Mapped register selects: return labels from options_map.
@@ -455,7 +456,7 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):  # type: ignore[reportIncompat
             value = self.coordinator.data.get(self._key)
             if isinstance(value, int) and value not in self._options_map:
                 suffix = self._props.get("fallback_suffix", "")
-                return [f"{value}{suffix}"] + options
+                return [f"{value}{suffix}", *options]
             return options
 
         return [self._options_map[k] for k in option_keys]

--- a/custom_components/neopool/select.py
+++ b/custom_components/neopool/select.py
@@ -487,10 +487,10 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):  # type: ignore[reportIncompat
             # 0: Inactive
             if reg_val == 0:
                 return self._options_map[0]
-            # 1: Active (redox control disabled) – bit 0x8000 set
+            # 1: Active (redox control disabled) - bit 0x8000 set
             elif reg_val & 0x8000:
                 return self._options_map[1]
-            # 2: Active (Redox control) – bits 0x0500 | 0x00A0 set and 0x8000 NOT set
+            # 2: Active (Redox control) - bits 0x0500 | 0x00A0 set and 0x8000 NOT set
             elif (reg_val & (0x0500 | 0x00A0)) == (0x0500 | 0x00A0):
                 return self._options_map[2]
             # fallback (should not occur)

--- a/custom_components/neopool/select.py
+++ b/custom_components/neopool/select.py
@@ -543,6 +543,7 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):  # type: ignore[reportIncompat
 
     @property
     def available(self) -> bool:  # type: ignore[override]
+        """Return whether the select entity should be presented as available."""
         if self._key == "MBF_PAR_FILTRATION_SPEED":
             if not super().available:
                 return False

--- a/custom_components/neopool/select.py
+++ b/custom_components/neopool/select.py
@@ -180,7 +180,7 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):  # type: ignore[reportIncompat
             if value is None:
                 try:
                     value = int(option.rstrip("ms"))
-                except Exception:  # pragma: no cover
+                except (TypeError, ValueError):  # pragma: no cover
                     return
             write_val = value + self._props.get("write_offset", 0)
             await client.async_write_register(self._register, max(0, write_val))
@@ -224,7 +224,7 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):  # type: ignore[reportIncompat
                 # fallback to integer conversion
                 try:
                     period_value = int(option)
-                except Exception:  # pragma: no cover
+                except (TypeError, ValueError):  # pragma: no cover
                     return
 
             await self.hass.services.async_call(

--- a/custom_components/neopool/sensor.py
+++ b/custom_components/neopool/sensor.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool Integration for Home Assistant - Sensor Module"""
+"""NeoPool integration for Home Assistant - Sensor module."""
 
 import logging
 import math

--- a/custom_components/neopool/sensor.py
+++ b/custom_components/neopool/sensor.py
@@ -383,6 +383,7 @@ class NeoPoolFiltrationEnergySensor(NeoPoolEntity, SensorEntity, RestoreEntity):
         entry_id: str,
         pump_power_w: int,
     ) -> None:
+        """Initialise the filtration-pump energy accumulator sensor."""
         super().__init__(coordinator, entry_id)
         self._pump_power_w = pump_power_w
         self._attr_suggested_object_id = (

--- a/custom_components/neopool/switch.py
+++ b/custom_components/neopool/switch.py
@@ -364,7 +364,7 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):  # type: ignore[reportIncompat
     @property
     def available(self) -> bool:  # type: ignore[override]
         """Return True if the switch is available."""
-        # These switches are pure HA settings (not device state) – always operable.
+        # These switches are pure HA settings (not device state) - always operable.
         if self._switch_type in ("winter_mode", "auto_time_sync"):
             return True
         if not super().available:

--- a/custom_components/neopool/switch.py
+++ b/custom_components/neopool/switch.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool Integration for Home Assistant - Switch Module"""
+"""NeoPool integration for Home Assistant - Switch module."""
 
 import logging
 from collections.abc import Mapping

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ select = [
     # Blind except
     "BLE",
     # Selected pydocstyle rules — module / public-method / __init__ docstrings
-    # plus the "summary line + period" hygiene that HA core also enforces.
+    # plus the "summary line + period" hygiene.
     "D102", "D107", "D205", "D415",
     # Datetime: timezone-aware constructors
     "DTZ",
@@ -44,10 +44,10 @@ ignore = [
 # Tests use plenty of in-function imports for monkeypatch boundaries and
 # don't follow the same docstring conventions as production code.
 "tests/**/*.py" = ["PLC0415", "D102", "D107", "D205", "D415"]
-# __init__.py still hosts the legacy service-handler block; PLC0415, B904 and
-# TRY301 there are slated for removal when service handlers move to a dedicated
-# services.py module in a follow-up refactor.
-"custom_components/neopool/__init__.py" = ["PLC0415", "B904", "TRY301"]
+# __init__.py still hosts the legacy service-handler block; PLC0415, B904,
+# TRY301 and BLE001 there are slated for removal when service handlers move
+# to a dedicated services.py module in a follow-up refactor.
+"custom_components/neopool/__init__.py" = ["PLC0415", "B904", "TRY301", "BLE001"]
 
 [tool.codespell]
 skip = "??.json,CHANGELOG.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,45 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I"]
-ignore = ["E501"]
+select = [
+    # Default Python style / errors
+    "E", "F", "W", "I",
+    # Bugbear (likely bugs)
+    "B",
+    # Blind except
+    "BLE",
+    # Selected pydocstyle rules — module / public-method / __init__ docstrings
+    # plus the "summary line + period" hygiene that HA core also enforces.
+    "D102", "D107", "D205", "D415",
+    # Datetime: timezone-aware constructors
+    "DTZ",
+    # Logging format (% placeholders, not f-strings)
+    "G",
+    # Imports at top-level (not inside functions, save for genuine circulars)
+    "PLC0415",
+    # min/max collapse
+    "PLR1730",
+    # Drop redundant assignment-before-return
+    "RET504",
+    # Ruff-specific: ambiguous Unicode (EN DASH etc.), modern unpacking,
+    # int-cast on already-int, unused noqa hygiene
+    "RUF001", "RUF002", "RUF003", "RUF005", "RUF046", "RUF100",
+    # Try/except hygiene: chain causes, prefer else over duplicate paths
+    "B904", "TRY300", "TRY301",
+]
+ignore = [
+    # Long lines are formatter-managed; ruff format wraps where it can.
+    "E501",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests use plenty of in-function imports for monkeypatch boundaries and
+# don't follow the same docstring conventions as production code.
+"tests/**/*.py" = ["PLC0415", "D102", "D107", "D205", "D415"]
+# __init__.py still hosts the legacy service-handler block; PLC0415, B904 and
+# TRY301 there are slated for removal when service handlers move to a dedicated
+# services.py module in a follow-up refactor.
+"custom_components/neopool/__init__.py" = ["PLC0415", "B904", "TRY301"]
 
 [tool.codespell]
 skip = "??.json,CHANGELOG.md"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -193,9 +193,9 @@ def test_async_get_options_flow(monkeypatch):
         def __init__(self):
             self.called = True
 
-    # Patch import ve funkci
+    # Patch the symbol bound in config_flow's namespace (top-level import)
     monkeypatch.setattr(
-        "custom_components.neopool.options_flow.NeoPoolOptionsFlowHandler",
+        "custom_components.neopool.config_flow.NeoPoolOptionsFlowHandler",
         DummyOptionsFlow,
     )
     config_entry = DummyConfigEntry()
@@ -1229,11 +1229,11 @@ async def test_import_step_runs_migration_and_restores_device():
 
     with (
         patch(
-            "custom_components.neopool.migration.migrate_single_entry_cross_domain",
+            "custom_components.neopool.config_flow.migrate_single_entry_cross_domain",
             new=AsyncMock(return_value=2),
         ) as migrate_mock,
         patch(
-            "custom_components.neopool.migration.async_cleanup_old_folder",
+            "custom_components.neopool.config_flow.async_cleanup_old_folder",
             new=AsyncMock(return_value=True),
         ) as cleanup_mock,
         patch(
@@ -1285,11 +1285,11 @@ async def test_import_step_skips_device_without_vistapool_identifier():
 
     with (
         patch(
-            "custom_components.neopool.migration.migrate_single_entry_cross_domain",
+            "custom_components.neopool.config_flow.migrate_single_entry_cross_domain",
             new=AsyncMock(return_value=0),
         ),
         patch(
-            "custom_components.neopool.migration.async_cleanup_old_folder",
+            "custom_components.neopool.config_flow.async_cleanup_old_folder",
             new=AsyncMock(return_value=True),
         ),
         patch(
@@ -1335,11 +1335,11 @@ async def test_import_step_skips_restore_when_migrated_device_missing():
 
     with (
         patch(
-            "custom_components.neopool.migration.migrate_single_entry_cross_domain",
+            "custom_components.neopool.config_flow.migrate_single_entry_cross_domain",
             new=AsyncMock(return_value=0),
         ),
         patch(
-            "custom_components.neopool.migration.async_cleanup_old_folder",
+            "custom_components.neopool.config_flow.async_cleanup_old_folder",
             new=AsyncMock(return_value=True),
         ),
         patch(
@@ -1372,7 +1372,7 @@ async def test_import_step_aborts_on_migration_failure():
 
     with (
         patch(
-            "custom_components.neopool.migration.migrate_single_entry_cross_domain",
+            "custom_components.neopool.config_flow.migrate_single_entry_cross_domain",
             new=AsyncMock(side_effect=RuntimeError("simulated failure")),
         ),
         patch(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -621,7 +621,7 @@ async def test_get_default_name_falls_back_on_translation_error():
 
 
 # ---------------------------------------------------------------------------
-# async_step_user – name fallback
+# async_step_user - name fallback
 # ---------------------------------------------------------------------------
 
 
@@ -684,7 +684,7 @@ async def test_create_entry_no_name_key_uses_default():
 
 
 # ---------------------------------------------------------------------------
-# async_step_user – form schema defaults
+# async_step_user - form schema defaults
 # ---------------------------------------------------------------------------
 
 
@@ -742,7 +742,7 @@ async def test_user_form_schema_connection_defaults():
 
 
 # ---------------------------------------------------------------------------
-# async_step_user – optional flags stored correctly
+# async_step_user - optional flags stored correctly
 # ---------------------------------------------------------------------------
 
 
@@ -809,7 +809,7 @@ async def test_create_entry_stores_filtration_flags():
 
 
 # ---------------------------------------------------------------------------
-# async_step_reconfigure – missing optional keys fall back to constants
+# async_step_reconfigure - missing optional keys fall back to constants
 # ---------------------------------------------------------------------------
 
 
@@ -872,10 +872,12 @@ async def test_trial_modbus_read_success():
 
 @pytest.mark.asyncio
 async def test_trial_modbus_read_neopool_error_returns_none():
-    """Probe-level errors (timeout, connect refused, Modbus error, …) all
-    surface to the helper as NeoPoolError; the helper swallows them and
-    reports None so the config-flow / migration callers can treat them as
-    "device unreachable" rather than crashing."""
+    """Probe-level errors all surface to the helper as NeoPoolError.
+
+    Timeout, connect refused, Modbus error, etc. — the helper swallows them
+    and reports None so the config-flow / migration callers can treat them
+    as "device unreachable" rather than crashing.
+    """
     from neopool_modbus.exceptions import NeoPoolError
 
     from custom_components.neopool.helpers import async_get_device_serial

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import UpdateFailed
+from neopool_modbus.exceptions import NeoPoolError
 
 from custom_components.neopool.const import DOMAIN, FOLLOW_UP_REFRESH_DELAY
 from custom_components.neopool.coordinator import NeoPoolCoordinator
@@ -51,7 +52,7 @@ async def test_async_update_data_success(mock_entry):
 async def test_async_update_data_raises_UpdateFailed_on_subsequent_error(mock_entry):
     """When cached data exists, a Modbus error raises UpdateFailed (not a silent cache return)."""
     client = AsyncMock()
-    client.async_read_all = AsyncMock(side_effect=Exception("Modbus fail"))
+    client.async_read_all = AsyncMock(side_effect=NeoPoolError("Modbus fail"))
     client.read_all_timers = AsyncMock()
     coordinator = NeoPoolCoordinator(
         MagicMock(), client, mock_entry, mock_entry.entry_id
@@ -65,7 +66,7 @@ async def test_async_update_data_raises_UpdateFailed_on_subsequent_error(mock_en
 @pytest.mark.asyncio
 async def test_async_update_data_raises_ConfigEntryNotReady_on_first_error(mock_entry):
     client = AsyncMock()
-    client.async_read_all = AsyncMock(side_effect=Exception("fail"))
+    client.async_read_all = AsyncMock(side_effect=NeoPoolError("fail"))
     client.read_all_timers = AsyncMock()
     coordinator = NeoPoolCoordinator(
         MagicMock(), client, mock_entry, mock_entry.entry_id
@@ -81,7 +82,7 @@ async def test_async_update_data_raises_UpdateFailed_when_data_is_empty_dict(
 ):
     """An empty dict ({}) is treated as 'data was received' — subsequent errors raise UpdateFailed."""
     client = AsyncMock()
-    client.async_read_all = AsyncMock(side_effect=Exception("fail"))
+    client.async_read_all = AsyncMock(side_effect=NeoPoolError("fail"))
     client.read_all_timers = AsyncMock()
     coordinator = NeoPoolCoordinator(
         MagicMock(), client, mock_entry, mock_entry.entry_id

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -483,7 +483,7 @@ async def test_winter_mode_returns_frozen_cached_data(mock_entry):
     data = await coordinator._async_update_data()
 
     client.async_read_all.assert_not_called()
-    assert data is cached  # same object – not a copy, frozen in place
+    assert data is cached  # same object - not a copy, frozen in place
 
 
 @pytest.mark.asyncio
@@ -551,8 +551,8 @@ async def test_set_winter_mode_snapshots_capability_keys(mock_entry):
         "MBF_PAR_MODEL": 3,
         "MBF_PAR_TEMPERATURE_ACTIVE": 1,
         "MBF_PAR_HEATING_GPIO": 5,
-        "MBF_MEASURE_TEMPERATURE": 27.5,  # measurement – must NOT be in snapshot
-        "MBF_PAR_FILT_MODE": 2,  # runtime value – must NOT be in snapshot
+        "MBF_MEASURE_TEMPERATURE": 27.5,  # measurement - must NOT be in snapshot
+        "MBF_PAR_FILT_MODE": 2,  # runtime value - must NOT be in snapshot
     }
 
     await coordinator.set_winter_mode(True)
@@ -596,8 +596,11 @@ async def test_winter_mode_restores_capabilities_from_options_on_restart(mock_en
 
 @pytest.mark.asyncio
 async def test_async_update_data_updates_capability_snapshot(mock_entry):
-    """A successful Modbus read updates _capability_snapshot with the capability keys
-    and persists it to entry.options so it survives HA restarts while Modbus is down."""
+    """A successful Modbus read updates the capability snapshot.
+
+    The snapshot contains all capability keys and is persisted to
+    entry.options so it survives HA restarts while Modbus is down.
+    """
     mock_entry.options = {"winter_mode": False}
 
     client = AsyncMock()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -129,7 +129,7 @@ def test_get_filtration_speed_cumulative_encoding(relay_state, expected):
     """Controllers using cumulative (thermometer) speed bits (#152)."""
     d = {
         "MBF_RELAY_STATE": relay_state,
-        "MBF_PAR_FILTRATION_CONF": 0x0020,  # conf says high – must be ignored
+        "MBF_PAR_FILTRATION_CONF": 0x0020,  # conf says high - must be ignored
         "Filtration Pump": True,
     }
     assert get_filtration_speed(d) == expected

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -67,10 +67,10 @@ async def test_options_unlock_advanced_correct(monkeypatch):
     mock_config_entry.data = {"name": "Pool"}
     flow = make_flow(mock_config_entry)
 
-    with patch("custom_components.neopool.options_flow.date") as mock_date:
-        mock_today = MagicMock()
-        mock_today.year = 2025
-        mock_date.today.return_value = mock_today
+    with patch("custom_components.neopool.options_flow.dt_util") as mock_dt_util:
+        mock_now = MagicMock()
+        mock_now.year = 2025
+        mock_dt_util.now.return_value = mock_now
         # Password is derived from slugified name, NOT from unique_id
         user_input = {"unlock_advanced": "pool2025"}
         flow.async_step_advanced = AsyncMock(return_value="advanced_step_called")
@@ -88,8 +88,8 @@ async def test_options_unlock_advanced_wrong(monkeypatch, caplog):
     mock_config_entry.data = {"name": "Pool"}
     flow = make_flow(mock_config_entry)
 
-    with patch("custom_components.neopool.options_flow.date") as mock_date:
-        mock_date.today.return_value.year = 2025
+    with patch("custom_components.neopool.options_flow.dt_util") as mock_dt_util:
+        mock_dt_util.now.return_value.year = 2025
         user_input = {"unlock_advanced": "wrongpassword"}
         result = await flow.async_step_init(user_input=user_input)
         # Should show error in form
@@ -108,10 +108,10 @@ async def test_options_unlock_advanced_correct_slug_fallback(monkeypatch):
     mock_config_entry.data = {"name": "My Pool"}
     flow = make_flow(mock_config_entry)
 
-    with patch("custom_components.neopool.options_flow.date") as mock_date:
-        mock_today = MagicMock()
-        mock_today.year = 2025
-        mock_date.today.return_value = mock_today
+    with patch("custom_components.neopool.options_flow.dt_util") as mock_dt_util:
+        mock_now = MagicMock()
+        mock_now.year = 2025
+        mock_dt_util.now.return_value = mock_now
         # slugify("My Pool") == "my_pool", so expected password is "my_pool2025"
         user_input = {"unlock_advanced": "my_pool2025"}
         flow.async_step_advanced = AsyncMock(return_value="advanced_step_called")
@@ -129,8 +129,8 @@ async def test_options_unlock_advanced_wrong_slug_fallback(monkeypatch, caplog):
     mock_config_entry.data = {"name": "My Pool"}
     flow = make_flow(mock_config_entry)
 
-    with patch("custom_components.neopool.options_flow.date") as mock_date:
-        mock_date.today.return_value.year = 2025
+    with patch("custom_components.neopool.options_flow.dt_util") as mock_dt_util:
+        mock_dt_util.now.return_value.year = 2025
         user_input = {"unlock_advanced": "wrongpassword"}
         result = await flow.async_step_init(user_input=user_input)
         assert result.get("type") == "form"
@@ -148,10 +148,10 @@ async def test_options_unlock_advanced_title_fallback(monkeypatch):
     mock_config_entry.title = "My Pool"
     flow = make_flow(mock_config_entry)
 
-    with patch("custom_components.neopool.options_flow.date") as mock_date:
-        mock_today = MagicMock()
-        mock_today.year = 2025
-        mock_date.today.return_value = mock_today
+    with patch("custom_components.neopool.options_flow.dt_util") as mock_dt_util:
+        mock_now = MagicMock()
+        mock_now.year = 2025
+        mock_dt_util.now.return_value = mock_now
         # Falls back to slugify("My Pool") == "my_pool"
         user_input = {"unlock_advanced": "my_pool2025"}
         flow.async_step_advanced = AsyncMock(return_value="advanced_step_called")

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -120,8 +120,11 @@ def test_options_add_backwash(mock_coordinator):
 
 
 def test_options_add_backwash_via_filtvalve(mock_coordinator):
-    """Backwash must appear automatically when MBF_PAR_FILTVALVE_ENABLE=1 (Besgo valve),
-    even without enable_backwash_option in config options."""
+    """Backwash appears automatically when a Besgo valve is enabled.
+
+    MBF_PAR_FILTVALVE_ENABLE=1 must add backwash to the options list even
+    without enable_backwash_option set in config options.
+    """
     props = make_props(options_map={0: "auto", 1: "manual", 2: "off", 13: "backwash"})
     ent = NeoPoolSelect(mock_coordinator, "test_entry", "MBF_PAR_FILT_MODE", props)
     mock_coordinator.data = {"MBF_PAR_FILTVALVE_ENABLE": 1}
@@ -151,8 +154,11 @@ def test_options_add_backwash_via_gpio_only(mock_coordinator):
 
 
 def test_options_backwash_kept_when_active(mock_coordinator):
-    """Backwash must stay in options if device is currently in mode 13,
-    even when backwash is not allowed — so current_option stays valid."""
+    """Backwash stays in options if the device is currently in mode 13.
+
+    Even when backwash is not normally allowed, keeping it in options lets
+    current_option remain valid for the active mode.
+    """
     props = make_props(options_map={0: "auto", 1: "manual", 2: "off", 13: "backwash"})
     ent = NeoPoolSelect(mock_coordinator, "test_entry", "MBF_PAR_FILT_MODE", props)
     mock_coordinator.data = {
@@ -366,6 +372,7 @@ async def test_async_select_option_backwash(mock_coordinator):
 @pytest.mark.asyncio
 async def test_async_select_option_backwash_from_manual(mock_coordinator):
     """Switching from manual to backwash with a MANUAL valve must stop the pump first.
+
     The user needs the pump stopped so they can safely rotate the multi-way valve.
     """
     props = SELECT_DEFINITIONS["MBF_PAR_FILT_MODE"]
@@ -393,8 +400,10 @@ async def test_async_select_option_backwash_from_manual(mock_coordinator):
 
 @pytest.mark.asyncio
 async def test_async_select_option_backwash_from_manual_auto_valve(mock_coordinator):
-    """Switching from manual to backwash with an AUTOMATIC valve (Besgo) must NOT
-    stop the pump - it must keep running so the valve opens correctly.
+    """Switching from manual to backwash with an AUTOMATIC valve must keep the pump running.
+
+    A Besgo automatic valve needs flow to open correctly, so the pump must
+    keep running across the mode transition.
     """
     props = SELECT_DEFINITIONS["MBF_PAR_FILT_MODE"]
     ent = NeoPoolSelect(mock_coordinator, "test_entry", "MBF_PAR_FILT_MODE", props)
@@ -1129,7 +1138,7 @@ async def test_select_filtvalve_mode_created_with_gpio_only(mock_coordinator):
         (1, "enabled"),
         (3, "always_on"),
         (4, "always_off"),
-        (0, None),  # disabled – not in options_map, returns None
+        (0, None),  # disabled - not in options_map, returns None
     ],
 )
 def test_select_filtvalve_mode_current_option(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -776,7 +776,7 @@ async def test_sensor_setup_with_capability_snapshot_only():
             "Redox measurement module detected": True,
             "Chlorine measurement module detected": True,
             "Conductivity measurement module detected": True,
-            # No measurement values – as returned after a restart in winter mode
+            # No measurement values - as returned after a restart in winter mode
         }
         config_entry = DummyEntry()
         entry = config_entry


### PR DESCRIPTION
## 🎨 Summary

A series of code-quality and style fixes plus a wider ruff rule set wired into `pyproject.toml`. All 568 tests pass and **100 % code coverage is preserved**.

Most changes are pure lint / docstring / formatting cleanup, but a few do touch runtime behaviour:
- 🌍 `options_flow.py` — the advanced-options unlock password now uses `dt_util.now().year` (HA's configured timezone) instead of `date.today().year` (host clock). For users whose HA timezone disagrees with their host clock around midnight on Dec 31 / Jan 1, the password's year suffix changes accordingly.
- 🛡️ `coordinator.py` — `_async_update_data` now catches a narrow `(NeoPoolError, OSError, TimeoutError)` instead of bare `Exception`. Programming errors in decoders (`KeyError`, `AttributeError`, `TypeError`) are no longer silently treated as Modbus communication failures — they propagate so the bug is visible.
- The other narrowed exception sites (`is_host_port_open`, dev-overrides JSON path, setpoint sync, migration entity rename, select int() fallbacks) all narrow what was already a defensive catch — observable behaviour is unchanged in practice.

## 📋 What's in here

### 🔤 Cosmetic
- 🎨 Replace EN DASH (`–`, U+2013) with HYPHEN-MINUS (`-`) in comments and strings (`RUF001`/`RUF002`/`RUF003`) — both source and tests
- 🎨 Module-level docstrings now end with a period and put the summary on the first line (`D415`)
- 📝 Add missing docstrings to public methods and `__init__` constructors (`D102`, `D107`)
- 🎨 Reflow multi-line docstrings (blank line between summary and body) (`D205`)

### 🛡️ Defensive coding
- ♻️ Replace bare `except Exception:` with specific exception tuples where appropriate:
  - `is_host_port_open` → `(TimeoutError, OSError)`
  - dev-overrides JSON path → `(json.JSONDecodeError, TypeError, ValueError)`
  - setpoint sync path → `(NeoPoolError, OSError, KeyError, TypeError, ValueError)`
  - coordinator update path → `(NeoPoolError, OSError, TimeoutError)` — programming errors (KeyError, AttributeError, …) now surface in the log instead of silently marking entities unavailable
  - select `int()` fallbacks → `(TypeError, ValueError)`
- ♻️ Add `raise … from err` chaining where the original cause was being dropped (`B904`)
- 💬 Document every remaining intentionally-broad `except Exception` block with an inline comment explaining why narrowing is not appropriate

### 🧹 Modernisation
- ♻️ Hoist deferred imports to module level — drops the `TYPE_CHECKING` shim and three lazy imports in `config_flow.py`, plus two in `helpers.py` and `async_cleanup_legacy_files` in `__init__.py` (`PLC0415`)
- ♻️ Use `__all__` to make the `async_migrate_entry` re-export explicit instead of relying on the `import X as X` shortcut
- ♻️ Use unpacking `[x, *list]` instead of `[x] + list` concatenation (`RUF005`)
- ♻️ Drop redundant `int(round(raw))` cast (`RUF046`)
- ♻️ Collapse `if x > max: x = max` into `min()` (`PLR1730`)
- ♻️ Return dicts directly without intermediate variable (`RET504`)
- 🌍 Replace `date.today()` with `dt_util.now()` so the year reflects HA's configured timezone, not the host clock (`DTZ011`) — small behaviour change, see Summary
- 🪵 Switch the backwash log statement from f-string to `%`-placeholders (`G004`)
- ♻️ Restructure `is_host_port_open` with `try/except/else` (`TRY300`)
- 🧹 Drop unused `# noqa: SLF001` markers in `migration.py` (`RUF100`)

### 👷 CI tightening
- 👷 Expand the ruff `select` set in `pyproject.toml` so the rules above are now enforced going forward:
  ```
  E, F, W, I, B, BLE, D102, D107, D205, D415, DTZ, G,
  PLC0415, PLR1730, RET504, RUF001, RUF002, RUF003, RUF005, RUF046, RUF100,
  B904, TRY300, TRY301
  ```
- 🙈 `per-file-ignores`:
  - tests: lazy imports + relaxed docstring rules
  - `__init__.py`: `PLC0415`, `B904`, `TRY301`, `BLE001` — the embedded service-handler block uses these patterns intentionally and will move to a dedicated module in a follow-up

## ✅ Verification

```bash
ruff check                                    # all checks passed
ruff format --check                           # all formatted
pytest --cov=custom_components/neopool        # 568 passed, 100 % coverage
```

## 📦 Out of scope

A handful of warnings (`PLC0415`, `B904`, `TRY301`, `BLE001`) sit inside the embedded service-handler block in `__init__.py`. They are silenced with `per-file-ignores` here because the entire block is being moved to a dedicated `services.py` module in a follow-up PR — fixing them in this PR would just be undone there.
