### PR TITLE
chore(sensor): 🔧 drop unused type: ignore on energy native_value

### DIFF
--- a/custom_components/neopool/sensor.py
+++ b/custom_components/neopool/sensor.py
@@ -434,6 +434,6 @@ class NeoPoolFiltrationEnergySensor(NeoPoolEntity, SensorEntity, RestoreEntity):
         super()._handle_coordinator_update()
 
     @property
-    def native_value(self) -> float:  # type: ignore[override]
+    def native_value(self) -> float:
         """Return accumulated energy in Wh."""
         return round(self._total_wh, 3)

--- a/tools/sync_to_core/config.py
+++ b/tools/sync_to_core/config.py
@@ -117,7 +117,7 @@ MANIFEST_OVERRIDES: dict[str, object] = {
     # manifest omits this key (HACS doesn't surface it), but core
     # integrations declare it explicitly so hassfest can validate the
     # corresponding `quality_scale.yaml` rules.
-    "quality_scale": "gold",
+    "quality_scale": "platinum",
 }
 
 # JSON key paths to delete from `strings.json` and `translations/en.json`.


### PR DESCRIPTION
## 📋 Summary

Removes a stale `# type: ignore[override]` suppression from the energy meter sensor's `native_value` property and bumps the synced manifest's `quality_scale` tier from `gold` to `platinum`.

## 🔍 What changed

- 🩹 **`custom_components/neopool/sensor.py`** — drop `# type: ignore[override]` on `EnergyMeterSensor.native_value`. The narrowed `float` return type is covariant with the parent's `StateType | date | datetime | Decimal`, so under modern strict type checking the suppression is dead code (`mypy --strict` flags it as `unused-ignore`).
- 🔧 **`tools/sync_to_core/config.py`** — bump `MANIFEST_OVERRIDES["quality_scale"]` from `"gold"` to `"platinum"` so the synced `dist/neopool/.../manifest.json` declares the higher tier.

## ✅ Verification

- ✅ `ruff check` — clean
- ✅ `ruff format --check` — clean
- ✅ `basedpyright` — 0 errors, 0 warnings, 0 notes
- ✅ `pytest` — 258 passed, 8 snapshots passed, 1 unrelated warning
- ✅ `python -m tools.sync_to_core` — clean, dist now emits `"quality_scale": "platinum"`

## 🎯 Why platinum

The integration already meets every platinum-tier requirement of the [HA quality scale](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules):

- ✅ **`async-dependency`** — `neopool-modbus` is fully async
- ✅ **`inject-websession`** — `exempt`: Modbus TCP, no aiohttp involved
- ✅ **`strict-typing`** — `neopool-modbus` ships a `py.typed` marker, the integration uses a typed `NeoPoolConfigEntry = ConfigEntry[NeoPoolCoordinator]` for runtime data, and all platforms type their `entry` argument accordingly. The lone holdout was the unused `type: ignore` removed in this PR.