### PR TITLE
refactor: ♻️ delegate tier-2 logic to neopool-modbus library

### DIFF
--- a/.github/workflows/typecheck.yaml
+++ b/.github/workflows/typecheck.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install basedpyright homeassistant-stubs 'neopool-modbus>=3.1.3'
+          pip install basedpyright homeassistant-stubs 'neopool-modbus>=3.2.0'
 
       - name: Run BasedPyright
         run: basedpyright custom_components/neopool

--- a/custom_components/neopool/const.py
+++ b/custom_components/neopool/const.py
@@ -64,21 +64,6 @@ CURRENT_VERSION = 4
 # MBF_RELAY_STATE has 7 relays (bits 0-6); MBF_PAR_UV_RELAY_GPIO is a 1-based index.
 
 
-# GPIO registers that assign physical relay outputs.
-# Used for sanity-checking register values after the first Modbus read.
-GPIO_REGISTERS = {
-    "MBF_PAR_FILT_GPIO": "Filtration relay",
-    "MBF_PAR_LIGHTING_GPIO": "Lighting relay",
-    "MBF_PAR_HEATING_GPIO": "Heating relay",
-    "MBF_PAR_PH_ACID_RELAY_GPIO": "pH acid pump relay",
-    "MBF_PAR_PH_BASE_RELAY_GPIO": "pH base pump relay",
-    "MBF_PAR_RX_RELAY_GPIO": "Redox pump relay",
-    "MBF_PAR_CL_RELAY_GPIO": "Chlorine pump relay",
-    "MBF_PAR_CD_RELAY_GPIO": "Conductivity pump relay",
-    "MBF_PAR_UV_RELAY_GPIO": "UV lamp relay",
-    "MBF_PAR_FILTVALVE_GPIO": "Filter valve relay",
-}
-
 # Persisted in entry.options for winter-mode restarts.
 _CUSTOM_CAPABILITY_KEYS: tuple[str, ...] = (
     "MBF_PAR_HIDRO_NOM",

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -23,6 +23,7 @@ from neopool_modbus import NeoPoolModbusClient
 from neopool_modbus.decoders import aggregate_filtration_remaining, parse_version
 from neopool_modbus.exceptions import NeoPoolError
 from neopool_modbus.registers import (
+    GPIO_REGISTERS,
     HEATING_SETPOINT_REGISTER,
     INTELLIGENT_SETPOINT_REGISTER,
     MAX_RELAY_GPIO,
@@ -43,7 +44,6 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     FOLLOW_UP_REFRESH_DELAY,
-    GPIO_REGISTERS,
 )
 from .helpers import is_device_time_out_of_sync, prepare_device_time
 

--- a/custom_components/neopool/light.py
+++ b/custom_components/neopool/light.py
@@ -17,7 +17,7 @@
 import logging
 from typing import Any
 
-from neopool_modbus.registers import EXEC_REGISTER, is_valid_relay_gpio
+from neopool_modbus.registers import EXEC_REGISTER, TimerRelayMode, is_valid_relay_gpio
 
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.core import HomeAssistant
@@ -125,7 +125,9 @@ class NeoPoolLight(NeoPoolEntity, LightEntity):
             await client.async_write_register(
                 self.function_addr, self.function_code
             )  # Set function (if needed)
-            await client.async_write_register(self.timer_block_addr, 3)  # Always ON
+            await client.async_write_register(
+                self.timer_block_addr, TimerRelayMode.ALWAYS_ON
+            )
             await client.async_write_register(EXEC_REGISTER, 1)  # Commit
 
         # Optimistic update + schedule follow-up
@@ -153,7 +155,9 @@ class NeoPoolLight(NeoPoolEntity, LightEntity):
                 self._key,
                 self.timer_block_addr,
             )
-            await client.async_write_register(self.timer_block_addr, 4)  # Always OFF
+            await client.async_write_register(
+                self.timer_block_addr, TimerRelayMode.ALWAYS_OFF
+            )
             await client.async_write_register(EXEC_REGISTER, 1)  # Commit
 
         # Optimistic update + schedule follow-up
