### PR TITLE
chore: 🎨 code cleanup and consistency improvements

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,11 @@ jobs:
       - name: Update manifest.json version
         if: startsWith(github.ref, 'refs/heads/release-please--')
         run: |
+          # `jq` reformats the JSON (collapses multi-line arrays, etc.)
+          # so we always run prettier after it to restore the project's
+          # formatting conventions (see .prettierrc.js).
           jq ".version=\"$VERSION\"" custom_components/neopool/manifest.json > tmp.$$.json && mv tmp.$$.json custom_components/neopool/manifest.json
+          npx --yes prettier@3 --write custom_components/neopool/manifest.json
 
       - name: Commit manifest.json version bump
         if: startsWith(github.ref, 'refs/heads/release-please--')

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ htmlcov
 *.pyo
 *.pyd
 *.db
+node_modules/
+package-lock.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,9 @@
 LICENSE
 .github/CODEOWNERS
+
+# node_modules is not part of the integration; only present when devs
+# install the prettier tooling locally.
+node_modules/
+
+# Generated translations (created on demand for tests; gitignored).
+custom_components/neopool/translations/

--- a/custom_components/neopool/__init__.py
+++ b/custom_components/neopool/__init__.py
@@ -16,12 +16,12 @@
 
 import logging
 
+from neopool_modbus import NeoPoolModbusClient
+
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers import entity_registry as er
-from neopool_modbus import NeoPoolModbusClient
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 
 from .const import DOMAIN, PLATFORMS, REMOVED_ENTITY_KEYS
 from .coordinator import NeoPoolCoordinator
@@ -29,11 +29,7 @@ from .coordinator import NeoPoolCoordinator
 # Re-exported for Home Assistant — HA calls async_migrate_entry(hass, entry)
 # from the integration's __init__ module when config entry version changes.
 from .migration import async_cleanup_legacy_files, async_migrate_entry
-from .services import (
-    SERVICE_SET_TIMER,
-    SERVICE_WRITE_REGISTER,
-    async_setup_services,
-)
+from .services import SERVICE_SET_TIMER, SERVICE_WRITE_REGISTER, async_setup_services
 
 __all__ = ["async_migrate_entry"]
 

--- a/custom_components/neopool/__init__.py
+++ b/custom_components/neopool/__init__.py
@@ -18,10 +18,11 @@ import logging
 
 from neopool_modbus import NeoPoolModbusClient
 
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, PLATFORMS, REMOVED_ENTITY_KEYS
 from .coordinator import NeoPoolCoordinator
@@ -29,7 +30,7 @@ from .coordinator import NeoPoolCoordinator
 # Re-exported for Home Assistant — HA calls async_migrate_entry(hass, entry)
 # from the integration's __init__ module when config entry version changes.
 from .migration import async_cleanup_legacy_files, async_migrate_entry
-from .services import SERVICE_SET_TIMER, SERVICE_WRITE_REGISTER, async_setup_services
+from .services import async_setup_services
 
 __all__ = ["async_migrate_entry"]
 
@@ -60,8 +61,14 @@ def _cleanup_removed_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
             registry.async_remove(entity_entry.entity_id)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: NeoPoolConfigEntry) -> bool:
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the NeoPool integration."""
+    async_setup_services(hass)
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: NeoPoolConfigEntry) -> bool:
+    """Set up the NeoPool integration from a config entry."""
     # --- MIGRATE CONFIG FLOW DATA TO OPTIONS IF NEEDED ---
     # Copy all keys except connection settings from data to options
     connection_keys = [CONF_HOST, CONF_PORT, CONF_NAME, "slave_id"]
@@ -96,30 +103,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: NeoPoolConfigEntry) -> b
     # Forward entities setup to Home Assistant
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Register services (idempotent — each service is registered only if missing)
-    async_setup_services(hass)
-
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: NeoPoolConfigEntry) -> bool:
     """Unload a NeoPool config entry."""
-    coordinator = getattr(entry, "runtime_data", None)
-    if coordinator is not None:
-        coordinator.cancel_follow_up_refresh()
-        if getattr(coordinator, "client", None):
-            await coordinator.client.close()
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        # Cleanup services when no other loaded entry remains
-        remaining = [
-            e
-            for e in hass.config_entries.async_entries(DOMAIN)
-            if e.entry_id != entry.entry_id and e.state == ConfigEntryState.LOADED
-        ]
-        if not remaining:
-            if hass.services.has_service(DOMAIN, SERVICE_SET_TIMER):
-                hass.services.async_remove(DOMAIN, SERVICE_SET_TIMER)
-            if hass.services.has_service(DOMAIN, SERVICE_WRITE_REGISTER):
-                hass.services.async_remove(DOMAIN, SERVICE_WRITE_REGISTER)
-    return unload_ok
+    coordinator = entry.runtime_data
+    coordinator.cancel_follow_up_refresh()
+    if coordinator.client is not None:
+        await coordinator.client.close()
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/neopool/binary_sensor.py
+++ b/custom_components/neopool/binary_sensor.py
@@ -181,7 +181,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class NeoPoolBinarySensor(NeoPoolEntity, BinarySensorEntity):  # type: ignore[reportIncompatibleVariableOverride]
+class NeoPoolBinarySensor(NeoPoolEntity, BinarySensorEntity):
     """Representation of a NeoPool binary sensor."""
 
     _winter_mode_active = False  # binary sensors stay available during winter mode

--- a/custom_components/neopool/binary_sensor.py
+++ b/custom_components/neopool/binary_sensor.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool integration for Home Assistant - Binary Sensor module."""
+"""Binary sensor platform for the NeoPool integration."""
 
 from collections.abc import Mapping
 import logging
@@ -235,7 +235,7 @@ class NeoPoolBinarySensor(NeoPoolEntity, BinarySensorEntity):
         await super().async_added_to_hass()
 
     @property
-    def is_on(self) -> bool | None:  # type: ignore[override]
+    def is_on(self) -> bool | None:
         """Return True if the binary sensor is on."""
         if self._key == "Device Time Out Of Sync":
             if self.coordinator.data.get("MBF_PAR_TIME_LOW") is None:
@@ -264,14 +264,12 @@ class NeoPoolBinarySensor(NeoPoolEntity, BinarySensorEntity):
             status = self.coordinator.data.get(f"{base}_STATUS", {})
             if isinstance(status, dict):
                 return status.get(flag.lower())
-            else:
-                return None
-        else:
-            value = self.coordinator.data.get(self._key)
-            return None if value is None else bool(value)
+            return None
+        value = self.coordinator.data.get(self._key)
+        return None if value is None else bool(value)
 
     @property
-    def native_value(self) -> bool | None:  # type: ignore[override]
+    def native_value(self) -> bool | None:
         """Return the actual sensor value."""
         # Return the actual sensor value from coordinator data
         return self.coordinator.data.get(self._key)

--- a/custom_components/neopool/binary_sensor.py
+++ b/custom_components/neopool/binary_sensor.py
@@ -14,14 +14,15 @@
 
 """NeoPool integration for Home Assistant - Binary Sensor module."""
 
-import logging
 from collections.abc import Mapping
+import logging
 from typing import Any
+
+from neopool_modbus.registers import is_valid_relay_gpio
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from neopool_modbus.registers import is_valid_relay_gpio
 
 from . import NeoPoolConfigEntry
 from .const import BINARY_SENSOR_DEFINITIONS

--- a/custom_components/neopool/button.py
+++ b/custom_components/neopool/button.py
@@ -57,7 +57,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class NeoPoolButton(NeoPoolEntity, ButtonEntity):  # type: ignore[reportIncompatibleVariableOverride]
+class NeoPoolButton(NeoPoolEntity, ButtonEntity):
     """Representation of a NeoPool button entity."""
 
     def __init__(

--- a/custom_components/neopool/button.py
+++ b/custom_components/neopool/button.py
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool integration for Home Assistant - Button module."""
+"""Button platform for the NeoPool integration."""
 
 import logging
 from typing import Any
 
+from neopool_modbus.registers import COPY_TO_RTC_REGISTER
+
 from homeassistant.components.button import ButtonEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from neopool_modbus.registers import COPY_TO_RTC_REGISTER
 
 from . import NeoPoolConfigEntry
 from .const import BUTTON_DEFINITIONS

--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -31,11 +31,11 @@ from homeassistant.util import slugify
 from .const import (
     CONF_FILTRATION_PUMP_POWER,
     CURRENT_VERSION,
-    DEFAULT_NAME,
     DEFAULT_PORT,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SLAVE_ID,
     DOMAIN,
+    NAME,
 )
 from .helpers import async_get_device_serial
 from .migration import async_cleanup_old_folder, migrate_single_entry_cross_domain
@@ -81,11 +81,11 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
                 self.hass, self.hass.config.language, "config", {DOMAIN}
             )
             key = f"component.{DOMAIN}.config.step.user.data.name_default"
-            return t.get(key) or DEFAULT_NAME
+            return t.get(key) or NAME
         except Exception:  # noqa: BLE001
             # Translation lookup is best-effort; on any failure we fall
             # back to the literal English default so the form still opens.
-            return DEFAULT_NAME
+            return NAME
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool integration for Home Assistant - Config flow."""
+"""Config flow for the NeoPool integration."""
 
 import asyncio
 import logging
@@ -22,12 +22,14 @@ from neopool_modbus.registers import DEFAULT_MODBUS_FRAMER
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
-from homeassistant.helpers import device_registry as dr, translation as ha_translation
+from homeassistant.core import callback
+from homeassistant.helpers import translation as ha_translation
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 from homeassistant.util import slugify
 
+from . import NeoPoolConfigEntry
 from .const import (
     CONF_FILTRATION_PUMP_POWER,
     CURRENT_VERSION,
@@ -38,22 +40,21 @@ from .const import (
     NAME,
 )
 from .helpers import async_get_device_serial
-from .migration import async_cleanup_old_folder, migrate_single_entry_cross_domain
+from .migration import async_import_legacy_vistapool_entry
 from .options_flow import NeoPoolOptionsFlowHandler
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def is_host_port_open(host: str, port: int, timeout: int = 3) -> bool:
-    """Return True if a TCP connection to host:port can be established."""
+    """Probe a TCP host:port to verify it accepts connections."""
     try:
         _, writer = await asyncio.wait_for(asyncio.open_connection(host, port), timeout)
-        writer.close()
-        await writer.wait_closed()
     except (TimeoutError, OSError):
         return False
-    else:
-        return True
+    writer.close()
+    await writer.wait_closed()
+    return True
 
 
 class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
@@ -68,8 +69,8 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
     async def _async_validate_connection(self, user_input: dict) -> dict:
         """Validate host/port connectivity and return an errors dict."""
         errors = {}
-        host = user_input.get(CONF_HOST)
-        port = user_input.get(CONF_PORT, DEFAULT_PORT)
+        host: str = user_input[CONF_HOST]
+        port: int = user_input.get(CONF_PORT, DEFAULT_PORT)
         if not await is_host_port_open(host, port):
             errors[CONF_HOST] = "cannot_connect"
         return errors
@@ -237,21 +238,17 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
     ) -> ConfigFlowResult:
         """Offer to migrate an existing vistapool entry to the new neopool domain.
 
-        On confirmation:
-          1. Snapshot device-level customizations (area_id, name_by_user, labels)
-             from the device tied to the legacy vistapool entry, so we can
-             restore them onto the new neopool device after migration.
-          2. Run the cross-domain migration via `migrate_single_entry_cross_domain`
-             which retargets entity_registry rows, retargets device_registry rows,
-             creates a fresh neopool ConfigEntry mirroring the legacy data, and
-             removes the old vistapool entry.
-          3. Try to clean up the leftover `custom_components/vistapool/` folder.
-          4. Abort the flow with `migration_complete` — the new neopool entry
-             was already added by the migration, so we must NOT also call
-             `async_create_entry` here (would create a duplicate).
+        On confirmation, delegates to
+        :func:`migration.async_import_legacy_vistapool_entry` which:
+          1. Snapshots device-level customizations (area_id, name_by_user,
+             labels, disabled_by) tied to the legacy entry.
+          2. Runs the cross-domain migration that retargets entity / device
+             registries and creates a fresh neopool ConfigEntry.
+          3. Restores the snapshot onto the migrated device.
+          4. Cleans up the leftover ``custom_components/vistapool/`` folder.
 
         On decline ("user said no"):
-          - Fall through to the regular `async_step_user` form so the user
+          - Falls through to the regular ``async_step_user`` form so the user
             can manually configure a fresh, unrelated neopool entry.
         """
         # The legacy entry might have been removed between async_step_user
@@ -271,77 +268,22 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
                 },
             )
 
-        # ── Snapshot device customizations BEFORE migration ──────────────
-        # The cross-domain migration retargets the device's identifiers and
-        # config_entries, but it doesn't preserve user-set fields like
-        # area_id, name_by_user, or labels. We capture them here keyed by
-        # the device's serial-based identifier so we can match them onto the
-        # new device after migration.
-        device_registry = dr.async_get(self.hass)
-        snapshots: dict[str, dict[str, Any]] = {}
-        for device in dr.async_entries_for_config_entry(
-            device_registry, legacy_entry.entry_id
-        ):
-            # Match the (vistapool, X) tuple — that's the serial-based key
-            # the migration will rewrite to (neopool, X).
-            serial_key = next(
-                (ident for dom, ident in device.identifiers if dom == "vistapool"),
-                None,
-            )
-            if not serial_key:
-                continue
-            snapshots[serial_key] = {
-                "area_id": device.area_id,
-                "name_by_user": device.name_by_user,
-                "labels": set(device.labels),
-                "disabled_by": device.disabled_by,
-            }
-
-        # ── Run the cross-domain migration ───────────────────────────────
-        try:
-            await migrate_single_entry_cross_domain(self.hass, legacy_entry)
-        except Exception as exc:
-            # Intentionally broad: migration walks entity / device / config
-            # registries and the Modbus probe, so it can surface anything
-            # from HomeAssistantError to RuntimeError / OSError / NeoPoolError
-            # / ValueError. We never want a config-flow step to crash with a
-            # traceback — surface the message via abort(migration_failed)
-            # and let the user retry.
-            _LOGGER.exception(
-                "Cross-domain migration failed for %s",
-                legacy_entry.entry_id,
-            )
+        # Run the cross-domain migration (snapshot → retarget → restore →
+        # cleanup) — the helper already created and added the new neopool
+        # entry to hass.config_entries, so we MUST NOT call
+        # async_create_entry here. Aborting with a friendly reason gives
+        # the user a confirmation dialog ("migration completed").
+        reason, error = await async_import_legacy_vistapool_entry(
+            self.hass, self._legacy_entry_id
+        )
+        if reason is None:
+            # Legacy entry disappeared between detect and run — fall through.
+            return await self.async_step_user()
+        if reason == "migration_failed":
             return self.async_abort(
                 reason="migration_failed",
-                description_placeholders={"error": str(exc)},
+                description_placeholders={"error": error or ""},
             )
-
-        # ── Restore device customizations onto the migrated device ───────
-        # The migration kept the device row in place but flipped its
-        # identifier to (neopool, serial_key). Find each by that tuple
-        # and re-apply the user-set fields.
-        for serial_key, snap in snapshots.items():
-            device = device_registry.async_get_device(
-                identifiers={(DOMAIN, serial_key)}
-            )
-            if device is None:
-                continue
-            device_registry.async_update_device(
-                device.id,
-                area_id=snap["area_id"],
-                name_by_user=snap["name_by_user"],
-                labels=snap["labels"],
-                disabled_by=snap["disabled_by"],
-            )
-
-        # ── Clean up the leftover custom_components/vistapool/ folder ────
-        await async_cleanup_old_folder(self.hass)
-
-        # ── End the flow ─────────────────────────────────────────────────
-        # `migrate_single_entry_cross_domain` already created and added the
-        # new neopool entry to hass.config_entries, so we must NOT call
-        # async_create_entry here. Aborting with a friendly reason gives the
-        # user a confirmation dialog ("migration completed").
         return self.async_abort(reason="migration_complete")
 
     async def async_step_reconfigure(
@@ -399,8 +341,9 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
         )
 
     @staticmethod
+    @callback
     def async_get_options_flow(
-        config_entry: ConfigEntry,
+        config_entry: NeoPoolConfigEntry,
     ) -> NeoPoolOptionsFlowHandler:
-        """Return the options flow handler for this entry."""
+        """Return the options flow."""
         return NeoPoolOptionsFlowHandler()

--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -18,15 +18,15 @@ import asyncio
 import logging
 from typing import Any
 
+from neopool_modbus.registers import DEFAULT_MODBUS_FRAMER
 import voluptuous as vol
