### PR TITLE
refactor(strings): ♻️ adopt shared common strings and trim services.yaml

### DIFF
--- a/custom_components/neopool/services.yaml
+++ b/custom_components/neopool/services.yaml
@@ -13,33 +13,24 @@
 # limitations under the License.
 
 set_timer:
-  name: Set Timer
-  description: >
-    Set timer parameters for Filtration and relays (AUX, Light).
-    You can set start and stop time (in HH:MM format), and for AUX/Light also repeat interval ("period" in seconds).
-    Internally, the system stores "start" and "interval" (duration) in the device.
   fields:
     entry_id:
       example: "your-entry-id"
       selector:
         text:
-      description: "Entry ID of the integration instance"
     timer:
       required: true
       example: "filtration1"
       selector:
         text:
-      description: "Timer name (e.g. relay_aux1, relay_aux2, relay_light, ...)"
     start:
       example: "08:00"
       selector:
         text:
-      description: "Start time (in HH:MM, e.g. 08:00)"
     stop:
       example: "10:00"
       selector:
         text:
-      description: "Stop time (in HH:MM, e.g. 10:00)"
     period:
       example: 86400
       selector:
@@ -47,7 +38,6 @@ set_timer:
           min: 1
           max: 604800
           step: 1
-      description: "Repeat interval in seconds for AUX/Light timers (e.g. 86400 = every day). Not used for filtration timers."
     enable:
       example: 1
       selector:
@@ -55,58 +45,40 @@ set_timer:
           min: 0
           max: 4
           step: 1
-      description: "Relay-mode integer (0=disabled, 1=auto, 2=auto_linked, 3=on, 4=off). Used by the relay_mode select platform."
 
 write_register:
-  name: Write Register
-  description: >
-    Write a value to a Modbus holding register using FC16 (Write Multiple Registers).
-    The write is verified by reading the register back. By default, the value is saved
-    to EEPROM and applied (set apply: false to skip).
   fields:
     entry_id:
       example: "your-entry-id"
       selector:
         text:
-      description: "Entry ID of the integration instance"
     address:
       required: true
       example: "0x0432"
       selector:
         text:
-      description: "Modbus register address (decimal or hex, e.g. 1074 or 0x0432)"
     value:
       required: true
       example: "2"
       selector:
         text:
-      description: "Value to write (0–65535, decimal or hex, e.g. 2 or 0x0002)"
     apply:
       example: true
       default: true
       selector:
         boolean:
-      description: "Save to EEPROM and execute after write (default: true)"
 
 read_register:
-  name: Read Register
-  description: >
-    Read one or more Modbus registers and return the raw u16 values. The
-    integration picks Read Input Registers (FC04) for any address on the
-    0x01 page (MEASURE) and Read Holding Registers (FC03) elsewhere; the
-    caller does not need to know which is which.
   fields:
     entry_id:
       example: "your-entry-id"
       selector:
         text:
-      description: "Entry ID of the integration instance"
     address:
       required: true
       example: "0x0102"
       selector:
         text:
-      description: "Modbus register address (decimal or hex, e.g. 258 or 0x0102)"
     count:
       example: 1
       default: 1
@@ -115,4 +87,3 @@ read_register:
           min: 1
           max: 31
           step: 1
-      description: "Number of consecutive registers to read (1-31; the device firmware refuses larger requests)"