@@ -165,14 +169,16 @@ class NeoPoolLight(NeoPoolEntity, LightEntity):
         """Apply an optimistic state update to coordinator data."""
         data = self.coordinator.data
         if self._switch_type == "relay_timer":
-            data["relay_light_enable"] = 3 if state else 4
+            data["relay_light_enable"] = (
+                TimerRelayMode.ALWAYS_ON if state else TimerRelayMode.ALWAYS_OFF
+            )
 
     @property
     def is_on(self) -> bool:
         """Return True if the light is ON."""
         if self._switch_type == "relay_timer":
             enable_val = self.coordinator.data.get("relay_light_enable", None)
-            return enable_val == 3  # ON if ALWAYS ON
+            return enable_val == TimerRelayMode.ALWAYS_ON
         return False  # pragma: no cover
 
     @property
@@ -182,7 +188,7 @@ class NeoPoolLight(NeoPoolEntity, LightEntity):
             return False
         if self._switch_type == "relay_timer":
             mode_val = self.coordinator.data.get("relay_light_enable", None)
-            return mode_val in (0, 3, 4)
+            return mode_val in (0, TimerRelayMode.ALWAYS_ON, TimerRelayMode.ALWAYS_OFF)
         return True  # pragma: no cover
 
     @property

--- a/custom_components/neopool/manifest.json
+++ b/custom_components/neopool/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/svasek/homeassistant-neopool-modbus/issues",
   "loggers": ["neopool_modbus"],
-  "requirements": ["neopool-modbus>=3.1.3"],
+  "requirements": ["neopool-modbus>=3.2.0"],
   "version": "4.1.2"
 }

--- a/custom_components/neopool/sensor.py
+++ b/custom_components/neopool/sensor.py
@@ -20,7 +20,13 @@ import math
 from typing import Any
 
 from neopool_modbus.capabilities import has_filtvalve, is_ionization_present