+
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers import translation as ha_translation
+from homeassistant.helpers import device_registry as dr, translation as ha_translation
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 from homeassistant.util import slugify
-from neopool_modbus.registers import DEFAULT_MODBUS_FRAMER
 
 from .const import (
     CONF_FILTRATION_PUMP_POWER,

--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -40,7 +40,11 @@ from .const import (
     NAME,
 )
 from .helpers import async_get_device_serial
-from .migration import async_import_legacy_vistapool_entry
+from .migration import (
+    async_abort_if_unmigrated_v1_match,
+    async_handle_import_step,
+    async_offer_vistapool_import_if_present,
+)
 from .options_flow import NeoPoolOptionsFlowHandler
 
 _LOGGER = logging.getLogger(__name__)
@@ -57,7 +61,7 @@ async def is_host_port_open(host: str, port: int, timeout: int = 3) -> bool:
     return True
 
 
-class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
+class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for NeoPool."""
 
     # HA contract: ConfigFlow subclasses must declare a class-level VERSION
@@ -103,11 +107,10 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
         # We only offer the import on the first form display (user_input None);
         # if they already started typing a fresh config we don't interrupt.
         if user_input is None:
-            legacy_entries = self.hass.config_entries.async_entries("vistapool")
-            if legacy_entries:
-                self._legacy_entry_id = legacy_entries[0].entry_id
-                self._legacy_entry_title = legacy_entries[0].title
-                return await self.async_step_import_from_vistapool()
+            if (
+                result := await async_offer_vistapool_import_if_present(self)
+            ) is not None:
+                return result
 
         default_name = await self._async_get_default_name()
         data_schema = vol.Schema(
@@ -193,17 +196,10 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
             self._abort_if_unique_id_configured()
 
             # Validation 3b: Catch unmigrated v1 entries (unique_id=None) by connection params
-            for entry in self.hass.config_entries.async_entries(DOMAIN):
-                if entry.unique_id is not None:
-                    continue
-                if (
-                    entry.data.get(CONF_HOST) == user_input.get(CONF_HOST)
-                    and entry.data.get(CONF_PORT) == user_input.get(CONF_PORT)
-                    and entry.data.get("slave_id") == user_input.get("slave_id")
-                    and entry.data.get("modbus_framer")
-                    == user_input.get("modbus_framer")
-                ):
-                    return self.async_abort(reason="already_configured")
+            if (
+                result := async_abort_if_unmigrated_v1_match(self, user_input)
+            ) is not None:
+                return result
 
             # Validation 4: Unique device name (compare slugified to catch case/spacing variants)
             for entry in self.hass.config_entries.async_entries(DOMAIN):
@@ -238,53 +234,12 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
     ) -> ConfigFlowResult:
         """Offer to migrate an existing vistapool entry to the new neopool domain.
 
-        On confirmation, delegates to
-        :func:`migration.async_import_legacy_vistapool_entry` which:
-          1. Snapshots device-level customizations (area_id, name_by_user,
-             labels, disabled_by) tied to the legacy entry.
-          2. Runs the cross-domain migration that retargets entity / device
-             registries and creates a fresh neopool ConfigEntry.
-          3. Restores the snapshot onto the migrated device.
-          4. Cleans up the leftover ``custom_components/vistapool/`` folder.
-
-        On decline ("user said no"):
-          - Falls through to the regular ``async_step_user`` form so the user
-            can manually configure a fresh, unrelated neopool entry.
+        Thin dispatcher — see :func:`migration.async_handle_import_step` for
+        the full pre-check → form → migration → result-mapping pipeline.
         """
-        # The legacy entry might have been removed between async_step_user
-        # detecting it and the user clicking Submit — re-resolve to be safe.
-        legacy_entry = self.hass.config_entries.async_get_entry(self._legacy_entry_id)
-        if legacy_entry is None or legacy_entry.domain != "vistapool":
-            # Nothing to import any more; fall through to the regular new-entry
-            # path. user_input None forces a fresh form display there.
-            return await self.async_step_user()
-
-        if user_input is None:
-            return self.async_show_form(
-                step_id="import_from_vistapool",
-                data_schema=vol.Schema({}),
-                description_placeholders={
-                    "entry_title": self._legacy_entry_title,
-                },
-            )
-
-        # Run the cross-domain migration (snapshot → retarget → restore →
-        # cleanup) — the helper already created and added the new neopool
-        # entry to hass.config_entries, so we MUST NOT call
-        # async_create_entry here. Aborting with a friendly reason gives
-        # the user a confirmation dialog ("migration completed").
-        reason, error = await async_import_legacy_vistapool_entry(
-            self.hass, self._legacy_entry_id
+        return await async_handle_import_step(
+            self, user_input, self._legacy_entry_id, self._legacy_entry_title
         )
-        if reason is None:
-            # Legacy entry disappeared between detect and run — fall through.
-            return await self.async_step_user()
-        if reason == "migration_failed":
-            return self.async_abort(
-                reason="migration_failed",
-                description_placeholders={"error": error or ""},
-            )
-        return self.async_abort(reason="migration_complete")
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/neopool/const.py
+++ b/custom_components/neopool/const.py
@@ -12,38 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool integration for Home Assistant - constants.
+"""Constants for the NeoPool integration."""
 
-This file contains metadata about the integration such as name, version, domain, etc.
-The manifest file is loaded to get the integration name and version
-The integration name and version are used to identify the integration
-and to display information about the integration in Home Assistant
-"""
-
-import json
 import logging
-from pathlib import Path
+from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.number import NumberDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, Platform
 
-PLATFORMS = ["sensor", "binary_sensor", "switch", "number", "button", "select", "light"]
+DOMAIN = "neopool"
+NAME = "NeoPool"
 
-manifest_path = Path(__file__).parent / "manifest.json"
-with open(manifest_path, encoding="utf-8") as f:
-    MANIFEST = json.load(f)
-
-INTEGRATION_VERSION = MANIFEST.get("version")
-
-DOMAIN = (
-    MANIFEST.get("domain").lower().replace("-", "_").replace(" ", "_").replace(".", "_")
-    or "neopool"
-)
-NAME = MANIFEST.get("name") or "NeoPool Modbus"
-DEFAULT_NAME = "NeoPool"
-VERSION = MANIFEST.get("version") or None
+PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.LIGHT,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -159,7 +149,7 @@ PERIOD_MAP = {
 
 PERIOD_SECONDS_TO_KEY = {v: k for k, v in PERIOD_MAP.items()}
 
-SENSOR_DEFINITIONS = {
+SENSOR_DEFINITIONS: dict[str, dict[str, Any]] = {
     "MBF_ION_CURRENT": {
         "name": "Ionization Level",
         "unit": "%",
@@ -288,7 +278,7 @@ SENSOR_DEFINITIONS = {
     },
 }
 
-BINARY_SENSOR_DEFINITIONS = {
+BINARY_SENSOR_DEFINITIONS: dict[str, dict[str, Any]] = {
     "Device Time Out Of Sync": {
         "name": "Device Time Out Of Sync",
         "device_class": BinarySensorDeviceClass.PROBLEM,
@@ -507,7 +497,7 @@ BINARY_SENSOR_DEFINITIONS = {
     # into the ION_POLARITY enum sensor.
 }
 
-NUMBER_DEFINITIONS = {
+NUMBER_DEFINITIONS: dict[str, dict[str, Any]] = {
     "MBF_PAR_HIDRO": {
         "name": "Hydrolysis target production level",
         "unit": "%",
@@ -626,7 +616,7 @@ NUMBER_DEFINITIONS = {
     },
 }
 
-BUTTON_DEFINITIONS = {
+BUTTON_DEFINITIONS: dict[str, dict[str, Any]] = {
     "SYNC_TIME": {
         "name": "Synchronize Device Time",
         "entity_category": EntityCategory.CONFIG,
@@ -640,7 +630,7 @@ BUTTON_DEFINITIONS = {
     },
 }
 
-SELECT_DEFINITIONS = {
+SELECT_DEFINITIONS: dict[str, dict[str, Any]] = {
     "MBF_PAR_FILT_MODE": {
         "name": "Filtration Mode",
         "options_map": {
@@ -1070,7 +1060,7 @@ SELECT_DEFINITIONS = {
     },
 }
 
-SWITCH_DEFINITIONS = {
+SWITCH_DEFINITIONS: dict[str, dict[str, Any]] = {
     "WINTER_MODE": {
         "name": "Winter Mode",
         "entity_category": EntityCategory.CONFIG,
@@ -1172,7 +1162,7 @@ SWITCH_DEFINITIONS = {
     },
 }
 
-LIGHT_DEFINITIONS = {
+LIGHT_DEFINITIONS: dict[str, dict[str, Any]] = {
     "light": {
         "name": "Pool Light",
         "switch_type": "relay_timer",

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -14,19 +14,11 @@
 
 """NeoPool integration for Home Assistant - Coordinator module."""
 
+from datetime import timedelta
 import json
 import logging
-from datetime import timedelta
 from typing import Any
 
-from homeassistant.components import persistent_notification
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
-from homeassistant.helpers import issue_registry as ir
-from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import slugify
 from neopool_modbus import NeoPoolModbusClient
 from neopool_modbus.decoders import parse_version
 from neopool_modbus.exceptions import NeoPoolError
@@ -37,6 +29,15 @@ from neopool_modbus.registers import (
     MAX_RELAY_GPIO,
     TIMER_BLOCKS,
 )
+
+from homeassistant.components import persistent_notification
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import slugify
 
 from .const import (
     CAPABILITY_KEYS,

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool integration for Home Assistant - Coordinator module."""
+"""Data update coordinator for the NeoPool integration."""
 
 from datetime import timedelta
 import json
@@ -179,7 +179,186 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ir.async_delete_issue(self.hass, DOMAIN, "corrupted_gpio")
             _LOGGER.info("GPIO registers passed sanity check: all values are valid")
 
+    def _get_enabled_timers(self) -> list[str]:
+        """Return the list of timer block names enabled in entry options.
+
+        Filtration timer blocks are always included so the countdown
+        aggregation has fresh data even when the user hasn't enabled
+        their configuration entities.
+        """
+        options = self.entry.options
+        enabled: list[str] = []
+        for key in TIMER_BLOCKS:
+            if key.startswith("relay_aux"):
+                option_key = f"use_aux{key[len('relay_aux')]}"
+            elif key == "relay_light":
+                option_key = "use_light"
+            else:
+                option_key = f"use_{key}"
+            if options.get(option_key, False):
+                enabled.append(key)
+        for ft in _FILT_TIMERS:
+            if ft not in enabled:
+                enabled.append(ft)
+        return enabled
+
+    async def _read_timers_into_data(self, data: dict[str, Any]) -> None:
+        """Read every enabled timer block and merge derived fields into data."""
+        prev_remaining = self.data.get("FILTRATION_REMAINING") if self.data else None
+        filtration_active = bool(data.get("Filtration Pump")) or bool(
+            prev_remaining and prev_remaining > 0
+        )
+        timers = await self.client.read_all_timers(
+            enabled_timers=self._get_enabled_timers(),
+            force_read=_FILT_TIMERS if filtration_active else None,
+        )
+        for t_name, t in timers.items():
+            data[f"{t_name}_enable"] = t["enable"]
+            data[f"{t_name}_start"] = t["on"]  # saved as seconds since midnight
+            data[f"{t_name}_interval"] = t["interval"]
+            data[f"{t_name}_period"] = t["period"]
+            data[f"{t_name}_countdown"] = t["countdown"]
+            if t["on"] is not None and t["interval"] is not None:
+                data[f"{t_name}_stop"] = (t["on"] + t["interval"]) % 86400
+            else:
+                data[f"{t_name}_stop"] = None
+
+        # Aggregate filtration remaining time from active filtration timers
+        filt_remaining: int | None = None
+        for n in (1, 2, 3):
+            cd = data.get(f"filtration{n}_countdown")
+            if cd is not None and cd > 0:
+                filt_remaining = max(filt_remaining or 0, cd)
+        data["FILTRATION_REMAINING"] = filt_remaining
+
+    def _apply_dev_overrides(self, data: dict[str, Any]) -> None:
+        """Apply developer override values to data, if enabled."""
+        if not self.entry.options.get("dev_overrides_enabled", False):
+            return
+        raw = self.entry.options.get("dev_overrides", "{}")
+        try:
+            overrides = json.loads(raw) if isinstance(raw, str) else raw
+        except (
+            json.JSONDecodeError,
+            TypeError,
+            ValueError,
+        ) as dev_err:  # pragma: no cover
+            _LOGGER.warning("Failed to apply dev_overrides: %s", dev_err)
+            return
+        if not isinstance(overrides, dict):  # pragma: no cover
+            _LOGGER.warning("dev_overrides must be a JSON object (dict)")
+            return
+        data.update(overrides)
+        _LOGGER.debug("Applied dev overrides: %s", overrides)
+
+    async def _sync_heating_intelligent_setpoints(self, data: dict[str, Any]) -> None:
+        """Keep heating and intelligent setpoints synchronized last-change-wins.
+
+        If exactly one register changed since the previous snapshot, mirror
+        it to the other. If both changed in the same cycle, revert both to
+        their previous values to avoid conflicts. If neither changed but
+        the values differ, perform an initial sync using heating as the
+        source of truth.
+        """
+        prev = self.data
+        heat = data.get("MBF_PAR_HEATING_TEMP")
+        intel = data.get("MBF_PAR_INTELLIGENT_TEMP")
+        if heat is None or intel is None or heat == intel:
+            return
+        h_old = prev.get("MBF_PAR_HEATING_TEMP") if prev else None
+        i_old = prev.get("MBF_PAR_INTELLIGENT_TEMP") if prev else None
+        heating_changed = h_old is None or heat != h_old
+        intelligent_changed = i_old is None or intel != i_old
+
+        if heating_changed ^ intelligent_changed:
+            # Exactly one changed: sync the other to match (last-change-wins)
+            winner_val = int(heat if heating_changed else intel)
+            loser_reg = (
+                INTELLIGENT_SETPOINT_REGISTER
+                if heating_changed
+                else HEATING_SETPOINT_REGISTER
+            )
+            await self.client.async_write_register(loser_reg, winner_val, apply=True)
+            data["MBF_PAR_HEATING_TEMP"] = winner_val
+            data["MBF_PAR_INTELLIGENT_TEMP"] = winner_val
+            _LOGGER.debug(
+                "Auto-synced setpoints (last-change-wins) -> heating=%s, intelligent=%s",
+                data["MBF_PAR_HEATING_TEMP"],
+                data["MBF_PAR_INTELLIGENT_TEMP"],
+            )
+        elif heating_changed and intelligent_changed:
+            # Both changed this cycle; revert both to previous values
+            _LOGGER.warning(
+                "Both heating and intelligent setpoints changed simultaneously "
+                "(heating: %s→%s, intelligent: %s→%s). Reverting both to previous values to prevent conflict.",
+                h_old,
+                heat,
+                i_old,
+                intel,
+            )
+            if h_old is not None and i_old is not None:
+                await self.client.async_write_register(
+                    HEATING_SETPOINT_REGISTER, int(h_old), apply=False
+                )
+                await self.client.async_write_register(
+                    INTELLIGENT_SETPOINT_REGISTER, int(i_old), apply=True
+                )
+                data["MBF_PAR_HEATING_TEMP"] = h_old
+                data["MBF_PAR_INTELLIGENT_TEMP"] = i_old
+                _LOGGER.debug(
+                    "Reverted setpoints -> heating=%s, intelligent=%s",
+                    data["MBF_PAR_HEATING_TEMP"],
+                    data["MBF_PAR_INTELLIGENT_TEMP"],
+                )
+        else:
+            # Neither changed but they differ: initial sync (heating wins)
+            _LOGGER.info(
+                "Setpoints differ but neither changed (heating=%s, intelligent=%s). "
+                "Performing initial sync: setting intelligent to match heating.",
+                heat,
+                intel,
+            )
+            await self.client.async_write_register(
+                INTELLIGENT_SETPOINT_REGISTER, int(heat), apply=True
+            )
+            data["MBF_PAR_INTELLIGENT_TEMP"] = heat
+            _LOGGER.debug(
+                "Initial sync completed -> heating=%s, intelligent=%s",
+                data["MBF_PAR_HEATING_TEMP"],
+                data["MBF_PAR_INTELLIGENT_TEMP"],
+            )
+
+    def _persist_capability_snapshot(self, data: dict[str, Any]) -> None:
+        """Persist the capability snapshot so platform setup survives HA restarts.
+
+        While Modbus is down (e.g. because winter mode is on), platforms
+        still need to know which entities to register; the snapshot stored
+        in entry.options gives them that visibility.
+        """
+        new_snapshot = {k: data[k] for k in CAPABILITY_KEYS if k in data}
+        if new_snapshot == self._capability_snapshot:
+            return
+        self._capability_snapshot = new_snapshot
+        options = dict(self.entry.options)
+        options["_capabilities"] = new_snapshot
+        self.hass.config_entries.async_update_entry(self.entry, options=options)
+
+    async def _handle_modbus_failure(self, err: Exception) -> None:
+        """Increment the error counter and slow down polling exponentially."""
+        self._consecutive_errors += 1
+        _LOGGER.error("Modbus communication error: %s (%s)", err, type(err).__name__)
+        current_interval = self.update_interval or self.normal_update_interval
+        next_interval = min(current_interval * 2, self.max_update_interval)
+        if self.update_interval != next_interval:
+            _LOGGER.warning(
+                "Increasing update interval to %s seconds due to communication errors.",
+                int(next_interval.total_seconds()),
+            )
+            self.update_interval = next_interval
+        _LOGGER.warning("Modbus error - marking all entities unavailable")
+
     async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch the latest data from the pool controller."""
         # Winter mode: skip all Modbus communication; entities remain but show unknown values
         if self.winter_mode:
             _LOGGER.debug("Winter mode active - skipping Modbus communication")
@@ -187,232 +366,57 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         try:
             data = await self.client.async_read_all()
-            self._consecutive_errors = 0
-
-            # Reset interval after success
-            if self.update_interval != self.normal_update_interval:  # pragma: no cover
-                _LOGGER.info(
-                    "Communication OK, resetting update interval to %s seconds.",
-                    self.normal_update_interval.total_seconds(),
-                )
-                self.update_interval = self.normal_update_interval
-
-            self._firmware = parse_version(data.get("MBF_POWER_MODULE_VERSION"))
-            self._model = "NeoPool"
-
-            # One-time GPIO sanity check after first successful read
-            if not self._gpio_checked:
-                self._gpio_checked = True
-                self._check_gpio_registers(data)
-
-            options = self.entry.options
-            enabled_timers = []
-            # Collect enabled timers based on options
-            # This assumes that the options are set correctly in the config entry
-            for key in TIMER_BLOCKS:
-                if key.startswith("relay_aux"):
-                    n = key[len("relay_aux")]
-                    option_key = f"use_aux{n}"
-                elif key == "relay_light":
-                    option_key = "use_light"
-                else:
-                    option_key = f"use_{key}"
-                if options.get(option_key, False):
-                    enabled_timers.append(key)
-
-            # Always read filtration timer blocks for countdown aggregation,
-            # even if the user hasn't enabled their configuration entities.
-            for ft in _FILT_TIMERS:
-                if ft not in enabled_timers:
-                    enabled_timers.append(ft)
-
-            # Bypass the notification cache for filtration timers while
-            # filtration is running so the countdown values stay fresh.
-            # Use both the relay bit and the previous countdown to avoid
-            # missing cycles when the relay bit is unreliable.
-            prev_remaining = (
-                self.data.get("FILTRATION_REMAINING") if self.data else None
-            )
-            filtration_active = bool(data.get("Filtration Pump")) or bool(
-                prev_remaining and prev_remaining > 0
-            )
-            timers = await self.client.read_all_timers(
-                enabled_timers=enabled_timers,
-                force_read=_FILT_TIMERS if filtration_active else None,
-            )
-
-            for t_name, t in timers.items():
-                data[f"{t_name}_enable"] = t["enable"]
-                data[f"{t_name}_start"] = t["on"]  # saved as seconds since midnight
-                data[f"{t_name}_interval"] = t["interval"]
-                data[f"{t_name}_period"] = t["period"]
-                data[f"{t_name}_countdown"] = t["countdown"]
-                if t["on"] is not None and t["interval"] is not None:
-                    stop = (t["on"] + t["interval"]) % 86400
-                    data[f"{t_name}_stop"] = stop
-                else:
-                    data[f"{t_name}_stop"] = None
-
-            # Aggregate filtration remaining time from active filtration timers
-            filt_remaining = None
-            for n in (1, 2, 3):
-                cd = data.get(f"filtration{n}_countdown")
-                if cd is not None and cd > 0:
-                    filt_remaining = max(filt_remaining or 0, cd)
-            data["FILTRATION_REMAINING"] = filt_remaining
-
-            pump_power = max(
-                0, int(self.entry.options.get(CONF_FILTRATION_PUMP_POWER, 0) or 0)
-            )
-            data[CONF_FILTRATION_PUMP_POWER] = (
-                pump_power if data.get("Filtration Pump") else 0
-            )
-
-            if self.auto_time_sync:
-                if is_device_time_out_of_sync(data, self.hass):
-                    _LOGGER.debug("Device time is out of sync, updating...")
-                    await self.client.async_write_register(
-                        0x0408, prepare_device_time(self.hass)
-                    )
-                    await self.client.async_write_register(COPY_TO_RTC_REGISTER, 1)
-
-            # Apply developer overrides (for testing UI visibility without hardware)
-            try:
-                if self.entry.options.get("dev_overrides_enabled", False):
-                    raw = self.entry.options.get("dev_overrides", "{}")
-                    overrides = json.loads(raw) if isinstance(raw, str) else raw
-                    if isinstance(overrides, dict):
-                        for k, v in overrides.items():
-                            data[k] = v
-                        _LOGGER.debug("Applied dev overrides: %s", overrides)
-                    else:  # pragma: no cover
-                        _LOGGER.warning("dev_overrides must be a JSON object (dict)")
-            except (
-                json.JSONDecodeError,
-                TypeError,
-                ValueError,
-            ) as dev_err:  # pragma: no cover
-                _LOGGER.warning("Failed to apply dev_overrides: %s", dev_err)
-
-            # Keep heating and intelligent setpoints synchronized based on the last change.
-            # If exactly one changed since the previous snapshot and values differ now,
-            # mirror the changed value into the other register (last-change-wins).
-            # If both changed at once, revert both to previous values to avoid conflicts.
-            # If neither changed but they differ, sync intelligent to heating (initial sync).
-            try:
-                prev = getattr(self, "data", None)
-                heat = data.get("MBF_PAR_HEATING_TEMP")
-                intel = data.get("MBF_PAR_INTELLIGENT_TEMP")
-                if heat is not None and intel is not None and heat != intel:
-                    h_old = prev.get("MBF_PAR_HEATING_TEMP") if prev else None
-                    i_old = prev.get("MBF_PAR_INTELLIGENT_TEMP") if prev else None
-                    heating_changed = h_old is None or heat != h_old
-                    intelligent_changed = i_old is None or intel != i_old
-
-                    if heating_changed ^ intelligent_changed:
-                        # Exactly one changed: sync the other to match (last-change-wins)
-                        winner_val = int(heat if heating_changed else intel)
-                        loser_reg = (
-                            INTELLIGENT_SETPOINT_REGISTER
-                            if heating_changed
-                            else HEATING_SETPOINT_REGISTER
-                        )
-                        await self.client.async_write_register(
-                            loser_reg, winner_val, apply=True
-                        )
-                        # Reflect in returned data so HA shows synced values immediately
-                        data["MBF_PAR_HEATING_TEMP"] = winner_val
-                        data["MBF_PAR_INTELLIGENT_TEMP"] = winner_val
-                        _LOGGER.debug(
-                            "Auto-synced setpoints (last-change-wins) -> heating=%s, intelligent=%s",
-                            data["MBF_PAR_HEATING_TEMP"],
-                            data["MBF_PAR_INTELLIGENT_TEMP"],
-                        )
-                    elif heating_changed and intelligent_changed:
-                        # Both changed this cycle; revert both to previous values
-                        _LOGGER.warning(
-                            "Both heating and intelligent setpoints changed simultaneously "
-                            "(heating: %s→%s, intelligent: %s→%s). Reverting both to previous values to prevent conflict.",
-                            h_old,
-                            heat,
-                            i_old,
-                            intel,
-                        )
-                        if h_old is not None and i_old is not None:
-                            # Write both back to their old values
-                            await self.client.async_write_register(
-                                HEATING_SETPOINT_REGISTER, int(h_old), apply=False
-                            )
-                            await self.client.async_write_register(
-                                INTELLIGENT_SETPOINT_REGISTER, int(i_old), apply=True
-                            )
-                            # Reflect revert in returned data
-                            data["MBF_PAR_HEATING_TEMP"] = h_old
-                            data["MBF_PAR_INTELLIGENT_TEMP"] = i_old
-                            _LOGGER.debug(
-                                "Reverted setpoints -> heating=%s, intelligent=%s",
-                                data["MBF_PAR_HEATING_TEMP"],
-                                data["MBF_PAR_INTELLIGENT_TEMP"],
-                            )
-                    elif not heating_changed and not intelligent_changed:
-                        # Neither changed but they differ: initial sync (use heating as source)
-                        _LOGGER.info(
-                            "Setpoints differ but neither changed (heating=%s, intelligent=%s). "
-                            "Performing initial sync: setting intelligent to match heating.",
-                            heat,
-                            intel,
-                        )
-                        await self.client.async_write_register(
-                            INTELLIGENT_SETPOINT_REGISTER, int(heat), apply=True
-                        )
-                        # Reflect in returned data
-                        data["MBF_PAR_INTELLIGENT_TEMP"] = heat
-                        _LOGGER.debug(
-                            "Initial sync completed -> heating=%s, intelligent=%s",
-                            data["MBF_PAR_HEATING_TEMP"],
-                            data["MBF_PAR_INTELLIGENT_TEMP"],
-                        )
-            except (
-                NeoPoolError,
-                OSError,
-                KeyError,
-                TypeError,
-                ValueError,
-            ) as sync_err:  # pragma: no cover
-                _LOGGER.debug("Setpoint auto-sync skipped due to error: %s", sync_err)
-            # Keep capability snapshot up-to-date after every successful read and
-            # persist it to options so it survives HA restarts while Modbus is down.
-            new_snapshot = {k: data[k] for k in CAPABILITY_KEYS if k in data}
-            if new_snapshot != self._capability_snapshot:
-                self._capability_snapshot = new_snapshot
-                options = dict(self.entry.options)
-                options["_capabilities"] = new_snapshot
-                self.hass.config_entries.async_update_entry(self.entry, options=options)
-            # The except clause below always re-raises, so returning here
-            # rather than from an `else:` block keeps the happy path obvious.
-            return data  # noqa: TRY300
-
         except (NeoPoolError, OSError, TimeoutError) as err:
-            self._consecutive_errors += 1
-            _LOGGER.error(
-                "Modbus communication error: %s (%s)", err, type(err).__name__
-            )
-
-            # Exponential backoff: double the interval, but never more than max
-            current_interval = self.update_interval or self.normal_update_interval
-            next_interval = min(current_interval * 2, self.max_update_interval)
-            if self.update_interval != next_interval:
-                _LOGGER.warning(
-                    "Increasing update interval to %s seconds due to communication errors.",
-                    int(next_interval.total_seconds()),
-                )
-                self.update_interval = next_interval
-
-            # Always raise UpdateFailed; HA core converts it to
-            # ConfigEntryNotReady automatically on the first refresh
-            # (when self.data is still None) via async_config_entry_first_refresh.
-            _LOGGER.warning("Modbus error - marking all entities unavailable")
+            await self._handle_modbus_failure(err)
             raise UpdateFailed(f"Modbus communication error: {err}") from err
+
+        self._consecutive_errors = 0
+
+        # Reset interval after success
+        if self.update_interval != self.normal_update_interval:  # pragma: no cover
+            _LOGGER.info(
+                "Communication OK, resetting update interval to %s seconds.",
+                self.normal_update_interval.total_seconds(),
+            )
+            self.update_interval = self.normal_update_interval
+
+        self._firmware = parse_version(data.get("MBF_POWER_MODULE_VERSION"))
+        self._model = "NeoPool"
+
+        # One-time GPIO sanity check after first successful read
+        if not self._gpio_checked:
+            self._gpio_checked = True
+            self._check_gpio_registers(data)
+
+        await self._read_timers_into_data(data)
+
+        pump_power = max(
+            0, int(self.entry.options.get(CONF_FILTRATION_PUMP_POWER, 0) or 0)
+        )
+        data[CONF_FILTRATION_PUMP_POWER] = (
+            pump_power if data.get("Filtration Pump") else 0
+        )
+
+        if self.auto_time_sync and is_device_time_out_of_sync(data, self.hass):
+            _LOGGER.debug("Device time is out of sync, updating...")
+            await self.client.async_write_register(
+                0x0408, prepare_device_time(self.hass)
+            )
+            await self.client.async_write_register(COPY_TO_RTC_REGISTER, 1)
+
+        self._apply_dev_overrides(data)
+
+        try:
+            await self._sync_heating_intelligent_setpoints(data)
+        except Exception as sync_err:  # noqa: BLE001  # pragma: no cover
+            # Setpoint sync is best-effort: it walks coordinator data and
+            # writes a register, so anything from KeyError / TypeError /
+            # ValueError up to NeoPoolError / OSError can surface here. A
+            # failed sync must not poison the rest of the update cycle.
+            _LOGGER.debug("Setpoint auto-sync skipped due to error: %s", sync_err)
+
+        self._persist_capability_snapshot(data)
+        return data
 
     async def set_auto_time_sync(self, enabled: bool):
         """Persist the auto_time_sync flag and refresh the entry options."""

--- a/custom_components/neopool/diagnostics.py
+++ b/custom_components/neopool/diagnostics.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool integration for Home Assistant - Diagnostics module."""
-
-from __future__ import annotations
+"""Diagnostics support for the NeoPool integration."""
 
 from typing import Any
 

--- a/custom_components/neopool/entity.py
+++ b/custom_components/neopool/entity.py
@@ -44,19 +44,19 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
         self._entry_id = entry_id
 
     @property
-    def available(self) -> bool:  # type: ignore[override]
+    def available(self) -> bool:
         """Return False for control entities while winter mode is active."""
         if self._winter_mode_active and getattr(self.coordinator, "winter_mode", False):
             return False
         return super().available
 
     @property
-    def translation_key(self) -> str | None:  # type: ignore[override]
+    def translation_key(self) -> str | None:
         """Return the translation key for the entity."""
         return getattr(self, "_attr_translation_key", None)  # pragma: no cover
 
     @property
-    def device_info(self) -> DeviceInfo:  # type: ignore[override]  # pragma: no cover
+    def device_info(self) -> DeviceInfo:  # pragma: no cover
         """Return device information for the entity."""
         data = self.coordinator.data or {}
         serial_number = modbus_regs_to_hex_string(data.get("MBF_POWER_MODULE_NODEID"))

--- a/custom_components/neopool/entity.py
+++ b/custom_components/neopool/entity.py
@@ -12,21 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool integration for Home Assistant - Entity module.
+"""Base entity class for the NeoPool integration.
 
 This module defines the base entity class for the NeoPool integration.
 It provides common functionality for all entities, including device information,
 """
 
-from typing import Any
-
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import slugify as ha_slugify
 from neopool_modbus.decoders import (
     get_machine_name,
     modbus_regs_to_hex_string,
     parse_version,
 )
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import slugify as ha_slugify
 
 from .const import DOMAIN, NAME
 from .coordinator import NeoPoolCoordinator
@@ -39,7 +39,7 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
     _winter_mode_active: bool = True
 
     def __init__(self, coordinator: NeoPoolCoordinator, entry_id: str) -> None:
-        """Initialise the base NeoPool entity."""
+        """Initialise the NeoPool base entity."""
         super().__init__(coordinator)
         self._entry_id = entry_id
 
@@ -56,7 +56,7 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
         return getattr(self, "_attr_translation_key", None)  # pragma: no cover
 
     @property
-    def device_info(self) -> dict[str, Any]:  # type: ignore[override]  # pragma: no cover
+    def device_info(self) -> DeviceInfo:  # type: ignore[override]  # pragma: no cover
         """Return device information for the entity."""
         data = self.coordinator.data or {}
         serial_number = modbus_regs_to_hex_string(data.get("MBF_POWER_MODULE_NODEID"))
@@ -69,15 +69,15 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
         machine_type = (get_machine_name(data) or "").strip()
         model_prefix = "NeoPool Compatible: " if machine_type else "NeoPool Compatible"
 
-        return {
-            "identifiers": {(DOMAIN, hw_identifier)},
-            "name": getattr(self.coordinator, "device_name", NAME),
-            "model": f"{model_prefix}{machine_type}".strip(),
-            "manufacturer": "Hayward (Sugar Valley)",
-            "hw_version": f"Detected Modules: [{self.decode_modules(data.get('MBF_PAR_MODEL'))}]",
-            "sw_version": f"v{self.coordinator.firmware} (v{parse_version(data.get('MBF_PAR_VERSION'))})",
-            "serial_number": serial_number,
-        }
+        return DeviceInfo(
+            identifiers={(DOMAIN, hw_identifier)},
+            name=getattr(self.coordinator, "device_name", NAME),
+            model=f"{model_prefix}{machine_type}".strip(),
+            manufacturer="Hayward (Sugar Valley)",
+            hw_version=f"Detected Modules: [{self.decode_modules(data.get('MBF_PAR_MODEL'))}]",
+            sw_version=f"v{self.coordinator.firmware} (v{parse_version(data.get('MBF_PAR_VERSION'))})",
+            serial_number=serial_number,
+        )
 
     # Generate a unique object ID for the entity to use in Home Assistant
     # This remove the prefix "mbf_" and "par_" from the key and replaces spaces, dashes, and dots with underscores

--- a/custom_components/neopool/helpers.py
+++ b/custom_components/neopool/helpers.py
@@ -24,13 +24,14 @@ import datetime
 import logging
 from typing import Any
 
-import homeassistant.util.dt as dt_util
-from homeassistant.const import CONF_HOST, CONF_PORT
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
 from neopool_modbus import async_probe_serial
 from neopool_modbus.exceptions import NeoPoolError
 from neopool_modbus.registers import DEFAULT_MODBUS_FRAMER, is_valid_relay_gpio
+
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN
 

--- a/custom_components/neopool/helpers.py
+++ b/custom_components/neopool/helpers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool integration for Home Assistant - Helpers module.
+"""Helper functions for the NeoPool integration.
 
 This module contains helper functions for the NeoPool integration.
 It includes functions to handle device time, prepare data for writing to the device,
@@ -52,12 +52,11 @@ def get_device_time(
     unix_ts = (high << 16) | low
     if hass:
         local_tz = dt_util.get_time_zone(hass.config.time_zone)
-        # The naive datetime is intentional: we localise it to the HA timezone
-        # below before converting to UTC, since the device clock has no tz info.
-        dt_naive = datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=unix_ts)  # noqa: DTZ001
+        # WORKAROUND: This is the naive datetime object, without timezone info
+        dt_naive = datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=unix_ts)
         dt_local = dt_naive.replace(tzinfo=local_tz)
-        return dt_local.astimezone(datetime.timezone.utc)
-    return datetime.datetime.fromtimestamp(unix_ts, tz=datetime.timezone.utc)
+        return dt_local.astimezone(datetime.UTC)
+    return datetime.datetime.fromtimestamp(unix_ts, tz=datetime.UTC)
 
 
 # This function prepares the device time for writing to the device
@@ -74,9 +73,7 @@ def prepare_device_time(hass: HomeAssistant | None = None) -> list[int]:
         epoch_local = datetime.datetime(1970, 1, 1, tzinfo=ha_tz)
         unix_time_local = int((now_local - epoch_local).total_seconds())
     else:  # pragma: no cover
-        # No hass available (unit tests / standalone helpers): fall back to the
-        # host clock. The device protocol expects local epoch seconds, not UTC.
-        unix_time_local = int(datetime.datetime.now().timestamp())  # noqa: DTZ005
+        unix_time_local = int(datetime.datetime.now().timestamp())
     low = unix_time_local & 0xFFFF
     high = (unix_time_local >> 16) & 0xFFFF
     return [low, high]
@@ -87,22 +84,19 @@ def prepare_device_time(hass: HomeAssistant | None = None) -> list[int]:
 def is_device_time_out_of_sync(
     data: dict[str, Any], hass: HomeAssistant | None = None, threshold_seconds: int = 60
 ) -> bool:
-    """
-    Returns True if device time and HA time differ by more than threshold_seconds.
-    """
+    """Returns True if device time and HA time differ by more than threshold_seconds."""
     device_dt = get_device_time(data, hass)
     if device_dt is None:
         return False
-    now_dt = dt_util.utcnow().replace(tzinfo=datetime.timezone.utc)
+    now_dt = dt_util.utcnow().replace(tzinfo=datetime.UTC)
     diff = abs((device_dt - now_dt).total_seconds())
     return diff > threshold_seconds
 
 
 def calculate_next_interval_time(
-    seconds: int | float | None, hass: HomeAssistant | None = None
+    seconds: float | None, hass: HomeAssistant | None = None
 ) -> datetime.datetime | None:
-    """
-    Calculate the timestamp for the next interval start.
+    """Calculate the timestamp for the next interval start.
 
     Args:
         seconds: Number of seconds until the next interval starts (countdown).
@@ -124,7 +118,7 @@ def calculate_next_interval_time(
         target_time = now_local + datetime.timedelta(seconds=seconds)
     else:
         # Fallback to UTC if hass is not available
-        now_utc = datetime.datetime.now(datetime.timezone.utc)
+        now_utc = datetime.datetime.now(datetime.UTC)
         target_time = now_utc + datetime.timedelta(seconds=seconds)
 
     # Round to nearest minute (set seconds and microseconds to 0)

--- a/custom_components/neopool/icons.json
+++ b/custom_components/neopool/icons.json
@@ -313,7 +313,11 @@
     }
   },
   "services": {
-    "set_timer": "mdi:timer-cog",
-    "write_register": "mdi:pencil-box"
+    "set_timer": {
+      "service": "mdi:timer-cog"
+    },
+    "write_register": {
+      "service": "mdi:pencil-box"
+    }
   }
 }

--- a/custom_components/neopool/icons.json
+++ b/custom_components/neopool/icons.json
@@ -39,7 +39,9 @@
       "ph_pump_status": { "default": "mdi:pump" },
       "filtration_speed": { "default": "mdi:fan" },
       "intelligent_intervals": { "default": "mdi:counter" },
-      "intelligent_tt_next_interval": { "default": "mdi:timeline-clock-outline" },
+      "intelligent_tt_next_interval": {
+        "default": "mdi:timeline-clock-outline"
+      },
       "filtvalve_remaining": { "default": "mdi:timer-sand" },
       "filtration_remaining": { "default": "mdi:timer-sand" }
     },

--- a/custom_components/neopool/light.py
+++ b/custom_components/neopool/light.py
@@ -17,11 +17,12 @@
 import logging
 from typing import Any
 
+from neopool_modbus.registers import EXEC_REGISTER, is_valid_relay_gpio
+
 from homeassistant.components.light import LightEntity
 from homeassistant.components.light.const import ColorMode
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from neopool_modbus.registers import EXEC_REGISTER, is_valid_relay_gpio
 
 from . import NeoPoolConfigEntry
 from .const import LIGHT_DEFINITIONS

--- a/custom_components/neopool/light.py
+++ b/custom_components/neopool/light.py
@@ -67,7 +67,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class NeoPoolLight(NeoPoolEntity, LightEntity):  # type: ignore[reportIncompatibleVariableOverride]
+class NeoPoolLight(NeoPoolEntity, LightEntity):
     """Representation of a NeoPool light entity."""
 
     def __init__(

--- a/custom_components/neopool/light.py
+++ b/custom_components/neopool/light.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool integration for Home Assistant - Light module."""
+"""Light platform for the NeoPool integration."""
 
 import logging
 from typing import Any
@@ -187,7 +187,7 @@ class NeoPoolLight(NeoPoolEntity, LightEntity):
         await super().async_added_to_hass()
 
     @property
-    def is_on(self) -> bool:  # type: ignore[override]
+    def is_on(self) -> bool:
         """Return True if the light is ON."""
         if self._switch_type == "relay_timer":
             enable_val = self.coordinator.data.get("relay_light_enable", None)
@@ -195,7 +195,7 @@ class NeoPoolLight(NeoPoolEntity, LightEntity):
         return False
 
     @property
-    def available(self) -> bool:  # type: ignore[override]
+    def available(self) -> bool:
         """Return True if the light is available."""
         if not super().available:
             return False
@@ -205,13 +205,13 @@ class NeoPoolLight(NeoPoolEntity, LightEntity):
         return True
 
     @property
-    def supported_color_modes(self) -> set[str]:  # type: ignore[override]
+    def supported_color_modes(self) -> set[ColorMode]:
         """Return the color modes supported by this light."""
         # For simple on/off light, the correct mode is COLOR_MODE_ONOFF (or ColorMode.ONOFF)
         return {ColorMode.ONOFF}
 
     @property
-    def color_mode(self) -> str:  # type: ignore[override]
+    def color_mode(self) -> ColorMode:
         """Return the current color mode of the light."""
         # Actual mode is always onoff, as brightness and color are not available
         return ColorMode.ONOFF

--- a/custom_components/neopool/manifest.json
+++ b/custom_components/neopool/manifest.json
@@ -5,7 +5,6 @@
     "@svasek"
   ],
   "config_flow": true,
-  "dependencies": [],
   "documentation": "https://github.com/svasek/homeassistant-neopool-modbus",
   "integration_type": "hub",
   "iot_class": "local_polling",
@@ -14,7 +13,7 @@
     "neopool_modbus"
   ],
   "requirements": [
-    "neopool-modbus>=2.0.1"
+    "neopool-modbus==2.0.1"
   ],
   "version": "4.0.1"
 }

--- a/custom_components/neopool/manifest.json
+++ b/custom_components/neopool/manifest.json
@@ -1,19 +1,13 @@
 {
   "domain": "neopool",
   "name": "NeoPool Modbus",
-  "codeowners": [
-    "@svasek"
-  ],
+  "codeowners": ["@svasek"],
   "config_flow": true,
   "documentation": "https://github.com/svasek/homeassistant-neopool-modbus",
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/svasek/homeassistant-neopool-modbus/issues",
-  "loggers": [
-    "neopool_modbus"
-  ],
-  "requirements": [
-    "neopool-modbus==2.0.1"
-  ],
+  "loggers": ["neopool_modbus"],
+  "requirements": ["neopool-modbus==2.0.1"],
   "version": "4.0.1"
 }

--- a/custom_components/neopool/migration.py
+++ b/custom_components/neopool/migration.py
@@ -17,18 +17,14 @@
 import asyncio
 import json
 import logging
-import shutil
 from pathlib import Path
+import shutil
 from types import MappingProxyType
 
-from homeassistant.config_entries import (
-    ConfigEntry,
-    ConfigEntryChange,
-)
+from homeassistant.config_entries import ConfigEntry, ConfigEntryChange
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import CURRENT_VERSION, DOMAIN
 from .helpers import async_get_device_serial

--- a/custom_components/neopool/migration.py
+++ b/custom_components/neopool/migration.py
@@ -20,6 +20,7 @@ import logging
 from pathlib import Path
 import shutil
 from types import MappingProxyType
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry, ConfigEntryChange
 from homeassistant.core import HomeAssistant
@@ -765,3 +766,89 @@ async def async_cleanup_legacy_files(hass: HomeAssistant) -> None:
             path,
             err,
         )
+
+
+async def async_import_legacy_vistapool_entry(
+    hass: HomeAssistant, legacy_entry_id: str
+) -> tuple[str | None, str | None]:
+    """Run the cross-domain migration for a legacy vistapool entry.
+
+    Snapshots the device-level customisations (area_id, name_by_user,
+    labels, disabled_by) tied to the legacy entry before retargeting,
+    runs `migrate_single_entry_cross_domain`, restores the snapshot
+    onto the migrated device, and cleans up the leftover
+    `custom_components/vistapool/` folder.
+
+    Returns:
+        ``("migration_complete", None)`` on success.
+        ``("migration_failed", str(exc))`` if the cross-domain migration
+        raised — caller should ``async_abort`` with the error message.
+        ``(None, None)`` if the legacy entry disappeared between detect
+        and confirm — caller should fall through to the regular new-entry
+        flow.
+    """
+    legacy_entry = hass.config_entries.async_get_entry(legacy_entry_id)
+    if legacy_entry is None or legacy_entry.domain != OLD_DOMAIN:
+        return (None, None)
+
+    # ── Snapshot device customizations BEFORE migration ──────────────
+    # The cross-domain migration retargets the device's identifiers and
+    # config_entries, but it doesn't preserve user-set fields like
+    # area_id, name_by_user, or labels. We capture them here keyed by
+    # the device's serial-based identifier so we can match them onto the
+    # new device after migration.
+    device_registry = dr.async_get(hass)
+    snapshots: dict[str, dict[str, Any]] = {}
+    for device in dr.async_entries_for_config_entry(
+        device_registry, legacy_entry.entry_id
+    ):
+        # Match the (vistapool, X) tuple — that's the serial-based key
+        # the migration will rewrite to (neopool, X).
+        serial_key = next(
+            (ident for dom, ident in device.identifiers if dom == OLD_DOMAIN),
+            None,
+        )
+        if not serial_key:
+            continue
+        snapshots[serial_key] = {
+            "area_id": device.area_id,
+            "name_by_user": device.name_by_user,
+            "labels": set(device.labels),
+            "disabled_by": device.disabled_by,
+        }
+
+    # ── Run the cross-domain migration ───────────────────────────────
+    try:
+        await migrate_single_entry_cross_domain(hass, legacy_entry)
+    except Exception as exc:
+        # Intentionally broad: migration walks entity / device / config
+        # registries and the Modbus probe, so it can surface anything
+        # from HomeAssistantError to RuntimeError / OSError / NeoPoolError
+        # / ValueError. We never want a config-flow step to crash with a
+        # traceback — surface the message via abort(migration_failed)
+        # and let the user retry.
+        _LOGGER.exception(
+            "Cross-domain migration failed for %s",
+            legacy_entry.entry_id,
+        )
+        return ("migration_failed", str(exc))
+
+    # ── Restore device customizations onto the migrated device ───────
+    # The migration kept the device row in place but flipped its
+    # identifier to (neopool, serial_key). Find each by that tuple
+    # and re-apply the user-set fields.
+    for serial_key, snap in snapshots.items():
+        device = device_registry.async_get_device(identifiers={(DOMAIN, serial_key)})
+        if device is None:
+            continue
+        device_registry.async_update_device(
+            device.id,
+            area_id=snap["area_id"],
+            name_by_user=snap["name_by_user"],
+            labels=snap["labels"],
+            disabled_by=snap["disabled_by"],
+        )
+
+    # ── Clean up the leftover custom_components/vistapool/ folder ────
+    await async_cleanup_old_folder(hass)
+    return ("migration_complete", None)

--- a/custom_components/neopool/migration.py
+++ b/custom_components/neopool/migration.py
@@ -20,15 +20,25 @@ import logging
 from pathlib import Path
 import shutil
 from types import MappingProxyType
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from homeassistant.config_entries import ConfigEntry, ConfigEntryChange
+import voluptuous as vol
+
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigEntryChange,
+    ConfigFlowResult,
+)
+from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import CURRENT_VERSION, DOMAIN
 from .helpers import async_get_device_serial
+
+if TYPE_CHECKING:
+    from .config_flow import NeoPoolConfigFlow
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -852,3 +862,135 @@ async def async_import_legacy_vistapool_entry(
     # ── Clean up the leftover custom_components/vistapool/ folder ────
     await async_cleanup_old_folder(hass)
     return ("migration_complete", None)
+
+
+async def async_detect_legacy_vistapool_entry(
+    hass: HomeAssistant,
+) -> tuple[str, str] | None:
+    """Return ``(entry_id, title)`` of the first legacy vistapool entry, or ``None``.
+
+    Used by the config flow to decide whether to offer the one-click
+    cross-domain import step.
+    """
+    legacy_entries = hass.config_entries.async_entries(OLD_DOMAIN)
+    if not legacy_entries:
+        return None
+    return (legacy_entries[0].entry_id, legacy_entries[0].title)
+
+
+async def async_offer_vistapool_import_if_present(
+    flow: "NeoPoolConfigFlow",
+) -> ConfigFlowResult | None:
+    """Detect a legacy vistapool entry; if found, set state and dispatch.
+
+    Sets ``flow._legacy_entry_id`` / ``flow._legacy_entry_title`` and
+    returns the result of ``async_step_import_from_vistapool``. Returns
+    ``None`` if no legacy entry is present, signalling that the caller
+    should fall through to the regular new-entry form.
+    """
+    legacy = await async_detect_legacy_vistapool_entry(flow.hass)
+    if legacy is None:
+        return None
+    flow._legacy_entry_id, flow._legacy_entry_title = legacy
+    return await flow.async_step_import_from_vistapool()
+
+
+def find_unmigrated_v1_entry(
+    hass: HomeAssistant,
+    host: str | None,
+    port: int | None,
+    slave_id: int | None,
+    modbus_framer: str | None,
+) -> ConfigEntry | None:
+    """Return an existing v1 (``unique_id=None``) entry matching connection params.
+
+    Used by the config flow to abort with ``already_configured`` when a user
+    tries to add a controller that's already configured under a v1 entry
+    that hasn't been migrated yet (host/port/slave_id/framer all match).
+    """
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if entry.unique_id is not None:
+            continue
+        if (
+            entry.data.get(CONF_HOST) == host
+            and entry.data.get(CONF_PORT) == port
+            and entry.data.get("slave_id") == slave_id
+            and entry.data.get("modbus_framer") == modbus_framer
+        ):
+            return entry
+    return None
+
+
+def async_abort_if_unmigrated_v1_match(
+    flow: "NeoPoolConfigFlow",
+    user_input: dict[str, Any],
+) -> ConfigFlowResult | None:
+    """Abort the flow if ``user_input`` matches an unmigrated v1 entry, else None.
+
+    HA's standard ``_abort_if_unique_id_configured`` doesn't catch v1
+    entries (their ``unique_id`` is ``None``) — this defensive check
+    matches them by connection parameters instead.
+    """
+    if find_unmigrated_v1_entry(
+        flow.hass,
+        user_input.get(CONF_HOST),
+        user_input.get(CONF_PORT),
+        user_input.get("slave_id"),
+        user_input.get("modbus_framer"),
+    ):
+        return flow.async_abort(reason="already_configured")
+    return None
+
+
+async def async_handle_import_step(
+    flow: "NeoPoolConfigFlow",
+    user_input: dict[str, Any] | None,
+    legacy_entry_id: str,
+    legacy_entry_title: str,
+) -> ConfigFlowResult:
+    """Body of the ``import_from_vistapool`` config flow step.
+
+    The ConfigFlow class only owns the HA framework binding
+    (``async_step_import_from_vistapool``); the actual orchestration
+    of pre-check → form display → migration dispatch → result mapping
+    lives here so the rest of the migration plumbing stays in one
+    module.
+
+    On confirmation, delegates to :func:`async_import_legacy_vistapool_entry`.
+    On decline / disappearance of the legacy entry, falls through to the
+    regular ``async_step_user`` form.
+    """
+    # The legacy entry might have been removed between async_step_user
+    # detecting it and the user clicking Submit — re-resolve to be safe.
+    legacy_entry = flow.hass.config_entries.async_get_entry(legacy_entry_id)
+    if legacy_entry is None or legacy_entry.domain != OLD_DOMAIN:
+        # Nothing to import any more; fall through to the regular new-entry
+        # path. user_input None forces a fresh form display there.
+        return await flow.async_step_user()
+
+    if user_input is None:
+        return flow.async_show_form(
+            step_id="import_from_vistapool",
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "entry_title": legacy_entry_title,
+            },
+        )
+
+    # Run the cross-domain migration (snapshot → retarget → restore →
+    # cleanup) — the helper already created and added the new neopool
+    # entry to hass.config_entries, so we MUST NOT call
+    # async_create_entry here. Aborting with a friendly reason gives
+    # the user a confirmation dialog ("migration completed").
+    reason, error = await async_import_legacy_vistapool_entry(
+        flow.hass, legacy_entry_id
+    )
+    if reason is None:
+        # Legacy entry disappeared between detect and run — fall through.
+        return await flow.async_step_user()
+    if reason == "migration_failed":
+        return flow.async_abort(
+            reason="migration_failed",
+            description_placeholders={"error": error or ""},
+        )
+    return flow.async_abort(reason="migration_complete")

--- a/custom_components/neopool/number.py
+++ b/custom_components/neopool/number.py
@@ -167,7 +167,7 @@ class NeoPoolNumber(NeoPoolEntity, NumberEntity):
         self._attr_device_class = props.get("device_class") or None
         self._attr_entity_category = props.get("entity_category") or None
         self._pending_write_task: asyncio.Task[None] | None = None
-        self._pending_value: float | str | None = None
+        self._pending_value: float | None = None
         self._debounce_delay = 2.0
 
         _LOGGER.debug(
@@ -202,7 +202,7 @@ class NeoPoolNumber(NeoPoolEntity, NumberEntity):
 
         self.async_write_ha_state()
 
-    async def async_set_native_value(self, value: float | str) -> None:
+    async def async_set_native_value(self, value: float) -> None:
         """Set the native value of the number entity."""
         if self.coordinator.winter_mode:
             _LOGGER.warning(

--- a/custom_components/neopool/number.py
+++ b/custom_components/neopool/number.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool integration for Home Assistant - Number module."""
+"""Number platform for the NeoPool integration."""
 
 import asyncio
 from collections.abc import Mapping
@@ -141,10 +141,10 @@ class NeoPoolNumber(NeoPoolEntity, NumberEntity):
         """Initialize the NeoPool number entity."""
         super().__init__(coordinator, entry_id)
         self._key = key
-        self._register = props.get("register", None)
+        self._register = props.get("register")
         self._scale = props.get("scale", 1.0)
         # Optional bitmask support for compound registers
-        self._mask: int | None = props.get("mask", None)
+        self._mask: int | None = props.get("mask")
         self._shift: int = props.get("shift", 0)
         self._data_key: str = props.get("data_key", key)
 
@@ -156,16 +156,18 @@ class NeoPoolNumber(NeoPoolEntity, NumberEntity):
         self._attr_unique_id = f"{device_id}_{self._key.lower()}"
         self._attr_translation_key = NeoPoolEntity.slugify(self._key)
 
-        self._attr_native_unit_of_measurement = props.get("unit", None)
-        self._attr_native_min_value = props.get("min", None)
-        self._attr_native_max_value = props.get("max", None)
+        self._attr_native_unit_of_measurement = props.get("unit")
+        if (min_val := props.get("min")) is not None:
+            self._attr_native_min_value = min_val
+        if (max_val := props.get("max")) is not None:
+            self._attr_native_max_value = max_val
         self._attr_native_step = props.get("step", 1.0)
         self._attr_mode = NumberMode.BOX
 
         self._attr_device_class = props.get("device_class") or None
         self._attr_entity_category = props.get("entity_category") or None
-        self._pending_write_task = None
-        self._pending_value = None
+        self._pending_write_task: asyncio.Task[None] | None = None
+        self._pending_value: float | str | None = None
         self._debounce_delay = 2.0
 
         _LOGGER.debug(
@@ -200,7 +202,7 @@ class NeoPoolNumber(NeoPoolEntity, NumberEntity):
 
         self.async_write_ha_state()
 
-    async def async_set_native_value(self, value: float | int | str) -> None:
+    async def async_set_native_value(self, value: float | str) -> None:
         """Set the native value of the number entity."""
         if self.coordinator.winter_mode:
             _LOGGER.warning(
@@ -266,7 +268,7 @@ class NeoPoolNumber(NeoPoolEntity, NumberEntity):
         return None
 
     @property
-    def native_value(self) -> float | int | str | None:  # type: ignore[override]
+    def native_value(self) -> float | None:
         """Return the actual number value."""
         raw = self.coordinator.data.get(self._data_key)
         if raw is not None and self._mask is not None:
@@ -281,7 +283,7 @@ class NeoPoolNumber(NeoPoolEntity, NumberEntity):
 
     # Property to set correct native value for hydrolysis
     @property
-    def native_unit_of_measurement(self) -> str | None:  # type: ignore[override]
+    def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement for the number value."""
         if self._key == "MBF_PAR_HIDRO":
             # Dynamically determine unit based on machine configuration using the same logic as Tasmota
@@ -290,7 +292,7 @@ class NeoPoolNumber(NeoPoolEntity, NumberEntity):
 
     # Property to set correct native max value for hydrolysis
     @property
-    def native_max_value(self) -> float | None:  # type: ignore[override]
+    def native_max_value(self) -> float:
         """Return the maximum value for the number entity."""
         if self._key == "MBF_PAR_HIDRO":
             hidro_nom = self.coordinator.data.get("MBF_PAR_HIDRO_NOM")
@@ -299,7 +301,7 @@ class NeoPoolNumber(NeoPoolEntity, NumberEntity):
         return self._attr_native_max_value
 
     @property
-    def native_step(self) -> float | None:  # type: ignore[override]
+    def native_step(self) -> float | None:
         """Return the step value for the number entity."""
         if self._key == "MBF_PAR_HIDRO":
             # 1.0 step in percent mode, 0.1 step in g/h mode (matches display precision and register scale)

--- a/custom_components/neopool/number.py
+++ b/custom_components/neopool/number.py
@@ -15,19 +15,20 @@
 """NeoPool integration for Home Assistant - Number module."""
 
 import asyncio
-import logging
 from collections.abc import Mapping
+import logging
 from typing import Any
 
-from homeassistant.components.number import NumberEntity, NumberMode
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from neopool_modbus.decoders import is_hydrolysis_in_percent
 from neopool_modbus.registers import (
     HEATING_SETPOINT_REGISTER,
     INTELLIGENT_SETPOINT_REGISTER,
     is_valid_relay_gpio,
 )
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import NeoPoolConfigEntry
 from .const import NUMBER_DEFINITIONS

--- a/custom_components/neopool/number.py
+++ b/custom_components/neopool/number.py
@@ -128,7 +128,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class NeoPoolNumber(NeoPoolEntity, NumberEntity):  # type: ignore[reportIncompatibleVariableOverride]
+class NeoPoolNumber(NeoPoolEntity, NumberEntity):
     """Representation of a NeoPool number entity."""
 
     def __init__(

--- a/custom_components/neopool/options_flow.py
+++ b/custom_components/neopool/options_flow.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool integration for Home Assistant - Options flow module."""
+"""Options flow for the NeoPool integration."""
 
 import logging
 from typing import Any
@@ -44,7 +44,7 @@ class NeoPoolOptionsFlowHandler(config_entries.OptionsFlow):
         self.config_entry property provided by the OptionsFlow base class.
         """
         super().__init__()
-        self._base_options = {}
+        self._base_options: dict[str, Any] = {}
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -141,14 +141,13 @@ class NeoPoolOptionsFlowHandler(config_entries.OptionsFlow):
                 self._base_options = user_input.copy()
                 self._base_options.pop("unlock_advanced", None)
                 return await self.async_step_advanced()
-            else:
-                if (user_input.get("unlock_advanced") or "").strip() != "":
-                    _LOGGER.warning("Wrong password for the advanced settings!")
-                    return self.async_show_form(
-                        step_id="init",
-                        data_schema=schema,
-                        errors={"unlock_advanced": "unlock_advanced_error"},
-                    )
+            if (user_input.get("unlock_advanced") or "").strip() != "":
+                _LOGGER.warning("Wrong password for the advanced settings!")
+                return self.async_show_form(
+                    step_id="init",
+                    data_schema=schema,
+                    errors={"unlock_advanced": "unlock_advanced_error"},
+                )
             data = user_input.copy()
             data.pop("unlock_advanced", None)
             prev_options = dict(self.config_entry.options)

--- a/custom_components/neopool/options_flow.py
+++ b/custom_components/neopool/options_flow.py
@@ -18,12 +18,12 @@ import logging
 from typing import Any
 
 import voluptuous as vol
+
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
-from homeassistant.util import dt as dt_util
-from homeassistant.util import slugify
+from homeassistant.util import dt as dt_util, slugify
 
 from .const import (
     CONF_FILTRATION_PUMP_POWER,

--- a/custom_components/neopool/select.py
+++ b/custom_components/neopool/select.py
@@ -15,13 +15,10 @@
 """NeoPool integration for Home Assistant - Select module."""
 
 import asyncio
-import logging
 from collections.abc import Mapping
+import logging
 from typing import Any
 
-from homeassistant.components.select import SelectEntity
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from neopool_modbus.decoders import (
     generate_time_options,
     get_filtration_pump_type,
@@ -29,6 +26,10 @@ from neopool_modbus.decoders import (
     seconds_to_hhmm,
 )
 from neopool_modbus.registers import MANUAL_FILTRATION_REGISTER
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import NeoPoolConfigEntry
 from .const import (

--- a/custom_components/neopool/select.py
+++ b/custom_components/neopool/select.py
@@ -119,7 +119,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class NeoPoolSelect(NeoPoolEntity, SelectEntity):  # type: ignore[reportIncompatibleVariableOverride]
+class NeoPoolSelect(NeoPoolEntity, SelectEntity):
     """Representation of a NeoPool select entity."""
 
     def __init__(

--- a/custom_components/neopool/select.py
+++ b/custom_components/neopool/select.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool integration for Home Assistant - Select module."""
+"""Select platform for the NeoPool integration."""
 
 import asyncio
 from collections.abc import Mapping
@@ -161,8 +161,175 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):
             getattr(self, "has_entity_name", None),
         )
 
+    async def _select_mapped_register(self, client: Any, option: str) -> None:
+        """Reverse-lookup the option label and write to a register.
+
+        Used by mapped-register selects (INTELLIGENT_FILT_MIN_TIME,
+        FILTVALVE_PERIOD_MINUTES, RELAY_ACTIVATION_DELAY): looks the option
+        label back to its register value, applies the optional
+        ``write_offset``, and writes to the entity's register.
+        """
+        reverse_map = {v: k for k, v in self._options_map.items()}
+        value = reverse_map.get(option)
+        if value is None:
+            try:  # pragma: no cover  # mapped_register option is always in options_map; this fallback is for raw values
+                value = int(option.rstrip("ms"))
+            except (TypeError, ValueError):  # pragma: no cover
+                return
+        write_val = value + self._props.get("write_offset", 0)
+        await client.async_write_register(self._register, max(0, write_val))
+        await asyncio.sleep(0.2)
+        self._optimistic_update(value)
+        if self.coordinator.data is not None:
+            self.coordinator.async_set_updated_data(self.coordinator.data)
+        self.coordinator.request_refresh_with_followup()
+
+    async def _select_timer_time(self, option: str) -> None:
+        """Update the start or stop time of a timer via the set_timer service."""
+        timer_name, field = self._key.rsplit("_", 1)
+        data = self.coordinator.data
+        if field == "start":
+            start = option
+            stop = seconds_to_hhmm(data.get(f"{timer_name}_stop", 0))
+        elif field == "stop":
+            start = seconds_to_hhmm(data.get(f"{timer_name}_start", 0))
+            stop = option
+        else:  # pragma: no cover
+            return
+        await self.hass.services.async_call(
+            DOMAIN,
+            "set_timer",
+            {
+                "entry_id": self._entry_id,
+                "timer": timer_name,
+                "start": start,
+                "stop": stop,
+            },
+        )
+
+    async def _select_timer_period(self, option: str) -> None:
+        """Update the repeat period of a timer via the set_timer service."""
+        timer_name = self._key.rsplit("_", 1)[0]  # for example, "relay_aux1"
+        period_value = PERIOD_MAP.get(option)
+        if period_value is None:
+            # fallback to integer conversion
+            try:  # pragma: no cover  # 'option' is always one of the labels in PERIOD_MAP
+                period_value = int(option)
+            except (TypeError, ValueError):  # pragma: no cover
+                return
+        await self.hass.services.async_call(
+            DOMAIN,
+            "set_timer",
+            {
+                "entry_id": self._entry_id,
+                "timer": timer_name,
+                "period": period_value,
+            },
+        )
+
+    async def _select_relay_mode(self, option: str) -> None:
+        """Update a relay's automatic/on/off mode via the set_timer service."""
+        timer_field = self._props.get("timer_field", "enable")
+        timer_name = self._key.rsplit("_", 1)[0]  # for example, "relay_aux1"
+        reverse_map = {v: k for k, v in self._options_map.items()}
+        value = reverse_map.get(option)
+        if value is None:  # pragma: no cover
+            return
+        await self.hass.services.async_call(
+            DOMAIN,
+            "set_timer",
+            {
+                "entry_id": self._entry_id,
+                "timer": timer_name,
+                timer_field: value,
+            },
+        )
+        self._optimistic_update(value)
+        if self.coordinator.data is not None:
+            self.coordinator.async_set_updated_data(self.coordinator.data)
+
+    async def _select_cell_boost(self, client: Any, option: str) -> None:
+        """Encode the cell boost mode into the composite cell-status register."""
+        value = next(
+            (k for k, v in self._options_map.items() if v == option),
+            None,
+        )
+        if value is None:  # pragma: no cover
+            return
+        if value == 0:  # pragma: no cover
+            write_val = 0
+        elif value == 1:  # pragma: no cover
+            # 0x85A0 = Boost active, redox control DISABLED
+            write_val = 0x0500 | 0x00A0 | 0x8000
+        elif value == 2:
+            # 0x05A0 = Boost active, redox control ENABLED
+            write_val = 0x0500 | 0x00A0
+        else:  # pragma: no cover
+            return
+        reg = SELECT_DEFINITIONS[self._key]["register"]
+        await client.async_write_register(reg, write_val)
+        await asyncio.sleep(0.2)
+
+    async def _select_filtration_speed(self, client: Any, option: str) -> None:
+        """Pack the filtration speed into the composite filtration_conf register."""
+        rev_map = {v: k for k, v in self._options_map.items()}
+        value = rev_map.get(option)
+        if value is None:  # pragma: no cover
+            return
+        current = self.coordinator.data.get("MBF_PAR_FILTRATION_CONF")
+        if current is None or self._attr_mask is None or self._attr_shift is None:
+            return  # pragma: no cover
+        new_val = (current & ~self._attr_mask) | (value << self._attr_shift)
+        _LOGGER.debug(
+            "Setting new filtration speed: current=0x%04X, new_val=0x%04X, mask=0x%04X, shift=%s",
+            current,
+            new_val,
+            self._attr_mask,
+            self._attr_shift,
+        )
+        await client.async_write_register(self._register, new_val, apply=True)
+        await asyncio.sleep(0.2)
+
+    async def _select_default_register(self, client: Any, option: str) -> None:
+        """Write the option's mapped value to the entity's register.
+
+        Special-cases MBF_PAR_FILT_MODE: leaving manual mode first stops the
+        pump (writing 0 to MANUAL_FILTRATION_REGISTER), except when switching
+        to backwash on a device with an automatic Besgo valve, where the pump
+        must keep running for the valve to open correctly.
+        """
+        value = next(
+            (k for k, v in self._options_map.items() if v == option),
+            None,
+        )
+        if value is None:  # pragma: no cover
+            return
+        if self._key == "MBF_PAR_FILT_MODE":
+            current_mode = self.coordinator.data.get(self._key)
+            current_name = self._options_map.get(current_mode)
+            has_auto_valve = has_filtvalve(self.coordinator.data)
+            # When leaving manual mode, stop the pump first - EXCEPT when
+            # switching to backwash on a device WITH an automatic valve (Besgo).
+            # In that case the pump must keep running so the valve opens correctly.
+            # For manual valve users the pump must stop so the user can safely
+            # rotate the multi-way valve before the backwash cycle begins.
+            if current_name == "manual" and option != "manual":
+                if not (option == "backwash" and has_auto_valve):
+                    await client.async_write_register(MANUAL_FILTRATION_REGISTER, 0)
+                    await asyncio.sleep(0.1)
+        await client.async_write_register(self._register, value)
+        if self._key == "MBF_PAR_FILT_MODE" and option == "backwash":
+            _LOGGER.info(
+                'Your pool "%s" has been switched to the BACKWASH mode!',
+                NeoPoolEntity.slugify(self.coordinator.device_name),
+            )
+        self._optimistic_update(value)
+        if self.coordinator.data is not None:
+            self.coordinator.async_set_updated_data(self.coordinator.data)
+        self.coordinator.request_refresh_with_followup()
+
     async def async_select_option(self, option: str) -> None:
-        """Handle option selection."""
+        """Handle option selection by dispatching to the per-type writer."""
         if self.coordinator.winter_mode:
             _LOGGER.warning(
                 "Winter mode is active — ignoring select_option for %s", self._key
@@ -172,179 +339,25 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):
         if client is None:  # pragma: no cover
             _LOGGER.error("Modbus client not available for writing registers.")
             return
-        # Mapped register selects (INTELLIGENT_FILT_MIN_TIME, FILTVALVE_PERIOD_MINUTES,
-        # RELAY_ACTIVATION_DELAY): reverse-lookup option label to register value,
-        # apply optional write_offset, and write to register.
         if self._select_type == "mapped_register":
-            reverse_map = {v: k for k, v in self._options_map.items()}
-            value = reverse_map.get(option)
-            if value is None:
-                try:
-                    value = int(option.rstrip("ms"))
-                except (TypeError, ValueError):  # pragma: no cover
-                    return
-            write_val = value + self._props.get("write_offset", 0)
-            await client.async_write_register(self._register, max(0, write_val))
-            await asyncio.sleep(0.2)
-            self._optimistic_update(value)
-            if self.coordinator.data is not None:
-                self.coordinator.async_set_updated_data(self.coordinator.data)
-            self.coordinator.request_refresh_with_followup()
+            await self._select_mapped_register(client, option)
             return
         if self._select_type == "timer_time":
-            timer_name, field = self._key.rsplit("_", 1)
-            entry_id = self._entry_id
-            data = self.coordinator.data
-            if field == "start":
-                start = option
-                stop = seconds_to_hhmm(data.get(f"{timer_name}_stop", 0))
-            elif field == "stop":
-                start = seconds_to_hhmm(data.get(f"{timer_name}_start", 0))
-                stop = option
-            else:  # pragma: no cover
-                return
-
-            await self.hass.services.async_call(
-                DOMAIN,
-                "set_timer",
-                {
-                    "entry_id": entry_id,
-                    "timer": timer_name,
-                    "start": start,
-                    "stop": stop,
-                },
-            )
+            await self._select_timer_time(option)
             return
-
         if self._select_type == "timer_period":
-            timer_name = self._key.rsplit("_", 1)[0]  # for example, "relay_aux1"
-            entry_id = self._entry_id
-
-            period_value = PERIOD_MAP.get(option)
-            if period_value is None:
-                # fallback to integer conversion
-                try:
-                    period_value = int(option)
-                except (TypeError, ValueError):  # pragma: no cover
-                    return
-
-            await self.hass.services.async_call(
-                DOMAIN,
-                "set_timer",
-                {
-                    "entry_id": entry_id,
-                    "timer": timer_name,
-                    "period": period_value,
-                },
-            )
+            await self._select_timer_period(option)
             return
-
         if self._select_type == "relay_mode":
-            timer_field = self._props.get("timer_field", "enable")
-            timer_name = self._key.rsplit("_", 1)[0]  # for example, "relay_aux1"
-            reverse_map = {v: k for k, v in self._options_map.items()}
-            value = reverse_map.get(option)
-            if value is None:  # pragma: no cover
-                return
-            entry_id = self._entry_id
-            await self.hass.services.async_call(
-                DOMAIN,
-                "set_timer",
-                {
-                    "entry_id": entry_id,
-                    "timer": timer_name,
-                    timer_field: value,
-                },
-            )
-            self._optimistic_update(value)
-            if self.coordinator.data is not None:
-                self.coordinator.async_set_updated_data(self.coordinator.data)
+            await self._select_relay_mode(option)
             return
-
         if self._key == "MBF_CELL_BOOST":
-            value = None
-            for k, v in self._options_map.items():
-                if v == option:
-                    value = k
-                    break
-
-            reg = SELECT_DEFINITIONS[self._key]["register"]
-            if value is not None:
-                if value == 0:  # pragma: no cover
-                    write_val = 0
-                elif value == 1:  # pragma: no cover
-                    write_val = (
-                        0x0500 | 0x00A0 | 0x8000
-                    )  # 0x85A0 = Boost active, redox control DISABLED
-                elif value == 2:
-                    write_val = (
-                        0x0500 | 0x00A0
-                    )  # 0x05A0 = Boost active, redox control ENABLED
-                else:  # pragma: no cover
-                    return
-
-                await client.async_write_register(reg, write_val)
-                await asyncio.sleep(0.2)
+            await self._select_cell_boost(client, option)
             return
-
         if self._key in _FILTRATION_SPEED_KEYS:
-            rev_map = {v: k for k, v in self._options_map.items()}
-            value = rev_map.get(option)
-            if value is None:  # pragma: no cover
-                return
-
-            current = self.coordinator.data.get("MBF_PAR_FILTRATION_CONF")
-            if current is None or self._attr_mask is None or self._attr_shift is None:
-                return  # pragma: no cover
-
-            new_val = (current & ~self._attr_mask) | (value << self._attr_shift)
-            _LOGGER.debug(
-                "Setting new filtration speed: current=0x%04X, new_val=0x%04X, mask=0x%04X, shift=%s",
-                current,
-                new_val,
-                self._attr_mask,
-                self._attr_shift,
-            )
-            await client.async_write_register(self._register, new_val, apply=True)
-            await asyncio.sleep(0.2)
+            await self._select_filtration_speed(client, option)
             return
-
-        value = None
-        for k, v in self._options_map.items():
-            if v == option:
-                value = k
-                break
-
-        if value is not None:
-            # Special: MBF_PAR_FILT_MODE needs to handle manual → other
-            # We have to turn off manual filtration first (set register 0x0413 to 0)
-            # and then set the new mode
-            if self._key == "MBF_PAR_FILT_MODE":
-                current_mode = self.coordinator.data.get(self._key)
-                current_name = self._options_map.get(current_mode)
-                has_auto_valve = has_filtvalve(self.coordinator.data)
-                # When leaving manual mode, stop the pump first - EXCEPT when
-                # switching to backwash on a device WITH an automatic valve (Besgo).
-                # In that case the pump must keep running so the valve opens correctly.
-                # For manual valve users the pump must stop so the user can safely
-                # rotate the multi-way valve before the backwash cycle begins.
-                if current_name == "manual" and option != "manual":
-                    if not (option == "backwash" and has_auto_valve):
-                        await client.async_write_register(MANUAL_FILTRATION_REGISTER, 0)
-                        await asyncio.sleep(0.1)
-            # Set the new mode
-            await client.async_write_register(self._register, value)
-            if self._key == "MBF_PAR_FILT_MODE" and option == "backwash":
-                _LOGGER.info(
-                    'Your pool "%s" has been switched to the BACKWASH mode!',
-                    NeoPoolEntity.slugify(self.coordinator.device_name),
-                )
-
-            # Optimistic update + schedule follow-up
-            self._optimistic_update(value)
-            if self.coordinator.data is not None:
-                self.coordinator.async_set_updated_data(self.coordinator.data)
-            self.coordinator.request_refresh_with_followup()
+        await self._select_default_register(client, option)
 
     async def async_added_to_hass(self) -> None:
         """Run when the entity is added to hass."""
@@ -357,7 +370,7 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):
         await super().async_added_to_hass()
 
     @property
-    def options(self) -> list[str]:  # type: ignore[override]
+    def options(self) -> list[str]:
         """Return the list of options for the select entity."""
         option_keys = list(self._options_map.keys())
 
@@ -480,7 +493,7 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):
             data[self._key] = value
 
     @property
-    def current_option(self) -> str | None:  # type: ignore[override]
+    def current_option(self) -> str | None:
         """Return the current option for the select entity."""
         if self._key == "MBF_CELL_BOOST":
             reg_val = self.coordinator.data.get(self._key)
@@ -544,7 +557,7 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):
         return seconds_to_hhmm(value)  # pragma: no cover
 
     @property
-    def available(self) -> bool:  # type: ignore[override]
+    def available(self) -> bool:
         """Return whether the select entity should be presented as available."""
         if self._key == "MBF_PAR_FILTRATION_SPEED":
             if not super().available:

--- a/custom_components/neopool/sensor.py
+++ b/custom_components/neopool/sensor.py
@@ -14,10 +14,12 @@
 
 """NeoPool integration for Home Assistant - Sensor module."""
 
+from datetime import datetime
 import logging
 import math
-from datetime import datetime
 from typing import Any
+
+from neopool_modbus.decoders import get_filtration_pump_type, is_hydrolysis_in_percent
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -29,7 +31,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_util
-from neopool_modbus.decoders import get_filtration_pump_type, is_hydrolysis_in_percent
 
 from . import NeoPoolConfigEntry
 from .const import CONF_FILTRATION_PUMP_POWER, SENSOR_DEFINITIONS

--- a/custom_components/neopool/sensor.py
+++ b/custom_components/neopool/sensor.py
@@ -165,7 +165,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class NeoPoolSensor(NeoPoolEntity, SensorEntity):  # type: ignore[reportIncompatibleVariableOverride]
+class NeoPoolSensor(NeoPoolEntity, SensorEntity):
     """Representation of a NeoPool sensor."""
 
     _winter_mode_active = False  # sensors stay available during winter mode
@@ -363,7 +363,7 @@ class NeoPoolSensor(NeoPoolEntity, SensorEntity):  # type: ignore[reportIncompat
         return None  # pragma: no cover
 
 
-class NeoPoolFiltrationEnergySensor(NeoPoolEntity, SensorEntity, RestoreEntity):  # type: ignore[reportIncompatibleVariableOverride]
+class NeoPoolFiltrationEnergySensor(NeoPoolEntity, SensorEntity, RestoreEntity):
     """Cumulative energy consumed by the filtration pump (Wh).
 
     Integrates instantaneous power over time using coordinator update timestamps.

--- a/custom_components/neopool/sensor.py
+++ b/custom_components/neopool/sensor.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool integration for Home Assistant - Sensor module."""
+"""Sensor platform for the NeoPool integration."""
 
 from datetime import datetime
 import logging
@@ -136,7 +136,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up NeoPool sensors from a config entry."""
     coordinator = entry.runtime_data
-    entities = []
+    entities: list[SensorEntity] = []
 
     if coordinator.data is None:
         _LOGGER.warning("No data from Modbus, skipping sensor setup!")
@@ -216,7 +216,7 @@ class NeoPoolSensor(NeoPoolEntity, SensorEntity):
         await super().async_added_to_hass()
 
     @property
-    def suggested_display_precision(self) -> int | None:  # type: ignore[override]
+    def suggested_display_precision(self) -> int | None:
         """Return the suggested display precision for the sensor value."""
         if self._key == "MBF_HIDRO_CURRENT" and not is_hydrolysis_in_percent(
             self.coordinator.data
@@ -225,7 +225,7 @@ class NeoPoolSensor(NeoPoolEntity, SensorEntity):
         return self._attr_suggested_display_precision
 
     @property
-    def native_unit_of_measurement(self) -> str | None:  # type: ignore[override]
+    def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement for the sensor value."""
         if self._key == "MBF_HIDRO_CURRENT" and not is_hydrolysis_in_percent(
             self.coordinator.data
@@ -233,96 +233,106 @@ class NeoPoolSensor(NeoPoolEntity, SensorEntity):
             return "g/h"
         return self._attr_native_unit_of_measurement
 
+    _MEASURE_KEYS_REQUIRING_FILTRATION = frozenset(
+        {
+            "MBF_MEASURE_TEMPERATURE",
+            "MBF_MEASURE_PH",
+            "MBF_MEASURE_RX",
+            "MBF_MEASURE_CONDUCTIVITY",
+            "MBF_HIDRO_VOLTAGE",
+            "FILTRATION_SPEED",
+        }
+    )
+
+    def _is_measurement_suppressed(self) -> bool:
+        """Return True if a measurement sensor should report None.
+
+        Some chemical / temperature sensors only return meaningful values
+        while the filtration pump is running. The 'measure_when_filtration_off'
+        option lets the user opt out of this gating.
+        """
+        if self._key not in self._MEASURE_KEYS_REQUIRING_FILTRATION:
+            return False
+        if self.coordinator.entry.options.get("measure_when_filtration_off", False):
+            return False
+        return self.coordinator.data.get("Filtration Pump") is False
+
+    def _compute_ph_pump_status(self) -> str | None:
+        """Decode the pH pump status from the control + per-pump bits."""
+        ctrl = self.coordinator.data.get("pH control module")
+        acid_bit = self.coordinator.data.get("pH acid pump active")
+        pump_bit = self.coordinator.data.get("pH pump active")
+        if ctrl is None and acid_bit is None and pump_bit is None:
+            return None
+        if ctrl is None:
+            return None  # partial data — cannot determine status
+        if not ctrl:
+            return "off"
+        # MBF_PAR_RELAY_PH determines the pH pump configuration:
+        #   0 = acid + base (bit 11 = acid, bit 12 = base)
+        #   1 = acid only   (bit 12 = acid pump; bit 11 unused)
+        #   2 = base only   (bit 12 = base pump; bit 11 unused)
+        relay_ph = self.coordinator.data.get("MBF_PAR_RELAY_PH", 0) or 0
+        if relay_ph == 1:
+            return "acid" if pump_bit else "idle"
+        if relay_ph == 2:
+            return "base" if pump_bit else "idle"
+        # Both pumps (relay_ph == 0): bit 11 = acid, bit 12 = base
+        if acid_bit and pump_bit:
+            return "both"
+        if acid_bit:
+            return "acid"
+        if pump_bit:
+            return "base"
+        return "idle"
+
+    def _compute_hidro_polarity(self) -> str | None:
+        """Decode the hydrolysis polarity from the cell status bits."""
+        pol1 = self.coordinator.data.get("HIDRO in Pol1")
+        pol2 = self.coordinator.data.get("HIDRO in Pol2")
+        dead = self.coordinator.data.get("HIDRO in dead time")
+        if pol1 is None and pol2 is None and dead is None:
+            return None
+        filtration = self.coordinator.data.get("Filtration Pump")
+        if filtration is not None and filtration is False:
+            return "off"
+        fl1 = self.coordinator.data.get("HIDRO Cell Flow FL1")
+        if filtration is True and fl1 is False:
+            return "no_flow"
+        if dead:
+            return "dead_time"
+        if pol1:
+            return "pol1"
+        if pol2:
+            return "pol2"
+        return "off"
+
+    def _compute_ion_polarity(self) -> str | None:
+        """Decode the ionizer polarity from the cell status bits."""
+        pol1 = self.coordinator.data.get("ION in Pol1")
+        pol2 = self.coordinator.data.get("ION in Pol2")
+        dead = self.coordinator.data.get("ION in dead time")
+        if pol1 is None and pol2 is None and dead is None:
+            return None
+        if dead:
+            return "dead_time"
+        if pol1:
+            return "pol1"
+        if pol2:
+            return "pol2"
+        return "off"
+
     @property
-    def native_value(self) -> float | int | str | datetime | None:  # type: ignore[override]
+    def native_value(self) -> float | int | str | datetime | None:
         """Return the actual sensor value from coordinator data."""
-
-        # If filtration is not running, some sensors should not return a value
-        # This is to avoid showing stale or irrelevant data when filtration is off
-        # For example, temperature, pH, RX, conductivity, and voltage sensors
-        # These sensors are only relevant when the filtration pump is running
-        # Anyway, we allow to override this behavior in the options
-        measure_when_off = self.coordinator.entry.options.get(
-            "measure_when_filtration_off", False
-        )
-        if (
-            self._key
-            in {
-                "MBF_MEASURE_TEMPERATURE",
-                "MBF_MEASURE_PH",
-                "MBF_MEASURE_RX",
-                "MBF_MEASURE_CONDUCTIVITY",
-                "MBF_HIDRO_VOLTAGE",
-                "FILTRATION_SPEED",
-            }
-            and not measure_when_off
-        ):
-            filtration_state = self.coordinator.data.get("Filtration Pump")
-            if filtration_state is not None and filtration_state is False:
-                return None
-
-        # Polarity sensors created from status register bits (Pol1, Pol2, dead time)
+        if self._is_measurement_suppressed():
+            return None
         if self._key == "PH_PUMP_STATUS":
-            ctrl = self.coordinator.data.get("pH control module")
-            acid_bit = self.coordinator.data.get("pH acid pump active")
-            pump_bit = self.coordinator.data.get("pH pump active")
-            if ctrl is None and acid_bit is None and pump_bit is None:
-                return None
-            if ctrl is None:
-                return None  # partial data — cannot determine status
-            if not ctrl:
-                return "off"
-            # MBF_PAR_RELAY_PH determines the pH pump configuration:
-            #   0 = acid + base (bit 11 = acid, bit 12 = base)
-            #   1 = acid only   (bit 12 = acid pump; bit 11 unused)
-            #   2 = base only   (bit 12 = base pump; bit 11 unused)
-            relay_ph = self.coordinator.data.get("MBF_PAR_RELAY_PH", 0) or 0
-            if relay_ph == 1:
-                # Acid-only: bit 12 is the acid pump
-                return "acid" if pump_bit else "idle"
-            if relay_ph == 2:
-                # Base-only: bit 12 is the base pump
-                return "base" if pump_bit else "idle"
-            # Both pumps (relay_ph == 0): bit 11 = acid, bit 12 = base
-            if acid_bit and pump_bit:
-                return "both"
-            if acid_bit:
-                return "acid"
-            if pump_bit:
-                return "base"
-            return "idle"
+            return self._compute_ph_pump_status()
         if self._key == "HIDRO_POLARITY":
-            pol1 = self.coordinator.data.get("HIDRO in Pol1")
-            pol2 = self.coordinator.data.get("HIDRO in Pol2")
-            dead = self.coordinator.data.get("HIDRO in dead time")
-            if pol1 is None and pol2 is None and dead is None:
-                return None
-            filtration = self.coordinator.data.get("Filtration Pump")
-            if filtration is not None and filtration is False:
-                return "off"
-            fl1 = self.coordinator.data.get("HIDRO Cell Flow FL1")
-            if filtration is True and fl1 is False:
-                return "no_flow"
-            if dead:
-                return "dead_time"
-            if pol1:
-                return "pol1"
-            if pol2:
-                return "pol2"
-            return "off"
+            return self._compute_hidro_polarity()
         if self._key == "ION_POLARITY":
-            pol1 = self.coordinator.data.get("ION in Pol1")
-            pol2 = self.coordinator.data.get("ION in Pol2")
-            dead = self.coordinator.data.get("ION in dead time")
-            if pol1 is None and pol2 is None and dead is None:
-                return None
-            if dead:
-                return "dead_time"
-            if pol1:
-                return "pol1"
-            if pol2:
-                return "pol2"
-            return "off"
+            return self._compute_ion_polarity()
         if self._key == "MBF_PAR_FILT_MODE":
             filt_mode: int | None = self.coordinator.data.get(self._key)
             return FILTRATION_MODE_MAP.get(filt_mode) if filt_mode is not None else None
@@ -341,7 +351,7 @@ class NeoPoolSensor(NeoPoolEntity, SensorEntity):
         return self.coordinator.data.get(self._key)
 
     @property
-    def options(self) -> list[str] | None:  # type: ignore[override]
+    def options(self) -> list[str] | None:
         """Return the list of options for the sensor."""
         if self._key == "MBF_PAR_FILT_MODE":
             return list(FILTRATION_MODE_MAP.values())

--- a/custom_components/neopool/services.py
+++ b/custom_components/neopool/services.py
@@ -17,14 +17,15 @@
 import logging
 from typing import Any
 
+from neopool_modbus.decoders import get_timer_interval, hhmm_to_seconds
+from neopool_modbus.exceptions import NeoPoolError
+from neopool_modbus.registers import TIMER_BLOCKS
 import voluptuous as vol
+
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv
-from neopool_modbus.decoders import get_timer_interval, hhmm_to_seconds
-from neopool_modbus.exceptions import NeoPoolError
-from neopool_modbus.registers import TIMER_BLOCKS
 
 from .const import DOMAIN
 from .coordinator import NeoPoolCoordinator

--- a/custom_components/neopool/services.py
+++ b/custom_components/neopool/services.py
@@ -53,8 +53,8 @@ SERVICE_SET_TIMER_SCHEMA = vol.Schema(
         vol.Optional(ATTR_START): cv.string,
         vol.Optional(ATTR_STOP): cv.string,
         vol.Optional(ATTR_PERIOD): vol.All(int, vol.Range(min=1, max=604800)),
-        # 'enable' carries the relay-mode integer (0=disabled, 1=auto, 2=auto_linked, 3=on, 4=off)
-        # used by the relay_mode select platform.
+        # 'enable' carries the relay-mode integer (0=disabled, 1=auto,
+        # 2=auto_linked, 3=on, 4=off) used by the relay_mode select platform.
         vol.Optional(ATTR_ENABLE): vol.All(int, vol.Range(min=0, max=4)),
     }
 )
@@ -137,7 +137,9 @@ async def _async_set_timer(call: ServiceCall) -> None:
     try:
         start_sec = hhmm_to_seconds(start) if start else None
         stop_sec = hhmm_to_seconds(stop) if stop else None
-        interval = get_timer_interval(start_sec, stop_sec) if (start and stop) else None
+        interval: int | None = None
+        if start_sec is not None and stop_sec is not None:
+            interval = get_timer_interval(start_sec, stop_sec)
     except (TypeError, ValueError) as err:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
@@ -230,18 +232,16 @@ async def _async_write_register(call: ServiceCall) -> None:
 
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
-    """Register the NeoPool services (idempotent)."""
-    if not hass.services.has_service(DOMAIN, SERVICE_SET_TIMER):
-        hass.services.async_register(
-            DOMAIN,
-            SERVICE_SET_TIMER,
-            _async_set_timer,
-            schema=SERVICE_SET_TIMER_SCHEMA,
-        )
-    if not hass.services.has_service(DOMAIN, SERVICE_WRITE_REGISTER):
-        hass.services.async_register(
-            DOMAIN,
-            SERVICE_WRITE_REGISTER,
-            _async_write_register,
-            schema=SERVICE_WRITE_REGISTER_SCHEMA,
-        )
+    """Register the NeoPool services."""
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_TIMER,
+        _async_set_timer,
+        schema=SERVICE_SET_TIMER_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_WRITE_REGISTER,
+        _async_write_register,
+        schema=SERVICE_WRITE_REGISTER_SCHEMA,
+    )

--- a/custom_components/neopool/services.yaml
+++ b/custom_components/neopool/services.yaml
@@ -20,7 +20,6 @@ set_timer:
     Internally, the system stores "start" and "interval" (duration) in the device.
   fields:
     entry_id:
-      required: false
       example: "your-entry-id"
       selector:
         text:
@@ -32,17 +31,17 @@ set_timer:
         text:
       description: "Timer name (e.g. relay_aux1, relay_aux2, relay_light, ...)"
     start:
-      required: false
+      example: "08:00"
       selector:
         text:
       description: "Start time (in HH:MM, e.g. 08:00)"
     stop:
-      required: false
+      example: "10:00"
       selector:
         text:
       description: "Stop time (in HH:MM, e.g. 10:00)"
     period:
-      required: false
+      example: 86400
       selector:
         number:
           min: 1
@@ -50,7 +49,6 @@ set_timer:
           step: 1
       description: "Repeat interval in seconds for AUX/Light timers (e.g. 86400 = every day). Not used for filtration timers."
     enable:
-      required: false
       example: 1
       selector:
         number:
@@ -67,7 +65,6 @@ write_register:
     to EEPROM and applied (set apply: false to skip).
   fields:
     entry_id:
-      required: false
       example: "your-entry-id"
       selector:
         text:
@@ -85,7 +82,6 @@ write_register:
         text:
       description: "Value to write (0–65535, decimal or hex, e.g. 2 or 0x0002)"
     apply:
-      required: false
       example: true
       default: true
       selector:

--- a/custom_components/neopool/strings.json
+++ b/custom_components/neopool/strings.json
@@ -234,7 +234,9 @@
       "chlorine_control_module": { "name": "Chlorine Regulation Active" },
       "chlorine_measurement_active": { "name": "Chlorine Measurement" },
       "conductivity_pump_active": { "name": "Conductivity Pump Active" },
-      "conductivity_control_module": { "name": "Conductivity Regulation Active" },
+      "conductivity_control_module": {
+        "name": "Conductivity Regulation Active"
+      },
       "conductivity_measurement_active": { "name": "Conductivity Measurement" },
       "ion_on_target": { "name": "Ionizer On Target" },
       "ion_low_flow": { "name": "Ionizer Production Problem" },
@@ -243,9 +245,15 @@
       "pool_cover": { "name": "Pool Cover" },
       "hidro_module_active": { "name": "Hydrolysis Enabled" },
       "hidro_module_regulated": { "name": "Hydrolysis Regulation Active" },
-      "hidro_activated_by_the_rx_module": { "name": "Hydrolysis Activated by Redox Module" },
-      "hidro_chlorine_shock_mode": { "name": "Hydrolysis Chlorine Shock Mode (Boost)" },
-      "hidro_activated_by_the_cl_module": { "name": "Hydrolysis Activated by Chlorine Module" },
+      "hidro_activated_by_the_rx_module": {
+        "name": "Hydrolysis Activated by Redox Module"
+      },
+      "hidro_chlorine_shock_mode": {
+        "name": "Hydrolysis Chlorine Shock Mode (Boost)"
+      },
+      "hidro_activated_by_the_cl_module": {
+        "name": "Hydrolysis Activated by Chlorine Module"
+      },
       "heating": { "name": "Heating" },
       "uv_lamp": { "name": "UV Lamp" },
       "device_time_out_of_sync": { "name": "Device Time Sync" },
@@ -264,7 +272,9 @@
       "smart_temp_high": { "name": "Smart upper temperature" },
       "smart_temp_low": { "name": "Smart lower temperature" },
       "hidro_cover_reduction": { "name": "Cover Reduction (when covered)" },
-      "hidro_shutdown_temperature": { "name": "Hydrolysis Shutdown Temp. Threshold" }
+      "hidro_shutdown_temperature": {
+        "name": "Hydrolysis Shutdown Temp. Threshold"
+      }
     },
     "switch": {
       "winter_mode": { "name": "Winter Mode" },
@@ -277,7 +287,9 @@
       "aux3": { "name": "Relay Aux3" },
       "aux4": { "name": "Relay Aux4" },
       "hidro_cover_enable": { "name": "Enable cover reduction (when covered)" },
-      "hidro_temp_shutdown": { "name": "Enable hydrolysis shutdown on high temperature" },
+      "hidro_temp_shutdown": {
+        "name": "Enable hydrolysis shutdown on high temperature"
+      },
       "uv_mode": { "name": "UV Mode" }
     },
     "light": {
@@ -545,7 +557,9 @@
           "10800": "3 hours"
         }
       },
-      "intelligent_filt_min_time": { "name": "Intelligent: Minimum Filtration Time" },
+      "intelligent_filt_min_time": {
+        "name": "Intelligent: Minimum Filtration Time"
+      },
       "filtvalve_period_minutes": {
         "name": "Backwash Repeat Interval",
         "state": {
@@ -625,22 +639,44 @@
     }
   },
   "exceptions": {
-    "entry_not_found": { "message": "No NeoPool config entry found for entry_id {entry_id}" },
-    "no_loaded_entry": { "message": "No loaded NeoPool config entry available" },
-    "no_coordinator": { "message": "No NeoPool coordinator found for entry_id {entry_id}" },
-    "missing_parameter": { "message": "Missing required parameter {parameter}" },
-    "invalid_timer": { "message": "Invalid timer name {timer_name}. Valid timers: {valid_timers}" },
-    "invalid_timer_time": { "message": "Invalid timer time format (start: {start}, stop: {stop}). Use HH:MM (e.g. 08:30)." },
+    "entry_not_found": {
+      "message": "No NeoPool config entry found for entry_id {entry_id}"
+    },
+    "no_loaded_entry": {
+      "message": "No loaded NeoPool config entry available"
+    },
+    "no_coordinator": {
+      "message": "No NeoPool coordinator found for entry_id {entry_id}"
+    },
+    "missing_parameter": {
+      "message": "Missing required parameter {parameter}"
+    },
+    "invalid_timer": {
+      "message": "Invalid timer name {timer_name}. Valid timers: {valid_timers}"
+    },
+    "invalid_timer_time": {
+      "message": "Invalid timer time format (start: {start}, stop: {stop}). Use HH:MM (e.g. 08:30)."
+    },
     "timer_failed": { "message": "Timer setting failed: {error}" },
-    "invalid_apply": { "message": "Invalid apply {apply}: must be a boolean (true/false)" },
+    "invalid_apply": {
+      "message": "Invalid apply {apply}: must be a boolean (true/false)"
+    },
     "write_failed": { "message": "Write to register {address} failed" },
     "write_verification_failed": {
       "message": "Write verification failed at {address}: wrote {value}, read back {confirmed}"
     },
-    "register_write_failed": { "message": "Register write failed at {address}: {error}" },
-    "invalid_register_type": { "message": "Invalid {name} {value}: use a decimal number or hex (0x…)" },
-    "invalid_register_float": { "message": "Invalid {name} {value}: use an integer, not a float" },
-    "register_out_of_range": { "message": "{name} {value} out of range (0-65535)" }
+    "register_write_failed": {
+      "message": "Register write failed at {address}: {error}"
+    },
+    "invalid_register_type": {
+      "message": "Invalid {name} {value}: use a decimal number or hex (0x…)"
+    },
+    "invalid_register_float": {
+      "message": "Invalid {name} {value}: use an integer, not a float"
+    },
+    "register_out_of_range": {
+      "message": "{name} {value} out of range (0-65535)"
+    }
   },
   "issues": {
     "corrupted_gpio": {

--- a/custom_components/neopool/switch.py
+++ b/custom_components/neopool/switch.py
@@ -101,7 +101,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):  # type: ignore[reportIncompatibleVariableOverride]
+class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
     """Representation of a NeoPool switch entity."""
 
     def __init__(

--- a/custom_components/neopool/switch.py
+++ b/custom_components/neopool/switch.py
@@ -14,18 +14,19 @@
 
 """NeoPool integration for Home Assistant - Switch module."""
 
-import logging
 from collections.abc import Mapping
+import logging
 from typing import Any
 
-from homeassistant.components.switch import SwitchEntity
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from neopool_modbus.registers import (
     EXEC_REGISTER,
     MANUAL_FILTRATION_REGISTER,
     is_valid_relay_gpio,
 )
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import NeoPoolConfigEntry
 from .const import SWITCH_DEFINITIONS

--- a/custom_components/neopool/switch.py
+++ b/custom_components/neopool/switch.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeoPool integration for Home Assistant - Switch module."""
+"""Switch platform for the NeoPool integration."""
 
 from collections.abc import Mapping
 import logging
@@ -334,36 +334,36 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
                 data[self._data_key] = current & ~self._mask_bit
 
     @property
-    def is_on(self) -> bool:  # type: ignore[override]
+    def is_on(self) -> bool:
         """Return True if the switch is on."""
         if self._switch_type == "manual_filtration":
             if self.coordinator.data.get("MBF_PAR_FILT_MODE") == 1:
                 return False
             return self.coordinator.data.get("MBF_PAR_FILT_MANUAL_STATE") == 1
-        elif self._switch_type == "aux":
+        if self._switch_type == "aux":
             return bool(self.coordinator.data.get(self._key, False))
-        elif self._switch_type == "auto_time_sync":
+        if self._switch_type == "auto_time_sync":
             return getattr(self.coordinator, "auto_time_sync", False)
-        elif self._switch_type == "winter_mode":
+        if self._switch_type == "winter_mode":
             return getattr(self.coordinator, "winter_mode", False)
-        elif self._switch_type == "timer_enable":
+        if self._switch_type == "timer_enable":
             return bool(self.coordinator.data.get(self._key, 0))
-        elif self._switch_type == "relay_timer":
+        if self._switch_type == "relay_timer":
             enable_val = self.coordinator.data.get(f"relay_{self._key}_enable", None)
             return enable_val == 3  # ON if ALWAYS ON
-        elif self._switch_type == "climate_mode":
+        if self._switch_type == "climate_mode":
             return bool(self.coordinator.data.get("MBF_PAR_CLIMA_ONOFF", 0))
-        elif self._switch_type == "smart_anti_freeze":
+        if self._switch_type == "smart_anti_freeze":
             return bool(self.coordinator.data.get("MBF_PAR_SMART_ANTI_FREEZE", 0))
-        elif self._switch_type == "uv_mode":
+        if self._switch_type == "uv_mode":
             return bool(self.coordinator.data.get("MBF_PAR_UV_MODE", 0))
-        elif self._switch_type == "bitmask" and self._mask_bit is not None:
+        if self._switch_type == "bitmask" and self._mask_bit is not None:
             raw = int(self.coordinator.data.get(self._data_key, 0) or 0)
             return bool(raw & self._mask_bit)
         return False
 
     @property
-    def available(self) -> bool:  # type: ignore[override]
+    def available(self) -> bool:
         """Return True if the switch is available."""
         # These switches are pure HA settings (not device state) - always operable.
         if self._switch_type in ("winter_mode", "auto_time_sync"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,12 @@ ignore = [
 # to a dedicated services.py module in a follow-up refactor.
 "custom_components/neopool/__init__.py" = ["PLC0415", "B904", "TRY301", "BLE001"]
 
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+known-first-party = ["homeassistant"]
+combine-as-imports = true
+split-on-trailing-comma = false
+
 [tool.codespell]
 skip = "??.json,CHANGELOG.md"
 ignore-words-list = "hass"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,9 @@ select = [
     # Selected pydocstyle rules — module / public-method / __init__ docstrings
     # plus the "summary line + period" hygiene.
     "D102", "D107", "D205", "D415",
-    # Datetime: timezone-aware constructors
-    "DTZ",
+    # Datetime: timezone-aware constructors (excluding DTZ001 / DTZ005 which
+    # we use intentionally for the Modbus device clock — it has no tz info)
+    "DTZ002", "DTZ003", "DTZ004", "DTZ006", "DTZ007", "DTZ011", "DTZ012",
     # Logging format (% placeholders, not f-strings)
     "G",
     # Imports at top-level (not inside functions, save for genuine circulars)

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -16,5 +16,6 @@
   "reportAttributeAccessIssue": false,
   "reportOperatorIssue": false,
   "reportAssignmentType": false,
-  "reportMissingModuleSource": false
+  "reportMissingModuleSource": false,
+  "reportIncompatibleVariableOverride": false
 }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1195,8 +1195,8 @@ async def test_import_step_shows_form_on_first_call():
 
 
 @pytest.mark.asyncio
-async def test_import_step_runs_migration_and_restores_device():
-    """Submit → migration runs, device customizations are restored, abort emitted."""
+async def test_import_step_dispatches_migration_complete():
+    """Submit → import helper returns migration_complete → flow aborts."""
     flow = config_flow.NeoPoolConfigFlow()
     flow.hass = MagicMock()
     flow._legacy_entry_id = "legacy_entry"
@@ -1204,66 +1204,21 @@ async def test_import_step_runs_migration_and_restores_device():
 
     legacy_entry = MagicMock()
     legacy_entry.domain = "vistapool"
-    legacy_entry.entry_id = "legacy_entry"
     flow.hass.config_entries.async_get_entry.return_value = legacy_entry
 
-    # Build a legacy device tied to the vistapool entry, with all the user
-    # customizations we want to see restored after migration.
-    device = MagicMock()
-    device.id = "device_1"
-    device.identifiers = {("vistapool", "neopool_SERIAL_X")}
-    device.area_id = "kitchen"
-    device.name_by_user = "Můj bazén"
-    device.labels = {"outdoor", "pool"}
-    device.disabled_by = None
-
-    # Migrated device (after migration the identifier was flipped to neopool)
-    migrated_device = MagicMock()
-    migrated_device.id = "device_1"  # same row, same id
-
-    device_registry = MagicMock()
-    device_registry.async_get_device.return_value = migrated_device
-
-    with (
-        patch(
-            "custom_components.neopool.config_flow.migrate_single_entry_cross_domain",
-            new=AsyncMock(return_value=2),
-        ) as migrate_mock,
-        patch(
-            "custom_components.neopool.config_flow.async_cleanup_old_folder",
-            new=AsyncMock(return_value=True),
-        ) as cleanup_mock,
-        patch(
-            "homeassistant.helpers.device_registry.async_get",
-            return_value=device_registry,
-        ),
-        patch(
-            "homeassistant.helpers.device_registry.async_entries_for_config_entry",
-            return_value=[device],
-        ),
+    with patch(
+        "custom_components.neopool.config_flow.async_import_legacy_vistapool_entry",
+        new=AsyncMock(return_value=("migration_complete", None)),
     ):
         result = await flow.async_step_import_from_vistapool(user_input={})
 
-    # Migration was invoked with the legacy entry
-    migrate_mock.assert_awaited_once_with(flow.hass, legacy_entry)
-    # Cleanup was called
-    cleanup_mock.assert_awaited_once_with(flow.hass)
-    # Device customizations restored onto the migrated device
-    device_registry.async_update_device.assert_called_once_with(
-        "device_1",
-        area_id="kitchen",
-        name_by_user="Můj bazén",
-        labels={"outdoor", "pool"},
-        disabled_by=None,
-    )
-    # Flow ends with the migration_complete abort reason
     assert result["type"] == "abort"
     assert result["reason"] == "migration_complete"
 
 
 @pytest.mark.asyncio
-async def test_import_step_skips_device_without_vistapool_identifier():
-    """A legacy device without a (vistapool, X) identifier is skipped during snapshot."""
+async def test_import_step_dispatches_migration_failed():
+    """Submit → import helper returns migration_failed → flow aborts with error."""
     flow = config_flow.NeoPoolConfigFlow()
     flow.hass = MagicMock()
     flow._legacy_entry_id = "legacy_entry"
@@ -1271,118 +1226,39 @@ async def test_import_step_skips_device_without_vistapool_identifier():
 
     legacy_entry = MagicMock()
     legacy_entry.domain = "vistapool"
-    legacy_entry.entry_id = "legacy_entry"
     flow.hass.config_entries.async_get_entry.return_value = legacy_entry
 
-    # Device with only a non-vistapool identifier — defensive case
-    device = MagicMock()
-    device.identifiers = {("zigbee", "stray-id")}
-
-    device_registry = MagicMock()
-
-    with (
-        patch(
-            "custom_components.neopool.config_flow.migrate_single_entry_cross_domain",
-            new=AsyncMock(return_value=0),
-        ),
-        patch(
-            "custom_components.neopool.config_flow.async_cleanup_old_folder",
-            new=AsyncMock(return_value=True),
-        ),
-        patch(
-            "homeassistant.helpers.device_registry.async_get",
-            return_value=device_registry,
-        ),
-        patch(
-            "homeassistant.helpers.device_registry.async_entries_for_config_entry",
-            return_value=[device],
-        ),
-    ):
-        result = await flow.async_step_import_from_vistapool(user_input={})
-
-    # Nothing to restore — no async_update_device call
-    device_registry.async_update_device.assert_not_called()
-    assert result["reason"] == "migration_complete"
-
-
-@pytest.mark.asyncio
-async def test_import_step_skips_restore_when_migrated_device_missing():
-    """If the migrated device disappeared, restore is silently skipped."""
-    flow = config_flow.NeoPoolConfigFlow()
-    flow.hass = MagicMock()
-    flow._legacy_entry_id = "legacy_entry"
-    flow._legacy_entry_title = "Bazén"
-
-    legacy_entry = MagicMock()
-    legacy_entry.domain = "vistapool"
-    legacy_entry.entry_id = "legacy_entry"
-    flow.hass.config_entries.async_get_entry.return_value = legacy_entry
-
-    device = MagicMock()
-    device.identifiers = {("vistapool", "neopool_SERIAL_X")}
-    device.area_id = "kitchen"
-    device.name_by_user = None
-    device.labels = set()
-    device.disabled_by = None
-
-    device_registry = MagicMock()
-    # After migration, the device row is gone (e.g. migration also dropped it
-    # because all config_entries became empty during a partial failure)
-    device_registry.async_get_device.return_value = None
-
-    with (
-        patch(
-            "custom_components.neopool.config_flow.migrate_single_entry_cross_domain",
-            new=AsyncMock(return_value=0),
-        ),
-        patch(
-            "custom_components.neopool.config_flow.async_cleanup_old_folder",
-            new=AsyncMock(return_value=True),
-        ),
-        patch(
-            "homeassistant.helpers.device_registry.async_get",
-            return_value=device_registry,
-        ),
-        patch(
-            "homeassistant.helpers.device_registry.async_entries_for_config_entry",
-            return_value=[device],
-        ),
-    ):
-        result = await flow.async_step_import_from_vistapool(user_input={})
-
-    device_registry.async_update_device.assert_not_called()
-    assert result["reason"] == "migration_complete"
-
-
-@pytest.mark.asyncio
-async def test_import_step_aborts_on_migration_failure():
-    """If migrate_single_entry_cross_domain raises, abort with migration_failed."""
-    flow = config_flow.NeoPoolConfigFlow()
-    flow.hass = MagicMock()
-    flow._legacy_entry_id = "legacy_entry"
-    flow._legacy_entry_title = "Bazén"
-
-    legacy_entry = MagicMock()
-    legacy_entry.domain = "vistapool"
-    legacy_entry.entry_id = "legacy_entry"
-    flow.hass.config_entries.async_get_entry.return_value = legacy_entry
-
-    with (
-        patch(
-            "custom_components.neopool.config_flow.migrate_single_entry_cross_domain",
-            new=AsyncMock(side_effect=RuntimeError("simulated failure")),
-        ),
-        patch(
-            "homeassistant.helpers.device_registry.async_get",
-            return_value=MagicMock(),
-        ),
-        patch(
-            "homeassistant.helpers.device_registry.async_entries_for_config_entry",
-            return_value=[],
-        ),
+    with patch(
+        "custom_components.neopool.config_flow.async_import_legacy_vistapool_entry",
+        new=AsyncMock(return_value=("migration_failed", "boom")),
     ):
         result = await flow.async_step_import_from_vistapool(user_input={})
 
     assert result["type"] == "abort"
     assert result["reason"] == "migration_failed"
-    assert "simulated failure" in result["description_placeholders"]["error"]
+    assert result["description_placeholders"]["error"] == "boom"
+
+
+@pytest.mark.asyncio
+async def test_import_step_falls_through_when_legacy_disappears_in_helper():
+    """Submit → import helper returns (None, None) → flow falls through to user step."""
+    flow = config_flow.NeoPoolConfigFlow()
+    flow.hass = MagicMock()
+    flow._legacy_entry_id = "legacy_entry"
+    flow._legacy_entry_title = "Bazén"
+
+    legacy_entry = MagicMock()
+    legacy_entry.domain = "vistapool"
+    flow.hass.config_entries.async_get_entry.return_value = legacy_entry
+    # No legacy vistapool entries → async_step_user goes to fresh form
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[])
+
+    with patch(
+        "custom_components.neopool.config_flow.async_import_legacy_vistapool_entry",
+        new=AsyncMock(return_value=(None, None)),
+    ):
+        result = await flow.async_step_import_from_vistapool(user_input={})
+
+    # async_step_user shows the regular new-entry form
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1207,7 +1207,7 @@ async def test_import_step_dispatches_migration_complete():
     flow.hass.config_entries.async_get_entry.return_value = legacy_entry
 
     with patch(
-        "custom_components.neopool.config_flow.async_import_legacy_vistapool_entry",
+        "custom_components.neopool.migration.async_import_legacy_vistapool_entry",
         new=AsyncMock(return_value=("migration_complete", None)),
     ):
         result = await flow.async_step_import_from_vistapool(user_input={})
@@ -1229,7 +1229,7 @@ async def test_import_step_dispatches_migration_failed():
     flow.hass.config_entries.async_get_entry.return_value = legacy_entry
 
     with patch(
-        "custom_components.neopool.config_flow.async_import_legacy_vistapool_entry",
+        "custom_components.neopool.migration.async_import_legacy_vistapool_entry",
         new=AsyncMock(return_value=("migration_failed", "boom")),
     ):
         result = await flow.async_step_import_from_vistapool(user_input={})
@@ -1254,7 +1254,7 @@ async def test_import_step_falls_through_when_legacy_disappears_in_helper():
     flow.hass.config_entries.async_entries = MagicMock(return_value=[])
 
     with patch(
-        "custom_components.neopool.config_flow.async_import_legacy_vistapool_entry",
+        "custom_components.neopool.migration.async_import_legacy_vistapool_entry",
         new=AsyncMock(return_value=(None, None)),
     ):
         result = await flow.async_step_import_from_vistapool(user_input={})

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -15,16 +15,11 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from neopool_modbus.registers import DEFAULT_MODBUS_FRAMER
+import pytest
 
 from custom_components.neopool import config_flow
-from custom_components.neopool.const import (
-    DEFAULT_NAME,
-    DEFAULT_PORT,
-    DEFAULT_SLAVE_ID,
-    DOMAIN,
-)
+from custom_components.neopool.const import DEFAULT_PORT, DEFAULT_SLAVE_ID, DOMAIN, NAME
 
 # Default serial register values for tests
 DEFAULT_SERIAL_REGS = [0x0000, 0x0001, 0x00AC, 0x00CD, 0x0012, 0x0034]
@@ -586,7 +581,7 @@ async def test_get_default_name_returns_translated_name():
 
 @pytest.mark.asyncio
 async def test_get_default_name_falls_back_when_key_missing():
-    """When translation dict does not contain name_default, DEFAULT_NAME is returned."""
+    """When translation dict does not contain name_default, NAME is returned."""
     flow = config_flow.NeoPoolConfigFlow()
     flow.hass = MagicMock()
     flow.hass.config.language = "en"
@@ -595,20 +590,20 @@ async def test_get_default_name_falls_back_when_key_missing():
         new=AsyncMock(return_value={}),
     ):
         name = await flow._async_get_default_name()
-    assert name == DEFAULT_NAME
+    assert name == NAME
 
 
 @pytest.mark.asyncio
 async def test_get_default_name_falls_back_without_hass():
-    """When hass is not set (AttributeError), DEFAULT_NAME is returned."""
+    """When hass is not set (AttributeError), NAME is returned."""
     flow = config_flow.NeoPoolConfigFlow()
     name = await flow._async_get_default_name()
-    assert name == DEFAULT_NAME
+    assert name == NAME
 
 
 @pytest.mark.asyncio
 async def test_get_default_name_falls_back_on_translation_error():
-    """When async_get_translations raises, DEFAULT_NAME is returned."""
+    """When async_get_translations raises, NAME is returned."""
     flow = config_flow.NeoPoolConfigFlow()
     flow.hass = MagicMock()
     flow.hass.config.language = "en"
@@ -617,7 +612,7 @@ async def test_get_default_name_falls_back_on_translation_error():
         new=AsyncMock(side_effect=RuntimeError("fail")),
     ):
         name = await flow._async_get_default_name()
-    assert name == DEFAULT_NAME
+    assert name == NAME
 
 
 # ---------------------------------------------------------------------------
@@ -650,8 +645,8 @@ async def test_create_entry_empty_name_uses_default():
         assert result is not None
 
     assert result["type"] == "create_entry"
-    assert result["title"] == DEFAULT_NAME
-    assert result["data"]["name"] == DEFAULT_NAME
+    assert result["title"] == NAME
+    assert result["data"]["name"] == NAME
 
 
 @pytest.mark.asyncio
@@ -679,8 +674,8 @@ async def test_create_entry_no_name_key_uses_default():
         assert result is not None
 
     assert result["type"] == "create_entry"
-    assert result["title"] == DEFAULT_NAME
-    assert result["data"]["name"] == DEFAULT_NAME
+    assert result["title"] == NAME
+    assert result["data"]["name"] == NAME
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -14,12 +14,12 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-from homeassistant.helpers.update_coordinator import UpdateFailed
 from neopool_modbus.exceptions import NeoPoolError
+import pytest
 
 from custom_components.neopool.const import DOMAIN, FOLLOW_UP_REFRESH_DELAY
 from custom_components.neopool.coordinator import NeoPoolCoordinator
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
 
 @pytest.fixture

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -14,7 +14,6 @@
 
 import datetime
 
-import pytest
 from neopool_modbus.decoders import (
     build_timer_block,
     generate_time_options,
@@ -31,6 +30,7 @@ from neopool_modbus.decoders import (
     parse_version,
     seconds_to_hhmm,
 )
+import pytest
 
 from custom_components.neopool.helpers import (
     get_device_time,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -19,10 +19,21 @@ import pytest
 from custom_components.neopool import (
     _cleanup_removed_entities,
     async_migrate_entry,
+    async_setup,
     async_setup_entry,
     async_unload_entry,
 )
 from custom_components.neopool.const import DEFAULT_PORT
+
+
+@pytest.mark.asyncio
+async def test_async_setup_registers_services():
+    """async_setup registers the neopool services and returns True."""
+    hass = MagicMock()
+    hass.services.async_register = MagicMock()
+    result = await async_setup(hass, {})
+    assert result is True
+    assert hass.services.async_register.call_count == 2
 
 
 @pytest.mark.asyncio
@@ -66,45 +77,11 @@ async def test_async_unload_entry_success():
     coordinator = MagicMock()
     coordinator.client = AsyncMock()
     config_entry.runtime_data = coordinator
-    # Simulate another entry still loaded — services should NOT be removed
-    from homeassistant.config_entries import ConfigEntryState
-
-    other_entry = MagicMock()
-    other_entry.entry_id = "entry2"
-    other_entry.state = ConfigEntryState.LOADED
-    hass.config_entries.async_entries = MagicMock(
-        return_value=[config_entry, other_entry]
-    )
-    hass.services.has_service = MagicMock(return_value=True)
-    hass.services.async_remove = MagicMock()
     result = await async_unload_entry(hass, config_entry)
     assert result is True
     # Check that follow-up refresh was cancelled and client closed
     coordinator.cancel_follow_up_refresh.assert_called_once()
     assert coordinator.client.close.await_count == 1
-    # Services should NOT be removed (other entry still loaded)
-    hass.services.async_remove.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_async_unload_entry_last_entry():
-    """Test async_unload_entry removes services when last entry is unloaded."""
-    hass = MagicMock()
-    hass.config_entries = MagicMock()
-    hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
-    config_entry = MagicMock()
-    config_entry.entry_id = "entry1"
-    coordinator = MagicMock()
-    coordinator.client = AsyncMock()
-    config_entry.runtime_data = coordinator
-    # Only this entry — after unload, no remaining entries
-    hass.config_entries.async_entries = MagicMock(return_value=[config_entry])
-    hass.services.has_service = MagicMock(return_value=True)
-    hass.services.async_remove = MagicMock()
-    result = await async_unload_entry(hass, config_entry)
-    assert result is True
-    # Services should be removed (last entry)
-    assert hass.services.async_remove.call_count == 2
 
 
 @pytest.mark.asyncio
@@ -118,9 +95,6 @@ async def test_async_unload_entry_no_client():
     coordinator = MagicMock()
     coordinator.client = None
     config_entry.runtime_data = coordinator
-    hass.config_entries.async_entries = MagicMock(return_value=[config_entry])
-    hass.services.has_service = MagicMock(return_value=True)
-    hass.services.async_remove = MagicMock()
     result = await async_unload_entry(hass, config_entry)
     assert result is True
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -25,6 +25,7 @@ from custom_components.neopool.migration import (
     _DeferredMigration,
     async_cleanup_legacy_files,
     async_cleanup_old_folder,
+    async_import_legacy_vistapool_entry,
     async_migrate_from_vistapool,
     migrate_single_entry_cross_domain,
 )
@@ -934,3 +935,207 @@ async def test_cleanup_legacy_files_logs_on_unlink_failure(
     assert not succeeding_path.exists()
     # The failing file is still present (because unlink raised)
     assert failing_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# async_import_legacy_vistapool_entry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_import_legacy_vistapool_entry_returns_none_when_legacy_gone():
+    """Legacy entry vanished between detect and run → (None, None) for fall-through."""
+    hass = MagicMock()
+    hass.config_entries.async_get_entry.return_value = None
+    reason, error = await async_import_legacy_vistapool_entry(hass, "missing")
+    assert reason is None
+    assert error is None
+
+
+@pytest.mark.asyncio
+async def test_import_legacy_vistapool_entry_returns_none_when_entry_is_not_vistapool():
+    """Entry exists but its domain is not vistapool → (None, None) for fall-through."""
+    hass = MagicMock()
+    other_entry = MagicMock()
+    other_entry.domain = "zigbee"
+    hass.config_entries.async_get_entry.return_value = other_entry
+    reason, error = await async_import_legacy_vistapool_entry(hass, "other")
+    assert reason is None
+    assert error is None
+
+
+@pytest.mark.asyncio
+async def test_import_legacy_vistapool_entry_runs_migration_and_restores_device():
+    """Submit → migration runs, device customizations are restored, success returned."""
+    hass = MagicMock()
+    legacy_entry = MagicMock()
+    legacy_entry.domain = OLD_DOMAIN
+    legacy_entry.entry_id = "legacy_entry"
+    hass.config_entries.async_get_entry.return_value = legacy_entry
+
+    # Build a legacy device tied to the vistapool entry, with all the user
+    # customizations we want to see restored after migration.
+    device = MagicMock()
+    device.id = "device_1"
+    device.identifiers = {(OLD_DOMAIN, "neopool_SERIAL_X")}
+    device.area_id = "kitchen"
+    device.name_by_user = "Můj bazén"
+    device.labels = {"outdoor", "pool"}
+    device.disabled_by = None
+
+    # Migrated device (after migration the identifier was flipped to neopool)
+    migrated_device = MagicMock()
+    migrated_device.id = "device_1"  # same row, same id
+
+    device_registry = MagicMock()
+    device_registry.async_get_device.return_value = migrated_device
+
+    with (
+        patch(
+            "custom_components.neopool.migration.migrate_single_entry_cross_domain",
+            new=AsyncMock(return_value=2),
+        ) as migrate_mock,
+        patch(
+            "custom_components.neopool.migration.async_cleanup_old_folder",
+            new=AsyncMock(return_value=True),
+        ) as cleanup_mock,
+        patch(
+            "homeassistant.helpers.device_registry.async_get",
+            return_value=device_registry,
+        ),
+        patch(
+            "homeassistant.helpers.device_registry.async_entries_for_config_entry",
+            return_value=[device],
+        ),
+    ):
+        reason, error = await async_import_legacy_vistapool_entry(hass, "legacy_entry")
+
+    # Migration was invoked with the legacy entry
+    migrate_mock.assert_awaited_once_with(hass, legacy_entry)
+    # Cleanup was called
+    cleanup_mock.assert_awaited_once_with(hass)
+    # Device customizations restored onto the migrated device
+    device_registry.async_update_device.assert_called_once_with(
+        "device_1",
+        area_id="kitchen",
+        name_by_user="Můj bazén",
+        labels={"outdoor", "pool"},
+        disabled_by=None,
+    )
+    assert reason == "migration_complete"
+    assert error is None
+
+
+@pytest.mark.asyncio
+async def test_import_legacy_vistapool_entry_skips_device_without_vistapool_identifier():
+    """A legacy device without a (vistapool, X) identifier is skipped during snapshot."""
+    hass = MagicMock()
+    legacy_entry = MagicMock()
+    legacy_entry.domain = OLD_DOMAIN
+    legacy_entry.entry_id = "legacy_entry"
+    hass.config_entries.async_get_entry.return_value = legacy_entry
+
+    # Device with only a non-vistapool identifier — defensive case
+    device = MagicMock()
+    device.identifiers = {("zigbee", "stray-id")}
+
+    device_registry = MagicMock()
+
+    with (
+        patch(
+            "custom_components.neopool.migration.migrate_single_entry_cross_domain",
+            new=AsyncMock(return_value=0),
+        ),
+        patch(
+            "custom_components.neopool.migration.async_cleanup_old_folder",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "homeassistant.helpers.device_registry.async_get",
+            return_value=device_registry,
+        ),
+        patch(
+            "homeassistant.helpers.device_registry.async_entries_for_config_entry",
+            return_value=[device],
+        ),
+    ):
+        reason, _ = await async_import_legacy_vistapool_entry(hass, "legacy_entry")
+
+    # Nothing to restore — no async_update_device call
+    device_registry.async_update_device.assert_not_called()
+    assert reason == "migration_complete"
+
+
+@pytest.mark.asyncio
+async def test_import_legacy_vistapool_entry_skips_restore_when_migrated_device_missing():
+    """If the migrated device disappeared, restore is silently skipped."""
+    hass = MagicMock()
+    legacy_entry = MagicMock()
+    legacy_entry.domain = OLD_DOMAIN
+    legacy_entry.entry_id = "legacy_entry"
+    hass.config_entries.async_get_entry.return_value = legacy_entry
+
+    device = MagicMock()
+    device.identifiers = {(OLD_DOMAIN, "neopool_SERIAL_X")}
+    device.area_id = "kitchen"
+    device.name_by_user = None
+    device.labels = set()
+    device.disabled_by = None
+
+    device_registry = MagicMock()
+    # After migration, the device row is gone (e.g. migration also dropped it
+    # because all config_entries became empty during a partial failure)
+    device_registry.async_get_device.return_value = None
+
+    with (
+        patch(
+            "custom_components.neopool.migration.migrate_single_entry_cross_domain",
+            new=AsyncMock(return_value=0),
+        ),
+        patch(
+            "custom_components.neopool.migration.async_cleanup_old_folder",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "homeassistant.helpers.device_registry.async_get",
+            return_value=device_registry,
+        ),
+        patch(
+            "homeassistant.helpers.device_registry.async_entries_for_config_entry",
+            return_value=[device],
+        ),
+    ):
+        reason, _ = await async_import_legacy_vistapool_entry(hass, "legacy_entry")
+
+    device_registry.async_update_device.assert_not_called()
+    assert reason == "migration_complete"
+
+
+@pytest.mark.asyncio
+async def test_import_legacy_vistapool_entry_returns_failure_on_migration_error():
+    """If migrate_single_entry_cross_domain raises, return migration_failed + msg."""
+    hass = MagicMock()
+    legacy_entry = MagicMock()
+    legacy_entry.domain = OLD_DOMAIN
+    legacy_entry.entry_id = "legacy_entry"
+    hass.config_entries.async_get_entry.return_value = legacy_entry
+
+    with (
+        patch(
+            "custom_components.neopool.migration.migrate_single_entry_cross_domain",
+            new=AsyncMock(side_effect=RuntimeError("simulated failure")),
+        ),
+        patch(
+            "homeassistant.helpers.device_registry.async_get",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "homeassistant.helpers.device_registry.async_entries_for_config_entry",
+            return_value=[],
+        ),
+    ):
+        reason, error = await async_import_legacy_vistapool_entry(hass, "legacy_entry")
+
+    assert reason == "migration_failed"
+    assert error is not None
+    assert "simulated failure" in error

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -25,8 +25,10 @@ from custom_components.neopool.migration import (
     _DeferredMigration,
     async_cleanup_legacy_files,
     async_cleanup_old_folder,
+    async_detect_legacy_vistapool_entry,
     async_import_legacy_vistapool_entry,
     async_migrate_from_vistapool,
+    find_unmigrated_v1_entry,
     migrate_single_entry_cross_domain,
 )
 from homeassistant.config_entries import ConfigEntryState
@@ -1139,3 +1141,79 @@ async def test_import_legacy_vistapool_entry_returns_failure_on_migration_error(
     assert reason == "migration_failed"
     assert error is not None
     assert "simulated failure" in error
+
+
+# ---------------------------------------------------------------------------
+# async_detect_legacy_vistapool_entry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_detect_legacy_vistapool_entry_returns_first():
+    """Returns (entry_id, title) of the first vistapool entry."""
+    hass = MagicMock()
+    entry1 = MagicMock()
+    entry1.entry_id = "vp1"
+    entry1.title = "Old Pool"
+    entry2 = MagicMock()
+    entry2.entry_id = "vp2"
+    entry2.title = "Other Pool"
+    hass.config_entries.async_entries = MagicMock(return_value=[entry1, entry2])
+    result = await async_detect_legacy_vistapool_entry(hass)
+    assert result == ("vp1", "Old Pool")
+    hass.config_entries.async_entries.assert_called_once_with(OLD_DOMAIN)
+
+
+@pytest.mark.asyncio
+async def test_detect_legacy_vistapool_entry_returns_none_when_empty():
+    """Returns None when no vistapool entries exist."""
+    hass = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=[])
+    result = await async_detect_legacy_vistapool_entry(hass)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# find_unmigrated_v1_entry
+# ---------------------------------------------------------------------------
+
+
+def _v1_entry(host: str, port: int, slave_id: int, framer: str) -> MagicMock:
+    entry = MagicMock()
+    entry.unique_id = None
+    entry.data = {
+        "host": host,
+        "port": port,
+        "slave_id": slave_id,
+        "modbus_framer": framer,
+    }
+    return entry
+
+
+def test_find_unmigrated_v1_entry_returns_match():
+    """Returns the entry whose connection params match all four fields."""
+    hass = MagicMock()
+    match = _v1_entry("10.0.0.1", 502, 1, "tcp")
+    other = _v1_entry("10.0.0.2", 502, 1, "tcp")
+    hass.config_entries.async_entries = MagicMock(return_value=[other, match])
+    found = find_unmigrated_v1_entry(hass, "10.0.0.1", 502, 1, "tcp")
+    assert found is match
+
+
+def test_find_unmigrated_v1_entry_skips_already_migrated_entries():
+    """Entries with a non-None unique_id are skipped (they're already migrated)."""
+    hass = MagicMock()
+    migrated = _v1_entry("10.0.0.1", 502, 1, "tcp")
+    migrated.unique_id = "neopool_SERIAL"
+    hass.config_entries.async_entries = MagicMock(return_value=[migrated])
+    found = find_unmigrated_v1_entry(hass, "10.0.0.1", 502, 1, "tcp")
+    assert found is None
+
+
+def test_find_unmigrated_v1_entry_returns_none_when_no_match():
+    """Different connection params → no match."""
+    hass = MagicMock()
+    other = _v1_entry("10.0.0.2", 502, 1, "tcp")
+    hass.config_entries.async_entries = MagicMock(return_value=[other])
+    found = find_unmigrated_v1_entry(hass, "10.0.0.1", 502, 1, "tcp")
+    assert found is None

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from homeassistant.config_entries import ConfigEntryState
 
 from custom_components.neopool.migration import (
     LEGACY_FILES_REMOVED_IN_V4,
@@ -29,6 +28,7 @@ from custom_components.neopool.migration import (
     async_migrate_from_vistapool,
     migrate_single_entry_cross_domain,
 )
+from homeassistant.config_entries import ConfigEntryState
 
 DEFAULT_SERIAL = "0000000100AC00CD00120034"
 NEW_UID = f"neopool_{DEFAULT_SERIAL}"

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -14,11 +14,11 @@
 
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
-import pytest
 from neopool_modbus.registers import (
     HEATING_SETPOINT_REGISTER,
     INTELLIGENT_SETPOINT_REGISTER,
 )
+import pytest
 
 from custom_components.neopool.number import NeoPoolNumber, async_setup_entry
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -952,9 +952,7 @@ def test_sensor_filtration_remaining_none_when_idle():
 @pytest.mark.asyncio
 async def test_filtration_power_sensor_created_when_nonzero():
     """Power sensor is created as a NeoPoolSensor when filtration_pump_power > 0."""
-    from custom_components.neopool.const import (
-        CONF_FILTRATION_PUMP_POWER,
-    )
+    from custom_components.neopool.const import CONF_FILTRATION_PUMP_POWER
 
     class DummyEntry:
         unique_id = None

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -22,10 +22,8 @@ service-registration path (which is covered separately in test_init.py).
 
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-from homeassistant.config_entries import ConfigEntryState
-from homeassistant.exceptions import ServiceValidationError
 from neopool_modbus.exceptions import NeoPoolError
+import pytest
 
 from custom_components.neopool.services import (
     SERVICE_SET_TIMER,
@@ -35,6 +33,8 @@ from custom_components.neopool.services import (
     _get_coordinator,
     async_setup_services,
 )
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.exceptions import ServiceValidationError
 
 
 def _make_call(data: dict, hass: MagicMock | None = None) -> MagicMock:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -356,20 +356,10 @@ async def test_write_register_out_of_range():
 
 
 def test_setup_services_registers_both_services():
-    """Both set_timer and write_register are registered when neither exists."""
+    """Both set_timer and write_register are registered."""
     hass = MagicMock()
-    hass.services.has_service = MagicMock(return_value=False)
     hass.services.async_register = MagicMock()
     async_setup_services(hass)
     registered = [c.args[1] for c in hass.services.async_register.call_args_list]
     assert SERVICE_SET_TIMER in registered
     assert SERVICE_WRITE_REGISTER in registered
-
-
-def test_setup_services_is_idempotent():
-    """Already-registered services are not re-registered (idempotent guard)."""
-    hass = MagicMock()
-    hass.services.has_service = MagicMock(return_value=True)
-    hass.services.async_register = MagicMock()
-    async_setup_services(hass)
-    hass.services.async_register.assert_not_called()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -15,8 +15,8 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
 from neopool_modbus.registers import EXEC_REGISTER
+import pytest
 
 from custom_components.neopool.switch import NeoPoolSwitch, async_setup_entry
 


### PR DESCRIPTION
# 🎨 Code cleanup and consistency improvements

A sweep of internal cleanups across the integration. **No behavioural
changes**: every commit is style, typing, structure or tooling — the
574-test suite passes throughout and full-line coverage is preserved
(100 % across all 17 modules in `custom_components/neopool/`).

## ✨ Highlights

- **Coordinator refactor** — the ~230-line `_async_update_data` is
  decomposed into six focused private helpers (`_get_enabled_timers`,
  `_read_timers_into_data`, `_apply_dev_overrides`,
  `_sync_heating_intelligent_setpoints`, `_persist_capability_snapshot`,
  `_handle_modbus_failure`). The orchestrator itself is now a clean
  read → derive → sync → persist sequence.
- **Select refactor** — the long `if/elif` chain in
  `async_select_option` becomes seven per-type writers
  (`_select_mapped_register`, `_select_timer_time`,
  `_select_timer_period`, `_select_relay_mode`, `_select_cell_boost`,
  `_select_filtration_speed`, `_select_default_register`).
- **Sensor refactor** — polarity / pH-pump-status decoders are
  extracted from `native_value` into focused helpers, and the
  "filtration must be running" gate keys are pulled into a class-level
  frozenset.
- **Config flow refactor** — every piece of migration mechanics that
  used to live inline in the config flow now lives in `migration.py`
  (`async_detect_legacy_vistapool_entry`, `find_unmigrated_v1_entry`,
  `async_handle_import_step`, `async_offer_vistapool_import_if_present`,
  `async_abort_if_unmigrated_v1_match`). The config flow is now a thin
  HA-framework binding.
- **Init refactor** — `async_setup_services` is now registered once
  from `async_setup` (HA's `action-setup` pattern) instead of from
  every `async_setup_entry`. Idempotency check, last-entry service
  cleanup, and the defensive `getattr` lookup in `async_unload_entry`
  are gone — services persist for the lifetime of HA.
- **Entity** — adopt the typed `DeviceInfo` helper from
  `homeassistant.helpers.device_registry` instead of a raw
  `dict[str, Any]`.

## 🔧 Tooling

- **Prettier** — single-run formatting pass over `strings.json`,
  `icons.json` and `manifest.json` so future diffs only show real
  changes, not whitespace noise. Devs can run prettier ad-hoc via
  `npx --yes prettier --write '**/*.{json,yaml,md}'`.
- **Release workflow** — `jq` reformats JSON in-place when it rewrites
  the version field, so we now run `npx --yes prettier@3` afterwards
  to restore the project's formatting conventions (verified locally —
  `jq` expands inline arrays to multi-line, `prettier` collapses them
  back, only the version bump remains in the diff).
- **Ruff isort** — treat `homeassistant` as first-party so third-party
  packages (e.g. `neopool_modbus`) sort before `homeassistant.*`.
- **basedpyright** — disable `reportIncompatibleVariableOverride` (HA's
  `Entity` declares `device_info` / `available` / `translation_key` as
  `cached_property` while we override with `@property` — that's the HA
  pattern, not a real type mismatch).

## 🩹 Smaller polish

- Module docstrings use the HA-style `"<Platform> for the <integration>
  integration."` form across all platform files.
- `# type: ignore[override]` and `# type: ignore[reportIncompatibleVariableOverride]`
  markers are dropped where they are now redundant (covered by the
  basedpyright config above).
- `services.yaml` — drop redundant `required: false` flags, add
  missing `example:` values for nicer dev-tools form rendering.
- `const.py` — replace the runtime `json.load(manifest.json)` with
  hardcoded `DOMAIN` / `NAME` constants (HA reads version / name from
  the manifest itself for UI display, the runtime read was just
  blocking I/O at import). Type the seven `*_DEFINITIONS` dicts as
  `dict[str, dict[str, Any]]`.
- `helpers.py` — replace `datetime.timezone.utc` with `datetime.UTC`,
  collapse multi-line docstring summaries to D200 single-line form,
  narrow `seconds: int | float | None` to `float | None`, narrow the
  ruff DTZ rule selection (drop DTZ001 / DTZ005 — the two intentional
  naive-datetime sites are for the Modbus device clock which has no
  timezone information).
- `manifest.json` — pin `neopool-modbus==2.0.1`, drop the redundant
  empty `"dependencies": []`.
- `icons.json` — modern object form for service icons
  (`{"service": "mdi:..."}`).

## ✅ Verification

- `ruff check` — passes
- `ruff format --check` — 33 files already formatted
- `basedpyright` — 0 errors, 0 warnings, 0 notes
- `pytest` — 574 passed
- Coverage — 100 % (every line in every module)

## 📋 Summary of files touched

20 commits split by area; squash-and-merge will produce a clean linear
history. Files touched:

- platform modules: `__init__.py`, `binary_sensor.py`, `button.py`,
  `config_flow.py`, `coordinator.py`, `diagnostics.py`, `entity.py`,
  `helpers.py`, `light.py`, `migration.py`, `number.py`,
  `options_flow.py`, `select.py`, `sensor.py`, `services.py`,
  `switch.py`
- registration / config: `const.py`, `manifest.json`, `icons.json`,
  `services.yaml`, `strings.json`
- tooling: `pyproject.toml`, `pyrightconfig.json`,
  `.github/workflows/release.yaml`, `.gitignore`, `.prettierignore`
- tests: `tests/test_*.py` (covered by the refactors — all green)
