### PR TITLE
fix: 🐛 use COPY_TO_RTC_REGISTER constant for time sync writes

### DIFF
--- a/custom_components/neopool/button.py
+++ b/custom_components/neopool/button.py
@@ -20,6 +20,7 @@ from typing import Any
 from homeassistant.components.button import ButtonEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from neopool_modbus.registers import COPY_TO_RTC_REGISTER
 
 from . import NeoPoolConfigEntry
 from .const import BUTTON_DEFINITIONS
@@ -94,7 +95,7 @@ class NeoPoolButton(NeoPoolEntity, ButtonEntity):  # type: ignore[reportIncompat
             client = self.coordinator.client
             _LOGGER.debug("Syncing time with device...")
             await client.async_write_register(0x0408, prepare_device_time(self.hass))
-            await client.async_write_register(0x04F0, 1)
+            await client.async_write_register(COPY_TO_RTC_REGISTER, 1)
             await self.coordinator.async_request_refresh()
         elif self._key == "MBF_ESCAPE":
             client = self.coordinator.client

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -31,6 +31,7 @@ from neopool_modbus import NeoPoolModbusClient
 from neopool_modbus.decoders import parse_version
 from neopool_modbus.exceptions import NeoPoolError
 from neopool_modbus.registers import (
+    COPY_TO_RTC_REGISTER,
     HEATING_SETPOINT_REGISTER,
     INTELLIGENT_SETPOINT_REGISTER,
     MAX_RELAY_GPIO,
@@ -272,7 +273,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     await self.client.async_write_register(
                         0x0408, prepare_device_time(self.hass)
                     )
-                    await self.client.async_write_register(0x04F0, 1)
+                    await self.client.async_write_register(COPY_TO_RTC_REGISTER, 1)
 
             # Apply developer overrides (for testing UI visibility without hardware)
             try:

--- a/custom_components/neopool/manifest.json
+++ b/custom_components/neopool/manifest.json
@@ -14,7 +14,7 @@
     "neopool_modbus"
   ],
   "requirements": [
-    "neopool-modbus>=2.0.0"
+    "neopool-modbus>=2.0.1"
   ],
   "version": "4.0.0"
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Runtime dependency (Modbus communication via NeoPool library)
-neopool-modbus>=2.0.0
+neopool-modbus>=2.0.1
 
 # Type stubs for Home Assistant Core
 homeassistant-stubs


### PR DESCRIPTION
## 🐛 Bug

The Sync Time button (and the auto-time-sync coordinator path) wrote the literal `0x04F0` to commit the new RTC value. With `neopool-modbus<2.0.1`, the library's write-then-verify cycle then read the auto-cleared register back as `0` and emitted a misleading warning:

```
Write verification mismatch at 0x04F0: wrote 1, read back 0.
This may indicate a framing misconfiguration between the Modbus gateway and the integration
```

The warning was a false positive — `0x04F0` (`MBF_ACTION_COPY_TO_RTC`) is a fire-and-forget action register, exactly like `EEPROM_SAVE_REGISTER` (`0x02F0`) and `EXEC_REGISTER` (`0x02F5`).

## 🔍 Root cause

The library's `COMMAND_REGISTERS` set was missing `0x04F0`, so the library applied the standard read-back verification to it. Fixed upstream in [`svasek/python-neopool-modbus#9`](https://github.com/svasek/python-neopool-modbus/pull/9), released as `2.0.1`.

## 🛠️ Change

- 🔄 Replace literal `0x04F0` with the new `COPY_TO_RTC_REGISTER` constant exported by `neopool-modbus>=2.0.1` in:
  - `custom_components/neopool/button.py` — SYNC_TIME handler
  - `custom_components/neopool/coordinator.py` — auto-time-sync path
- ⬆️ Bump `neopool-modbus` requirement to `>=2.0.1` in:
  - `custom_components/neopool/manifest.json`
  - `requirements-dev.txt`

Once HACS pulls the bumped library on next install/update, the misleading warning is silenced.

## ✅ Verification

```
$ ruff check
All checks passed!

$ ruff format --check
17 files already formatted

$ basedpyright
0 errors, 0 warnings, 0 notes

$ pytest
565 passed in 1.65s
```

## 📐 Stats

`4 files changed, 6 insertions(+), 4 deletions(-)`

## 🚦 Public API

No user-visible change beyond the warning disappearing on the next time-sync action. No entity, service, or config-flow changes.

## 🔗 Related

- Upstream fix: svasek/python-neopool-modbus#9 (released as `neopool-modbus 2.0.1`)