-from neopool_modbus.decoders import get_filtration_pump_type, is_hydrolysis_in_percent
+from neopool_modbus.decoders import (
+    decode_hidro_polarity,
+    decode_ion_polarity,
+    decode_ph_pump_status,
+    get_filtration_pump_type,
+    is_hydrolysis_in_percent,
+)
 
 from homeassistant.components.sensor import (
     RestoreSensor,
@@ -240,82 +246,17 @@ class NeoPoolSensor(NeoPoolEntity, SensorEntity):
             return False
         return self.coordinator.data.get("Filtration Pump") is False
 
-    def _compute_ph_pump_status(self) -> str | None:
-        """Decode the pH pump status from the control + per-pump bits."""
-        ctrl = self.coordinator.data.get("pH control module")
-        acid_bit = self.coordinator.data.get("pH acid pump active")
-        pump_bit = self.coordinator.data.get("pH pump active")
-        if ctrl is None and acid_bit is None and pump_bit is None:
-            return None
-        if ctrl is None:
-            return None  # partial data — cannot determine status
-        if not ctrl:
-            return "off"
-        # MBF_PAR_RELAY_PH determines the pH pump configuration:
-        #   0 = acid + base (bit 11 = acid, bit 12 = base)
-        #   1 = acid only   (bit 12 = acid pump; bit 11 unused)
-        #   2 = base only   (bit 12 = base pump; bit 11 unused)
-        relay_ph = self.coordinator.data.get("MBF_PAR_RELAY_PH", 0) or 0
-        if relay_ph == 1:
-            return "acid" if pump_bit else "idle"
-        if relay_ph == 2:
-            return "base" if pump_bit else "idle"
-        # Both pumps (relay_ph == 0): bit 11 = acid, bit 12 = base
-        if acid_bit and pump_bit:
-            return "both"
-        if acid_bit:
-            return "acid"
-        if pump_bit:
-            return "base"
-        return "idle"
-
-    def _compute_hidro_polarity(self) -> str | None:
-        """Decode the hydrolysis polarity from the cell status bits."""
-        pol1 = self.coordinator.data.get("HIDRO in Pol1")
-        pol2 = self.coordinator.data.get("HIDRO in Pol2")
-        dead = self.coordinator.data.get("HIDRO in dead time")
-        if pol1 is None and pol2 is None and dead is None:
-            return None
-        filtration = self.coordinator.data.get("Filtration Pump")
-        if filtration is not None and filtration is False:
-            return "off"
-        fl1 = self.coordinator.data.get("HIDRO Cell Flow FL1")
-        if filtration is True and fl1 is False:
-            return "no_flow"
-        if dead:
-            return "dead_time"
-        if pol1:
-            return "pol1"
-        if pol2:
-            return "pol2"
-        return "off"
-
-    def _compute_ion_polarity(self) -> str | None:
-        """Decode the ionizer polarity from the cell status bits."""
-        pol1 = self.coordinator.data.get("ION in Pol1")
-        pol2 = self.coordinator.data.get("ION in Pol2")
-        dead = self.coordinator.data.get("ION in dead time")
-        if pol1 is None and pol2 is None and dead is None:
-            return None
-        if dead:
-            return "dead_time"
-        if pol1:
-            return "pol1"
-        if pol2:
-            return "pol2"
-        return "off"
-
     @property
     def native_value(self) -> float | int | str | datetime | None:
         """Return the actual sensor value from coordinator data."""
         if self._is_measurement_suppressed():
             return None
         if self._key == "PH_PUMP_STATUS":
-            return self._compute_ph_pump_status()
+            return decode_ph_pump_status(self.coordinator.data)
         if self._key == "HIDRO_POLARITY":
-            return self._compute_hidro_polarity()
+            return decode_hidro_polarity(self.coordinator.data)
         if self._key == "ION_POLARITY":
-            return self._compute_ion_polarity()
+            return decode_ion_polarity(self.coordinator.data)
         if self._key == "MBF_PAR_FILT_MODE":
             return self.coordinator.data.get("filtration_mode")
         if self._key == "FILTRATION_SPEED":

--- a/custom_components/neopool/switch.py
+++ b/custom_components/neopool/switch.py
@@ -21,6 +21,7 @@ from typing import Any
 from neopool_modbus.registers import (
     EXEC_REGISTER,
     MANUAL_FILTRATION_REGISTER,
+    TimerRelayMode,
     is_valid_relay_gpio,
 )
 
@@ -175,7 +176,9 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
             await client.async_write_register(
                 self.function_addr, self.function_code
             )  # Set function (if needed)
-            await client.async_write_register(self.timer_block_addr, 3)  # Always on
+            await client.async_write_register(
+                self.timer_block_addr, TimerRelayMode.ALWAYS_ON
+            )
             await client.async_write_register(EXEC_REGISTER, 1)  # Commit
         elif self._switch_type in ("climate_mode", "smart_anti_freeze", "uv_mode"):
             if self.function_addr is None:  # pragma: no cover
@@ -246,7 +249,9 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
                 self._key,
                 self.timer_block_addr,
             )
-            await client.async_write_register(self.timer_block_addr, 4)  # Always off
+            await client.async_write_register(
+                self.timer_block_addr, TimerRelayMode.ALWAYS_OFF
+            )
             await client.async_write_register(EXEC_REGISTER, 1)  # Commit
         elif self._switch_type in ("climate_mode", "smart_anti_freeze", "uv_mode"):
             if self.function_addr is None:  # pragma: no cover
@@ -301,7 +306,9 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
         elif self._switch_type == "aux":  # pragma: no cover
             data[self._key] = state
         elif self._switch_type == "relay_timer":
-            data[f"relay_{self._key}_enable"] = 3 if state else 4
+            data[f"relay_{self._key}_enable"] = (
+                TimerRelayMode.ALWAYS_ON if state else TimerRelayMode.ALWAYS_OFF
+            )
         elif self._switch_type == "climate_mode":
             data["MBF_PAR_CLIMA_ONOFF"] = 1 if state else 0
         elif self._switch_type == "smart_anti_freeze":