--- a/custom_components/neopool/strings.json
+++ b/custom_components/neopool/strings.json
@@ -1,14 +1,14 @@
 {
   "config": {
     "abort": {
-      "already_configured": "This device is already configured.",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "entry_not_found": "The integration entry could not be found.",
       "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
       "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
-      "reconfigure_successful": "Connection settings updated successfully."
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
-      "cannot_connect": "Cannot connect to the specified address and port.",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "cannot_read_modbus": "Connected, but cannot read from the Modbus device. Check slave ID and framer settings.",
       "name_already_used": "This device name is already in use. Please choose a different name.",
       "serial_mismatch": "The device at this address has a different serial number than the one originally configured."
@@ -20,16 +20,16 @@
       },
       "reconfigure": {
         "data": {
-          "host": "Modbus gateway IP address",
-          "modbus_framer": "Protocol framing: 'tcp' = Modbus TCP (MBAP header, for gateways with conversion), 'rtu' = RTU over TCP (for transparent TCP gateways)",
-          "port": "TCP port for Modbus (default: 502).",
-          "slave_id": "Modbus device address (default: 1)."
+          "host": "[%key:common::config_flow::data::host%]",
+          "modbus_framer": "[%key:component::neopool::config::step::user::data::modbus_framer%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "slave_id": "[%key:component::neopool::config::step::user::data::slave_id%]"
         },
         "data_description": {
-          "host": "Enter the IP address of the Modbus TCP gateway connected to your pool controller.",
-          "modbus_framer": "Select 'tcp' for gateways that convert between TCP and RTU. Select 'rtu' for transparent gateways that forward raw RTU frames over TCP.",
-          "port": "Standard Modbus TCP port. Change only if your gateway uses a non-standard port.",
-          "slave_id": "The Modbus slave address of the pool controller. Most setups use 1."
+          "host": "[%key:component::neopool::config::step::user::data_description::host%]",
+          "modbus_framer": "[%key:component::neopool::config::step::user::data_description::modbus_framer%]",
+          "port": "[%key:component::neopool::config::step::user::data_description::port%]",
+          "slave_id": "[%key:component::neopool::config::step::user::data_description::slave_id%]"
         },
         "description": "Update the connection settings for your NeoPool controller.",
         "title": "Reconfigure NeoPool Connection"
@@ -37,13 +37,13 @@
       "user": {
         "data": {
           "filtration_pump_power": "Filtration pump power (W, 0 = disabled)",
-          "host": "Modbus gateway IP address",
-          "modbus_framer": "Protocol framing: 'tcp' = Modbus TCP (MBAP header, for gateways with conversion), 'rtu' = RTU over TCP (for transparent TCP gateways)",
-          "name": "Device name (used as entity ID prefix).",
+          "host": "[%key:common::config_flow::data::host%]",
+          "modbus_framer": "Modbus framer",
+          "name": "[%key:common::config_flow::data::name%]",
           "name_default": "Pool",
-          "port": "TCP port for Modbus (default: 502).",
+          "port": "[%key:common::config_flow::data::port%]",
           "scan_interval": "Data update interval (seconds)",
-          "slave_id": "Modbus device address (default: 1).",
+          "slave_id": "Slave ID",
           "use_cover_sensor": "Enable Pool Cover Sensor",
           "use_filtration1": "Enable 1st filtration timer for automatic mode",
           "use_filtration2": "Enable 2nd filtration timer for automatic mode",
@@ -55,13 +55,13 @@
           "host": "Enter the IP address of the Modbus TCP gateway connected to your pool controller.",
           "modbus_framer": "Select 'tcp' for gateways that convert between TCP and RTU. Select 'rtu' for transparent gateways that forward raw RTU frames over TCP.",
           "name": "Used as a prefix for all entity IDs. Spaces become underscores, e.g. 'Pool West' → sensor.pool_west_measure_ph.",
-          "port": "Standard Modbus TCP port. Change only if your gateway uses a non-standard port.",
+          "port": "Standard Modbus TCP port (default: 502). Change only if your gateway uses a non-standard port.",
           "scan_interval": "How often the integration reads data from the pool controller.",
           "slave_id": "The Modbus slave address of the pool controller. Most setups use 1.",
           "use_cover_sensor": "Creates a binary sensor indicating whether the pool cover is open or closed.",
           "use_filtration1": "Creates timer entities for configuring automatic filtration schedule.",
-          "use_filtration2": "Creates timer entities for configuring automatic filtration schedule.",
-          "use_filtration3": "Creates timer entities for configuring automatic filtration schedule.",
+          "use_filtration2": "[%key:component::neopool::config::step::user::data_description::use_filtration1%]",
+          "use_filtration3": "[%key:component::neopool::config::step::user::data_description::use_filtration1%]",
           "use_light": "Creates entities to control and monitor the pool light relay."
         },
         "description": "Configure the connection to your NeoPool controller.",
@@ -533,7 +533,7 @@
         "data": {
           "dev_overrides": "Developer overrides (JSON object of \"key\":value)",
           "dev_overrides_enabled": "Enable developer overrides",
-          "enable_backwash_option": "Enable ‘Backwash’ mode"
+          "enable_backwash_option": "[%key:component::neopool::options::step::init::data::enable_backwash_option%]"
         },
         "data_description": {
           "dev_overrides": "A JSON object where each key is a Modbus register name and each value overrides the actual reading.",
@@ -546,37 +546,37 @@
       "init": {
         "data": {
           "enable_backwash_option": "Enable 'Backwash' mode",
-          "filtration_pump_power": "Filtration pump power (W, 0 = disabled)",
+          "filtration_pump_power": "[%key:component::neopool::config::step::user::data::filtration_pump_power%]",
           "measure_when_filtration_off": "Measure values even when filtration is off",
-          "scan_interval": "Data update interval (seconds)",
+          "scan_interval": "[%key:component::neopool::config::step::user::data::scan_interval%]",
           "timer_resolution": "Timer adjustment step (minutes)",
           "unlock_advanced": "Unlock advanced options",
           "use_aux1": "Enable Aux1 Relay",
           "use_aux2": "Enable Aux2 Relay",
           "use_aux3": "Enable Aux3 Relay",
           "use_aux4": "Enable Aux4 Relay",
-          "use_cover_sensor": "Enable Pool Cover Sensor",
-          "use_filtration1": "Enable 1st filtration timer for automatic mode",
-          "use_filtration2": "Enable 2nd filtration timer for automatic mode",
-          "use_filtration3": "Enable 3rd filtration timer for automatic mode",
-          "use_light": "Enable Light Relay"
+          "use_cover_sensor": "[%key:component::neopool::config::step::user::data::use_cover_sensor%]",
+          "use_filtration1": "[%key:component::neopool::config::step::user::data::use_filtration1%]",
+          "use_filtration2": "[%key:component::neopool::config::step::user::data::use_filtration2%]",
+          "use_filtration3": "[%key:component::neopool::config::step::user::data::use_filtration3%]",
+          "use_light": "[%key:component::neopool::config::step::user::data::use_light%]"
         },
         "data_description": {
           "enable_backwash_option": "Adds 'Backwash' to the filtration mode select. Only for systems with manual multi-way valves.",
-          "filtration_pump_power": "Set the rated wattage of the filtration pump. When non-zero, two sensors are created: instantaneous power (W) and cumulative energy (Wh), both usable in the Energy dashboard.",
+          "filtration_pump_power": "[%key:component::neopool::config::step::user::data_description::filtration_pump_power%]",
           "measure_when_filtration_off": "When disabled, chemical measurements (pH, ORP, etc.) are only taken while the filtration pump is running.",
           "scan_interval": "Lower values increase responsiveness but generate more Modbus traffic.",
           "timer_resolution": "Determines the granularity of time selections in timer entities.",
           "unlock_advanced": "Enter the unlock code to access advanced settings (format: device_prefix + current year).",
           "use_aux1": "Creates switch and timer entities for this auxiliary relay output.",
-          "use_aux2": "Creates switch and timer entities for this auxiliary relay output.",
-          "use_aux3": "Creates switch and timer entities for this auxiliary relay output.",
-          "use_aux4": "Creates switch and timer entities for this auxiliary relay output.",
+          "use_aux2": "[%key:component::neopool::options::step::init::data_description::use_aux1%]",
+          "use_aux3": "[%key:component::neopool::options::step::init::data_description::use_aux1%]",
+          "use_aux4": "[%key:component::neopool::options::step::init::data_description::use_aux1%]",
           "use_cover_sensor": "Creates a binary sensor and enables cover-related entities (hydrolysis cover reduction, shutdown temperature).",
-          "use_filtration1": "Creates timer entities for configuring automatic filtration schedule.",
-          "use_filtration2": "Creates timer entities for configuring automatic filtration schedule.",
-          "use_filtration3": "Creates timer entities for configuring automatic filtration schedule.",
-          "use_light": "Creates entities to control and monitor the pool light relay."
+          "use_filtration1": "[%key:component::neopool::config::step::user::data_description::use_filtration1%]",
+          "use_filtration2": "[%key:component::neopool::config::step::user::data_description::use_filtration1%]",
+          "use_filtration3": "[%key:component::neopool::config::step::user::data_description::use_filtration1%]",
+          "use_light": "[%key:component::neopool::config::step::user::data_description::use_light%]"
         },
         "description": "WARNING: Changing enabled relays will automatically reload the integration! Changes take effect immediately.",
         "title": "NeoPool Settings"

--- a/custom_components/neopool/translations/cs.json
+++ b/custom_components/neopool/translations/cs.json
@@ -1,14 +1,14 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Toto zařízení je již nakonfigurováno.",
+            "already_configured": "Zařízení je již nakonfigurováno",
             "entry_not_found": "Záznam integrace nebyl nalezen.",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
-            "reconfigure_successful": "Connection settings updated successfully."
+            "reconfigure_successful": "Změna konfigurace byla úspěšná"
         },
         "error": {
-            "cannot_connect": "Nelze se připojit k zadané IP adrese a portu.",
+            "cannot_connect": "Nepodařilo se připojit",
             "cannot_read_modbus": "Připojeno, ale nelze číst z Modbus zařízení. Zkontrolujte slave ID a nastavení rámce.",
             "name_already_used": "Tento název zařízení je již použit. Zvolte prosím jiný název.",
             "serial_mismatch": "Zařízení na této adrese má jiné sériové číslo než původně nakonfigurované."
@@ -20,15 +20,15 @@
             },
             "reconfigure": {
                 "data": {
-                    "host": "IP adresa Modbus brány",
-                    "modbus_framer": "Rámování protokolu: 'tcp' = Modbus TCP (MBAP header, pro TCP brány s konverzí), 'rtu' = RTU přes TCP (pro transparentní TCP brány)",
-                    "port": "TCP port pro Modbus (výchozí: 502).",
-                    "slave_id": "Modbus Adresa zařízení (výchozí: 1)."
+                    "host": "Hostitel",
+                    "modbus_framer": "Modbus rámec",
+                    "port": "Port",
+                    "slave_id": "Slave ID"
                 },
                 "data_description": {
                     "host": "Zadejte IP adresu Modbus TCP brány připojené k vašemu řadiči bazénu.",
                     "modbus_framer": "Vyberte 'tcp' pro brány, které převádějí mezi TCP a RTU. Vyberte 'rtu' pro transparentní brány, které přeposílají surové RTU rámce přes TCP.",
-                    "port": "Standardní port Modbus TCP. Změňte pouze pokud vaše brána používá nestandardní port.",
+                    "port": "Standardní port Modbus TCP. Změňte pouze pokud vaše brána používá nestandardní port (výchozí: 502).",
                     "slave_id": "Modbus slave adresa řadiče bazénu. Většina zařízení používá 1."
                 },
                 "description": "Aktualizujte nastavení připojení k vašemu řadiči NeoPool.",
@@ -37,13 +37,13 @@
             "user": {
                 "data": {
                     "filtration_pump_power": "Příkon filtračního čerpadla (W, 0 = zakázáno)",
-                    "host": "IP adresa Modbus brány",
-                    "modbus_framer": "Rámování protokolu: 'tcp' = Modbus TCP (MBAP header, pro TCP brány s konverzí), 'rtu' = RTU přes TCP (pro transparentní TCP brány)",
-                    "name": "Název zařízení (používá se jako prefix v ID entit).",
+                    "host": "Hostitel",
+                    "modbus_framer": "Modbus rámec",
+                    "name": "Název",
                     "name_default": "Bazén",
-                    "port": "TCP port pro Modbus (výchozí: 502).",
+                    "port": "Port",
                     "scan_interval": "Interval aktualizace dat (v sekundách)",
-                    "slave_id": "Modbus Adresa zařízení (výchozí: 1).",
+                    "slave_id": "Slave ID",
                     "use_cover_sensor": "Povolit senzor zakrytí bazénu",
                     "use_filtration1": "Povolit 1. časovač filtrace pro automatický režim",
                     "use_filtration2": "Povolit 2. časovač filtrace pro automatický režim",
@@ -55,7 +55,7 @@
                     "host": "Zadejte IP adresu Modbus TCP brány připojené k vašemu řadiči bazénu.",
                     "modbus_framer": "Vyberte 'tcp' pro brány, které převádějí mezi TCP a RTU. Vyberte 'rtu' pro transparentní brány, které přeposílají surové RTU rámce přes TCP.",
                     "name": "Používá se jako prefix pro všechna ID entit. Mezery se nahradí podtržítky, např. 'Bazén Západ' → sensor.bazen_zapad_measure_ph.",
-                    "port": "Standardní port Modbus TCP. Změňte pouze pokud vaše brána používá nestandardní port.",
+                    "port": "Standardní port Modbus TCP. Změňte pouze pokud vaše brána používá nestandardní port (výchozí: 502).",
                     "scan_interval": "Jak často integrace čte data z řadiče bazénu.",
                     "slave_id": "Modbus slave adresa řadiče bazénu. Většina zařízení používá 1.",
                     "use_cover_sensor": "Vytvoří binární senzor indikující, zda je bazén zakrytý nebo odkrytý.",

--- a/custom_components/neopool/translations/de.json
+++ b/custom_components/neopool/translations/de.json
@@ -1,14 +1,14 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Dieses Gerät ist bereits konfiguriert.",
+            "already_configured": "Gerät ist bereits konfiguriert",
             "entry_not_found": "Der Integrationseintrag wurde nicht gefunden.",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
-            "reconfigure_successful": "Connection settings updated successfully."
+            "reconfigure_successful": "Neukonfiguration war erfolgreich"
         },
         "error": {
-            "cannot_connect": "Verbindung zur angegebenen Adresse und Port nicht möglich.",
+            "cannot_connect": "Verbindung fehlgeschlagen",
             "cannot_read_modbus": "Verbunden, aber Modbus-Gerät kann nicht gelesen werden. Überprüfen Sie Slave-ID und Framer-Einstellungen.",
             "name_already_used": "Dieser Gerätename wird bereits verwendet. Bitte wählen Sie einen anderen Namen.",
             "serial_mismatch": "Das Gerät an dieser Adresse hat eine andere Seriennummer als das ursprünglich konfigurierte."
@@ -20,15 +20,15 @@
             },
             "reconfigure": {
                 "data": {
-                    "host": "IP-Adresse des Modbus-Gateways",
-                    "modbus_framer": "Protokoll-Framing: 'tcp' = Modbus TCP (MBAP-Header, für Gateways mit Konvertierung), 'rtu' = RTU über TCP (für transparente TCP-Gateways)",
-                    "port": "TCP-Port für Modbus (Standard: 502).",
-                    "slave_id": "Modbus-Geräteadresse (Standard: 1)."
+                    "host": "Host",
+                    "modbus_framer": "Modbus-Framer",
+                    "port": "Port",
+                    "slave_id": "Slave-ID"
                 },
                 "data_description": {
                     "host": "Geben Sie die IP-Adresse des Modbus-TCP-Gateways ein, das mit Ihrem Pool-Controller verbunden ist.",
                     "modbus_framer": "Wählen Sie 'tcp' für Gateways, die zwischen TCP und RTU konvertieren. Wählen Sie 'rtu' für transparente Gateways, die rohe RTU-Frames über TCP weiterleiten.",
-                    "port": "Standard-Modbus-TCP-Port. Ändern Sie ihn nur, wenn Ihr Gateway einen nicht standardmäßigen Port verwendet.",
+                    "port": "Standard-Modbus-TCP-Port. Ändern Sie ihn nur, wenn Ihr Gateway einen nicht standardmäßigen Port verwendet (Standard: 502).",
                     "slave_id": "Die Modbus-Slave-Adresse des Pool-Controllers. Die meisten Setups verwenden 1."
                 },
                 "description": "Aktualisieren Sie die Verbindungseinstellungen Ihres NeoPool-Controllers.",
@@ -37,13 +37,13 @@
             "user": {
                 "data": {
                     "filtration_pump_power": "Leistung der Filtrationspumpe (W, 0 = deaktiviert)",
-                    "host": "IP-Adresse des Modbus-Gateways",
-                    "modbus_framer": "Protokoll-Framing: 'tcp' = Modbus TCP (MBAP-Header, für Gateways mit Konvertierung), 'rtu' = RTU über TCP (für transparente TCP-Gateways)",
-                    "name": "Gerätename (als Präfix für Entitäten-IDs verwendet).",
+                    "host": "Host",
+                    "modbus_framer": "Modbus-Framer",
+                    "name": "Name",
                     "name_default": "Pool",
-                    "port": "TCP-Port für Modbus (Standard: 502).",
+                    "port": "Port",
                     "scan_interval": "Datenaktualisierungsintervall (Sekunden)",
-                    "slave_id": "Modbus-Geräteadresse (Standard: 1).",
+                    "slave_id": "Slave-ID",
                     "use_cover_sensor": "Abdeckungssensor aktivieren",
                     "use_filtration1": "1. Filter-Timer für Automatikbetrieb aktivieren",
                     "use_filtration2": "2. Filter-Timer für Automatikbetrieb aktivieren",
@@ -55,7 +55,7 @@
                     "host": "Geben Sie die IP-Adresse des Modbus-TCP-Gateways ein, das mit Ihrem Pool-Controller verbunden ist.",
                     "modbus_framer": "Wählen Sie 'tcp' für Gateways, die zwischen TCP und RTU konvertieren. Wählen Sie 'rtu' für transparente Gateways, die rohe RTU-Frames über TCP weiterleiten.",
                     "name": "Wird als Präfix für alle Entitäten-IDs verwendet. Leerzeichen werden zu Unterstrichen, z.B. 'Pool West' → sensor.pool_west_measure_ph.",
-                    "port": "Standard-Modbus-TCP-Port. Ändern Sie ihn nur, wenn Ihr Gateway einen nicht standardmäßigen Port verwendet.",
+                    "port": "Standard-Modbus-TCP-Port. Ändern Sie ihn nur, wenn Ihr Gateway einen nicht standardmäßigen Port verwendet (Standard: 502).",
                     "scan_interval": "Wie oft die Integration Daten vom Pool-Controller liest.",
                     "slave_id": "Die Modbus-Slave-Adresse des Pool-Controllers. Die meisten Setups verwenden 1.",
                     "use_cover_sensor": "Erstellt einen Binärsensor, der anzeigt, ob die Poolabdeckung geöffnet oder geschlossen ist.",

--- a/custom_components/neopool/translations/en.json
+++ b/custom_components/neopool/translations/en.json
@@ -1,14 +1,14 @@
 {
     "config": {
         "abort": {
-            "already_configured": "This device is already configured.",
+            "already_configured": "Device is already configured",
             "entry_not_found": "The integration entry could not be found.",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
-            "reconfigure_successful": "Connection settings updated successfully."
+            "reconfigure_successful": "Reconfiguration was successful"
         },
         "error": {
-            "cannot_connect": "Cannot connect to the specified address and port.",
+            "cannot_connect": "Failed to connect",
             "cannot_read_modbus": "Connected, but cannot read from the Modbus device. Check slave ID and framer settings.",
             "name_already_used": "This device name is already in use. Please choose a different name.",
             "serial_mismatch": "The device at this address has a different serial number than the one originally configured."
@@ -20,15 +20,15 @@
             },
             "reconfigure": {
                 "data": {
-                    "host": "Modbus gateway IP address",
-                    "modbus_framer": "Protocol framing: 'tcp' = Modbus TCP (MBAP header, for gateways with conversion), 'rtu' = RTU over TCP (for transparent TCP gateways)",
-                    "port": "TCP port for Modbus (default: 502).",
-                    "slave_id": "Modbus device address (default: 1)."
+                    "host": "Host",
+                    "modbus_framer": "Modbus framer",
+                    "port": "Port",
+                    "slave_id": "Slave ID"
                 },
                 "data_description": {
                     "host": "Enter the IP address of the Modbus TCP gateway connected to your pool controller.",
                     "modbus_framer": "Select 'tcp' for gateways that convert between TCP and RTU. Select 'rtu' for transparent gateways that forward raw RTU frames over TCP.",
-                    "port": "Standard Modbus TCP port. Change only if your gateway uses a non-standard port.",
+                    "port": "Standard Modbus TCP port (default: 502). Change only if your gateway uses a non-standard port.",
                     "slave_id": "The Modbus slave address of the pool controller. Most setups use 1."
                 },
                 "description": "Update the connection settings for your NeoPool controller.",
@@ -37,13 +37,13 @@
             "user": {
                 "data": {
                     "filtration_pump_power": "Filtration pump power (W, 0 = disabled)",
-                    "host": "Modbus gateway IP address",
-                    "modbus_framer": "Protocol framing: 'tcp' = Modbus TCP (MBAP header, for gateways with conversion), 'rtu' = RTU over TCP (for transparent TCP gateways)",
-                    "name": "Device name (used as entity ID prefix).",
+                    "host": "Host",
+                    "modbus_framer": "Modbus framer",
+                    "name": "Name",
                     "name_default": "Pool",
-                    "port": "TCP port for Modbus (default: 502).",
+                    "port": "Port",
                     "scan_interval": "Data update interval (seconds)",
-                    "slave_id": "Modbus device address (default: 1).",
+                    "slave_id": "Slave ID",
                     "use_cover_sensor": "Enable Pool Cover Sensor",
                     "use_filtration1": "Enable 1st filtration timer for automatic mode",
                     "use_filtration2": "Enable 2nd filtration timer for automatic mode",
@@ -55,7 +55,7 @@
                     "host": "Enter the IP address of the Modbus TCP gateway connected to your pool controller.",
                     "modbus_framer": "Select 'tcp' for gateways that convert between TCP and RTU. Select 'rtu' for transparent gateways that forward raw RTU frames over TCP.",
                     "name": "Used as a prefix for all entity IDs. Spaces become underscores, e.g. 'Pool West' → sensor.pool_west_measure_ph.",
-                    "port": "Standard Modbus TCP port. Change only if your gateway uses a non-standard port.",
+                    "port": "Standard Modbus TCP port (default: 502). Change only if your gateway uses a non-standard port.",
                     "scan_interval": "How often the integration reads data from the pool controller.",
                     "slave_id": "The Modbus slave address of the pool controller. Most setups use 1.",
                     "use_cover_sensor": "Creates a binary sensor indicating whether the pool cover is open or closed.",

--- a/custom_components/neopool/translations/es.json
+++ b/custom_components/neopool/translations/es.json
@@ -1,14 +1,14 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Este dispositivo ya está configurado.",
+            "already_configured": "El dispositivo ya está configurado",
             "entry_not_found": "No se encontró la entrada de integración.",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
-            "reconfigure_successful": "Connection settings updated successfully."
+            "reconfigure_successful": "La reconfiguración se realizó correctamente"
         },
         "error": {
-            "cannot_connect": "No se puede conectar a la dirección y puerto especificados.",
+            "cannot_connect": "Error al conectar",
             "cannot_read_modbus": "Conectado, pero no se puede leer del dispositivo Modbus. Verifique el ID de esclavo y la configuración del marco.",
             "name_already_used": "Este nombre de dispositivo ya está en uso. Por favor, elija un nombre diferente.",
             "serial_mismatch": "El dispositivo en esta dirección tiene un número de serie diferente al configurado originalmente."
@@ -20,15 +20,15 @@
             },
             "reconfigure": {
                 "data": {
-                    "host": "Dirección IP de la puerta de enlace Modbus",
-                    "modbus_framer": "Encuadre de protocolo: 'tcp' = Modbus TCP (cabecera MBAP, para pasarelas con conversión), 'rtu' = RTU sobre TCP (para pasarelas TCP transparentes)",
-                    "port": "Puerto TCP para Modbus (por defecto: 502).",
-                    "slave_id": "Dirección de dispositivo Modbus (por defecto: 1)."
+                    "host": "Host",
+                    "modbus_framer": "Framer Modbus",
+                    "port": "Puerto",
+                    "slave_id": "Slave ID"
                 },
                 "data_description": {
                     "host": "Introduzca la dirección IP de la pasarela Modbus TCP conectada a su controlador de piscina.",
                     "modbus_framer": "Seleccione 'tcp' para pasarelas que convierten entre TCP y RTU. Seleccione 'rtu' para pasarelas transparentes que reenvían tramas RTU sin procesar por TCP.",
-                    "port": "Puerto estándar de Modbus TCP. Cámbielo solo si su pasarela usa un puerto no estándar.",
+                    "port": "Puerto estándar de Modbus TCP. Cámbielo solo si su pasarela usa un puerto no estándar (por defecto: 502).",
                     "slave_id": "La dirección Modbus esclava del controlador de piscina. La mayoría de las configuraciones usan 1."
                 },
                 "description": "Actualiza la configuración de conexión a tu controlador NeoPool.",
@@ -37,13 +37,13 @@
             "user": {
                 "data": {
                     "filtration_pump_power": "Potencia de la bomba de filtración (W, 0 = desactivado)",
-                    "host": "Dirección IP de la puerta de enlace Modbus",
-                    "modbus_framer": "Encuadre de protocolo: 'tcp' = Modbus TCP (cabecera MBAP, para pasarelas con conversión), 'rtu' = RTU sobre TCP (para pasarelas TCP transparentes)",
-                    "name": "Nombre del dispositivo (prefijo en IDs de entidad).",
+                    "host": "Host",
+                    "modbus_framer": "Framer Modbus",
+                    "name": "Nombre",
                     "name_default": "Piscina",
-                    "port": "Puerto TCP para Modbus (por defecto: 502).",
+                    "port": "Puerto",
                     "scan_interval": "Intervalo de actualización de datos (segundos)",
-                    "slave_id": "Dirección de dispositivo Modbus (por defecto: 1).",
+                    "slave_id": "Slave ID",
                     "use_cover_sensor": "Activar sensor de cubierta de piscina",
                     "use_filtration1": "Activar el 1º temporizador de filtración para modo automático",
                     "use_filtration2": "Activar el 2º temporizador de filtración para modo automático",
@@ -55,7 +55,7 @@
                     "host": "Introduzca la dirección IP de la pasarela Modbus TCP conectada a su controlador de piscina.",
                     "modbus_framer": "Seleccione 'tcp' para pasarelas que convierten entre TCP y RTU. Seleccione 'rtu' para pasarelas transparentes que reenvían tramas RTU sin procesar por TCP.",
                     "name": "Se usa como prefijo para todos los IDs de entidades. Los espacios se convierten en guiones bajos, p.ej. 'Piscina Oeste' → sensor.piscina_oeste_measure_ph.",
-                    "port": "Puerto estándar de Modbus TCP. Cámbielo solo si su pasarela usa un puerto no estándar.",
+                    "port": "Puerto estándar de Modbus TCP. Cámbielo solo si su pasarela usa un puerto no estándar (por defecto: 502).",
                     "scan_interval": "Con qué frecuencia la integración lee datos del controlador de piscina.",
                     "slave_id": "La dirección Modbus esclava del controlador de piscina. La mayoría de las configuraciones usan 1.",
                     "use_cover_sensor": "Crea un sensor binario que indica si la cubierta de la piscina está abierta o cerrada.",

--- a/custom_components/neopool/translations/fr.json
+++ b/custom_components/neopool/translations/fr.json
@@ -1,14 +1,14 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Cet appareil est déjà configuré.",
+            "already_configured": "L'appareil est déjà configuré",
             "entry_not_found": "L'entrée d'intégration est introuvable.",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
-            "reconfigure_successful": "Connection settings updated successfully."
+            "reconfigure_successful": "La reconfiguration a réussi"
         },
         "error": {
-            "cannot_connect": "Impossible de se connecter à l'adresse et au port spécifiés.",
+            "cannot_connect": "Échec de la connexion",
             "cannot_read_modbus": "Connecté, mais impossible de lire le périphérique Modbus. Vérifiez l'ID esclave et les paramètres du cadre.",
             "name_already_used": "Ce nom d'appareil est déjà utilisé. Veuillez choisir un nom différent.",
             "serial_mismatch": "L'appareil à cette adresse a un numéro de série différent de celui configuré à l'origine."
@@ -20,15 +20,15 @@
             },
             "reconfigure": {
                 "data": {
-                    "host": "Adresse IP de la passerelle Modbus",
-                    "modbus_framer": "Tramage du protocole : 'tcp' = Modbus TCP (en-tête MBAP, pour les passerelles avec conversion), 'rtu' = RTU sur TCP (pour les passerelles TCP transparentes)",
-                    "port": "Port TCP pour Modbus (défaut : 502).",
-                    "slave_id": "Adresse de l’appareil Modbus (défaut : 1)."
+                    "host": "Hôte",
+                    "modbus_framer": "Framer Modbus",
+                    "port": "Port",
+                    "slave_id": "Slave ID"
                 },
                 "data_description": {
                     "host": "Entrez l'adresse IP de la passerelle Modbus TCP connectée à votre contrôleur de piscine.",
                     "modbus_framer": "Sélectionnez 'tcp' pour les passerelles qui convertissent entre TCP et RTU. Sélectionnez 'rtu' pour les passerelles transparentes qui transmettent les trames RTU brutes via TCP.",
-                    "port": "Port Modbus TCP standard. Ne le modifiez que si votre passerelle utilise un port non standard.",
+                    "port": "Port Modbus TCP standard. Ne le modifiez que si votre passerelle utilise un port non standard (par défaut : 502).",
                     "slave_id": "L'adresse Modbus esclave du contrôleur de piscine. La plupart des configurations utilisent 1."
                 },
                 "description": "Mettez à jour les paramètres de connexion à votre contrôleur NeoPool.",
@@ -37,13 +37,13 @@
             "user": {
                 "data": {
                     "filtration_pump_power": "Puissance de la pompe de filtration (W, 0 = désactivé)",
-                    "host": "Adresse IP de la passerelle Modbus",
-                    "modbus_framer": "Tramage du protocole : 'tcp' = Modbus TCP (en-tête MBAP, pour les passerelles avec conversion), 'rtu' = RTU sur TCP (pour les passerelles TCP transparentes)",
-                    "name": "Nom de l'appareil (utilisé comme préfixe d’ID d’entité).",
+                    "host": "Hôte",
+                    "modbus_framer": "Framer Modbus",
+                    "name": "Nom",
                     "name_default": "Piscine",
-                    "port": "Port TCP pour Modbus (défaut : 502).",
+                    "port": "Port",
                     "scan_interval": "Intervalle de mise à jour des données (secondes)",
-                    "slave_id": "Adresse de l’appareil Modbus (défaut : 1).",
+                    "slave_id": "Slave ID",
                     "use_cover_sensor": "Activer le capteur de couverture de piscine",
                     "use_filtration1": "Activer le 1er minuteur de filtration pour le mode automatique",
                     "use_filtration2": "Activer le 2ème minuteur de filtration pour le mode automatique",
@@ -55,7 +55,7 @@
                     "host": "Entrez l'adresse IP de la passerelle Modbus TCP connectée à votre contrôleur de piscine.",
                     "modbus_framer": "Sélectionnez 'tcp' pour les passerelles qui convertissent entre TCP et RTU. Sélectionnez 'rtu' pour les passerelles transparentes qui transmettent les trames RTU brutes via TCP.",
                     "name": "Utilisé comme préfixe pour tous les IDs d'entités. Les espaces deviennent des tirets bas, ex. 'Piscine Ouest' → sensor.piscine_ouest_measure_ph.",
-                    "port": "Port Modbus TCP standard. Ne le modifiez que si votre passerelle utilise un port non standard.",
+                    "port": "Port Modbus TCP standard. Ne le modifiez que si votre passerelle utilise un port non standard (par défaut : 502).",
                     "scan_interval": "À quelle fréquence l'intégration lit les données du contrôleur de piscine.",
                     "slave_id": "L'adresse Modbus esclave du contrôleur de piscine. La plupart des configurations utilisent 1.",
                     "use_cover_sensor": "Crée un capteur binaire indiquant si la couverture de la piscine est ouverte ou fermée.",

--- a/custom_components/neopool/translations/it.json
+++ b/custom_components/neopool/translations/it.json
@@ -1,14 +1,14 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Questo dispositivo è già configurato.",
+            "already_configured": "Il dispositivo è già configurato",
             "entry_not_found": "Voce di integrazione non trovata.",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
-            "reconfigure_successful": "Connection settings updated successfully."
+            "reconfigure_successful": "La riconfigurazione è andata a buon fine"
         },
         "error": {
-            "cannot_connect": "Impossibile connettersi all'indirizzo e alla porta specificati.",
+            "cannot_connect": "Impossibile connettersi",
             "cannot_read_modbus": "Connesso, ma impossibile leggere dal dispositivo Modbus. Verificare l'ID slave e le impostazioni del frame.",
             "name_already_used": "Questo nome dispositivo è già in uso. Scegliere un nome diverso.",
             "serial_mismatch": "Il dispositivo a questo indirizzo ha un numero di serie diverso da quello configurato in origine."
@@ -20,15 +20,15 @@
             },
             "reconfigure": {
                 "data": {
-                    "host": "Indirizzo IP gateway Modbus",
-                    "modbus_framer": "Framing del protocollo: 'tcp' = Modbus TCP (intestazione MBAP, per gateway con conversione), 'rtu' = RTU su TCP (per gateway TCP trasparenti)",
-                    "port": "Porta TCP per Modbus (predefinito: 502).",
-                    "slave_id": "Indirizzo dispositivo Modbus (predefinito: 1)."
+                    "host": "Host",
+                    "modbus_framer": "Framer Modbus",
+                    "port": "Porta",
+                    "slave_id": "Slave ID"
                 },
                 "data_description": {
                     "host": "Inserire l'indirizzo IP del gateway Modbus TCP collegato al controller della piscina.",
                     "modbus_framer": "Selezionare 'tcp' per gateway che convertono tra TCP e RTU. Selezionare 'rtu' per gateway trasparenti che inoltrano frame RTU grezzi su TCP.",
-                    "port": "Porta Modbus TCP standard. Modificare solo se il gateway utilizza una porta non standard.",
+                    "port": "Porta Modbus TCP standard. Modificare solo se il gateway utilizza una porta non standard (predefinito: 502).",
                     "slave_id": "L'indirizzo Modbus slave del controller della piscina. La maggior parte delle configurazioni usa 1."
                 },
                 "description": "Aggiorna le impostazioni di connessione al tuo controller NeoPool.",
@@ -37,13 +37,13 @@
             "user": {
                 "data": {
                     "filtration_pump_power": "Potenza della pompa di filtrazione (W, 0 = disabilitato)",
-                    "host": "Indirizzo IP gateway Modbus",
-                    "modbus_framer": "Framing del protocollo: 'tcp' = Modbus TCP (intestazione MBAP, per gateway con conversione), 'rtu' = RTU su TCP (per gateway TCP trasparenti)",
-                    "name": "Nome del dispositivo (usato come prefisso ID entità).",
+                    "host": "Host",
+                    "modbus_framer": "Framer Modbus",
+                    "name": "Nome",
                     "name_default": "Piscina",
-                    "port": "Porta TCP per Modbus (predefinito: 502).",
+                    "port": "Porta",
                     "scan_interval": "Intervallo aggiornamento dati (secondi)",
-                    "slave_id": "Indirizzo dispositivo Modbus (predefinito: 1).",
+                    "slave_id": "Slave ID",
                     "use_cover_sensor": "Abilita sensore copertura piscina",
                     "use_filtration1": "Abilita il 1° timer di filtrazione per la modalità automatica",
                     "use_filtration2": "Abilita il 2° timer di filtrazione per la modalità automatica",
@@ -55,7 +55,7 @@
                     "host": "Inserire l'indirizzo IP del gateway Modbus TCP collegato al controller della piscina.",
                     "modbus_framer": "Selezionare 'tcp' per gateway che convertono tra TCP e RTU. Selezionare 'rtu' per gateway trasparenti che inoltrano frame RTU grezzi su TCP.",
                     "name": "Usato come prefisso per tutti gli ID entità. Gli spazi diventano trattini bassi, es. 'Piscina Ovest' → sensor.piscina_ovest_measure_ph.",
-                    "port": "Porta Modbus TCP standard. Modificare solo se il gateway utilizza una porta non standard.",
+                    "port": "Porta Modbus TCP standard. Modificare solo se il gateway utilizza una porta non standard (predefinito: 502).",
                     "scan_interval": "Quanto spesso l'integrazione legge i dati dal controller della piscina.",
                     "slave_id": "L'indirizzo Modbus slave del controller della piscina. La maggior parte delle configurazioni usa 1.",
                     "use_cover_sensor": "Crea un sensore binario che indica se la copertura della piscina è aperta o chiusa.",

--- a/custom_components/neopool/translations/pl.json
+++ b/custom_components/neopool/translations/pl.json
@@ -1,14 +1,14 @@
 {
     "config": {
         "abort": {
-            "already_configured": "To urządzenie jest już skonfigurowane.",
+            "already_configured": "Urządzenie jest już skonfigurowane",
             "entry_not_found": "Nie znaleziono wpisu integracji.",
             "migration_complete": "Migration completed successfully. Your VistaPool integration was moved to the new NeoPool domain. Please **restart Home Assistant** to clean up the old integration loaded in memory.",
             "migration_failed": "Migration failed: {error}\n\nCheck the Home Assistant logs and report the issue on GitHub. The legacy VistaPool integration is unaffected and continues to work.",
-            "reconfigure_successful": "Connection settings updated successfully."
+            "reconfigure_successful": "Rekonfiguracja zakończona pomyślnie"
         },
         "error": {
-            "cannot_connect": "Nie można połączyć się z podanym adresem i portem.",
+            "cannot_connect": "Nie udało się połączyć",
             "cannot_read_modbus": "Połączono, ale nie można odczytać danych z urządzenia Modbus. Sprawdź ID slave i ustawienia ramki.",
             "name_already_used": "Ta nazwa urządzenia jest już używana. Proszę wybrać inną nazwę.",
             "serial_mismatch": "Urządzenie pod tym adresem ma inny numer seryjny niż pierwotnie skonfigurowane."
@@ -20,15 +20,15 @@
             },
             "reconfigure": {
                 "data": {
-                    "host": "Adres IP bramki Modbus",
-                    "modbus_framer": "Ramkowanie protokołu: 'tcp' = Modbus TCP (nagłówek MBAP, dla bramek z konwersją), 'rtu' = RTU przez TCP (dla transparentnych bramek TCP)",
-                    "port": "Port TCP dla Modbus (domyślnie: 502).",
-                    "slave_id": "Adres urządzenia Modbus (domyślnie: 1)."
+                    "host": "Host",
+                    "modbus_framer": "Framer Modbus",
+                    "port": "Port",
+                    "slave_id": "Slave ID"
                 },
                 "data_description": {
                     "host": "Wprowadź adres IP bramki Modbus TCP podłączonej do kontrolera basenu.",
                     "modbus_framer": "Wybierz 'tcp' dla bramek konwertujących między TCP a RTU. Wybierz 'rtu' dla transparentnych bramek przesyłających surowe ramki RTU przez TCP.",
-                    "port": "Standardowy port Modbus TCP. Zmień tylko jeśli bramka używa niestandardowego portu.",
+                    "port": "Standardowy port Modbus TCP. Zmień tylko jeśli bramka używa niestandardowego portu (domyślnie: 502).",
                     "slave_id": "Adres Modbus slave kontrolera basenu. Większość konfiguracji używa 1."
                 },
                 "description": "Zaktualizuj ustawienia połączenia z kontrolerem NeoPool.",
@@ -37,13 +37,13 @@
             "user": {
                 "data": {
                     "filtration_pump_power": "Moc pompy filtracyjnej (W, 0 = wyłączone)",
-                    "host": "Adres IP bramki Modbus",
-                    "modbus_framer": "Ramkowanie protokołu: 'tcp' = Modbus TCP (nagłówek MBAP, dla bramek z konwersją), 'rtu' = RTU przez TCP (dla transparentnych bramek TCP)",
-                    "name": "Nazwa urządzenia (używana jako prefiks ID encji).",
+                    "host": "Host",
+                    "modbus_framer": "Framer Modbus",
+                    "name": "Nazwa",
                     "name_default": "Basen",
-                    "port": "Port TCP dla Modbus (domyślnie: 502).",
+                    "port": "Port",
                     "scan_interval": "Interwał aktualizacji danych (sekundy)",
-                    "slave_id": "Adres urządzenia Modbus (domyślnie: 1).",
+                    "slave_id": "Slave ID",
                     "use_cover_sensor": "Włącz czujnik przykrycia basenu",
                     "use_filtration1": "Włącz 1. timer filtracji w trybie automatycznym",
                     "use_filtration2": "Włącz 2. timer filtracji w trybie automatycznym",
@@ -55,7 +55,7 @@
                     "host": "Wprowadź adres IP bramki Modbus TCP podłączonej do kontrolera basenu.",
                     "modbus_framer": "Wybierz 'tcp' dla bramek konwertujących między TCP a RTU. Wybierz 'rtu' dla transparentnych bramek przesyłających surowe ramki RTU przez TCP.",
                     "name": "Używana jako prefiks dla wszystkich ID encji. Spacje zamieniane są na podkreślenia, np. 'Basen Zachodni' → sensor.basen_zachodni_measure_ph.",
-                    "port": "Standardowy port Modbus TCP. Zmień tylko jeśli bramka używa niestandardowego portu.",
+                    "port": "Standardowy port Modbus TCP. Zmień tylko jeśli bramka używa niestandardowego portu (domyślnie: 502).",
                     "scan_interval": "Jak często integracja odczytuje dane z kontrolera basenu.",
                     "slave_id": "Adres Modbus slave kontrolera basenu. Większość konfiguracji używa 1.",
                     "use_cover_sensor": "Tworzy czujnik binarny wskazujący, czy przykrycie basenu jest otwarte czy zamknięte.",


### PR DESCRIPTION
## ♻️ Summary

Reduces duplication in `strings.json` and aligns config_flow texts with the conventions used by gold/platinum integrations (peblar, airgradient).

## 📝 What changes

### `strings.json`

- 🔗 Shared abort/error keys now reference HA's common strings:
  - `already_configured` → `Device is already configured`
  - `reconfigure_successful` → `Reconfiguration was successful`
  - `cannot_connect` → `Failed to connect`
- 🏷️ Short common labels for connection fields:
  - `Host`, `Port`, `Name` (no more vendor-specific labels)
  - Long vendor context stays in `data_description`
- 🔁 Inter-step duplicates collapsed via local references (`reconfigure` and `options.init` reuse `user` step strings instead of duplicating them)

### `services.yaml`

- 🧹 Dropped deprecated top-level `name:` and `description:` keys
- 🧹 Dropped per-field `description:` lines
- ✅ Same texts already live in `strings.json` under `services.*` — the UI is unaffected

### Translations

- 🌍 Aligned cs / de / es / fr / it / pl with the new short labels
- 🌍 Translated the previously untranslated `reconfigure_successful` into all six languages

## 🧪 Verified

- ✅ `pytest` — 287 passed, 8 snapshots
- ✅ `ruff check` + `ruff format --check` — clean
- ✅ Service handlers untouched — service tests green

## 🔍 Why open this PR

Test that the UI still loads correctly in HACS with the shorter labels and that no entity/option screens regress before publishing more upstream PRs based on the same source.