### PR TITLE
fix: 🐛 import platform constants from public API

### DIFF
--- a/custom_components/neopool/light.py
+++ b/custom_components/neopool/light.py
@@ -19,8 +19,7 @@ from typing import Any
 
 from neopool_modbus.registers import EXEC_REGISTER, is_valid_relay_gpio
 
-from homeassistant.components.light import LightEntity
-from homeassistant.components.light.const import ColorMode
+from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -6,7 +6,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.neopool.const import DOMAIN
-from homeassistant.components.button.const import SERVICE_PRESS
+from homeassistant.components.button import SERVICE_PRESS
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform as ep, entity_registry as er

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -10,7 +10,7 @@ from neopool_modbus.registers import (
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from homeassistant.components.number.const import ATTR_VALUE, SERVICE_SET_VALUE
+from homeassistant.components.number import ATTR_VALUE, SERVICE_SET_VALUE
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform as ep, entity_registry as er

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -6,8 +6,7 @@ from neopool_modbus.registers import MANUAL_FILTRATION_REGISTER
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from homeassistant.components.select.const import ATTR_OPTION, SERVICE_SELECT_OPTION
-from homeassistant.const import Platform
+from homeassistant.const import ATTR_OPTION, SERVICE_SELECT_OPTION, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform as ep, entity_registry as er
 


### PR DESCRIPTION
## 🐛 Summary

Switches every platform-constant import to the package public API instead of the private `.const` modules — matches the convention used by gold/platinum core integrations and avoids breakage when upstream cleans up duplicate constants.

## 📝 Why

Earlier today, [home-assistant/core#173743](https://github.com/home-assistant/core/pull/173743) removed the `ATTR_OPTION` / `SERVICE_SELECT_OPTION` duplicates from `homeassistant.components.select.const` (they were already long present in the global `homeassistant.const`). Tests that imported them from the private `.const` module now fail on the HA dev branch.

To stay future-proof, this PR aligns **all** remaining platform-constant imports with the public package API in one go, not just the one that just broke.

## 📋 Changes

| File | Before | After |
| --- | --- | --- |
| `tests/test_select.py` | `from …select.const import ATTR_OPTION, SERVICE_SELECT_OPTION` | `from homeassistant.const import ATTR_OPTION, SERVICE_SELECT_OPTION` |
| `tests/test_button.py` | `from …button.const import SERVICE_PRESS` | `from homeassistant.components.button import SERVICE_PRESS` |
| `tests/test_number.py` | `from …number.const import ATTR_VALUE, SERVICE_SET_VALUE` | `from homeassistant.components.number import ATTR_VALUE, SERVICE_SET_VALUE` |
| `custom_components/neopool/light.py` | `from …light.const import ColorMode` | merged into the existing `from homeassistant.components.light import LightEntity, ColorMode` |

## 🧪 Verified

- ✅ `pytest` — 287 passed, 8 snapshots
- ✅ `basedpyright` — 0 errors, 0 warnings, 0 notes
- ✅ `ruff check` + `ruff format --check` — clean
- ✅ No behaviour change; all symbols are re-exported from each package's `__init__.py`

## 🔗 Compatibility

`ATTR_OPTION` and `SERVICE_SELECT_OPTION` have been in `homeassistant.const` since HA 0.36 (December 2016), so the new import works on every supported HA release. The public package re-exports for the other platforms are equally old. There is no minimum-HA-version bump.