@@ -332,7 +339,7 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
             return bool(self.coordinator.data.get(self._key, 0))
         if self._switch_type == "relay_timer":
             enable_val = self.coordinator.data.get(f"relay_{self._key}_enable", None)
-            return enable_val == 3  # ON if ALWAYS ON
+            return enable_val == TimerRelayMode.ALWAYS_ON
         if self._switch_type == "climate_mode":
             return bool(self.coordinator.data.get("MBF_PAR_CLIMA_ONOFF", 0))
         if self._switch_type == "smart_anti_freeze":

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Runtime dependency (Modbus communication via NeoPool library)
-neopool-modbus>=3.1.3
+neopool-modbus>=3.2.0
 
 # Type stubs for Home Assistant Core
 homeassistant-stubs

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,6 +5,11 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
+from neopool_modbus.decoders import (
+    decode_hidro_polarity,
+    decode_ion_polarity,
+    decode_ph_pump_status,
+)
 import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
@@ -143,14 +148,8 @@ async def test_ph_pump_status_decoder(
     data: dict[str, Any],
     expected: str | None,
 ) -> None:
-    """Drive _compute_ph_pump_status through every relay_ph branch."""
-    await setup_integration(hass, mock_config_entry)
-    entity = _sensor_by_key(hass, "PH_PUMP_STATUS")
-    if entity is None:
-        pytest.skip("PH_PUMP_STATUS entity not registered on this fixture")
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data.update(data)
-    assert entity._compute_ph_pump_status() == expected
+    """decode_ph_pump_status covers every relay_ph branch."""
+    assert decode_ph_pump_status(data) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -226,24 +225,8 @@ async def test_hidro_polarity_decoder(
     data: dict[str, Any],
     expected: str | None,
 ) -> None:
-    """Drive _compute_hidro_polarity through every polarity / flow branch."""
-    await setup_integration(hass, mock_config_entry)
-    entity = _sensor_by_key(hass, "HIDRO_POLARITY")
-    if entity is None:
-        pytest.skip("HIDRO_POLARITY entity not registered")
-    coordinator = mock_config_entry.runtime_data
-    # Reset polarity-related keys before each parametrization so prior
-    # state doesn't leak.
-    for k in (
-        "HIDRO in Pol1",
-        "HIDRO in Pol2",
-        "HIDRO in dead time",
-        "Filtration Pump",
-        "HIDRO Cell Flow FL1",
-    ):
-        coordinator.data.pop(k, None)
-    coordinator.data.update(data)
-    assert entity._compute_hidro_polarity() == expected
+    """decode_hidro_polarity covers every polarity / flow branch."""
+    assert decode_hidro_polarity(data) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -280,16 +263,8 @@ async def test_ion_polarity_decoder(
     data: dict[str, Any],
     expected: str | None,
 ) -> None:
-    """Drive _compute_ion_polarity through every branch."""
-    await setup_integration(hass, mock_config_entry)
-    entity = _sensor_by_key(hass, "ION_POLARITY")
-    if entity is None:
-        pytest.skip("ION_POLARITY entity not registered")
-    coordinator = mock_config_entry.runtime_data
-    for k in ("ION in Pol1", "ION in Pol2", "ION in dead time"):
-        coordinator.data.pop(k, None)
-    coordinator.data.update(data)
-    assert entity._compute_ion_polarity() == expected
+    """decode_ion_polarity covers every branch."""
+    assert decode_ion_polarity(data) == expected
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace magic integers in `switch.py` and `light.py` with `TimerRelayMode` IntEnum from lib
- Delegate `decode_hidro_polarity`, `decode_ion_polarity`, `decode_ph_pump_status` to lib -- removes three inline decoder methods from `sensor.py`
- Move `GPIO_REGISTERS` dict from `const.py` to lib `registers.py` -- single source of truth for relay GPIO register names
- Bump `neopool-modbus` pin to `>=3.2.0`