### PR TITLE
feat!: 💥 drop slave_id and migrate entries to unit_id 

### DIFF
--- a/custom_components/neopool/__init__.py
+++ b/custom_components/neopool/__init__.py
@@ -77,7 +77,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NeoPoolConfigEntry) -> b
     """Set up the NeoPool integration from a config entry."""
     # CUSTOM-ONLY START — historic config flow stored options inside `data`;
     # the core integration writes options correctly from day one.
-    connection_keys = [CONF_HOST, CONF_PORT, CONF_NAME, "unit_id", "slave_id"]
+    connection_keys = [CONF_HOST, CONF_PORT, CONF_NAME, "unit_id"]
     candidate_keys = [k for k in entry.data if k not in connection_keys]
     if not entry.options or not any(k in entry.options for k in candidate_keys):
         new_options = {k: entry.data[k] for k in candidate_keys}

--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -230,9 +230,7 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ): int,
                 vol.Optional(
                     "unit_id",
-                    default=current.get(
-                        "unit_id", current.get("slave_id", DEFAULT_UNIT_ID)
-                    ),
+                    default=current.get("unit_id", DEFAULT_UNIT_ID),
                 ): int,
                 vol.Optional(
                     "modbus_framer",

--- a/custom_components/neopool/const.py
+++ b/custom_components/neopool/const.py
@@ -42,7 +42,7 @@ DEFAULT_PORT = 502
 DEFAULT_UNIT_ID = 1
 CONF_FILTRATION_PUMP_POWER = "filtration_pump_power"
 
-CURRENT_VERSION = 4
+CURRENT_VERSION = 5
 
 
 # Persisted in entry.options for winter-mode restarts.

--- a/custom_components/neopool/helpers.py
+++ b/custom_components/neopool/helpers.py
@@ -130,7 +130,7 @@ async def async_get_device_serial(
     """Perform minimal Modbus read to get device serial number."""
     host = config.get(CONF_HOST, "")
     port = config.get(CONF_PORT, 502)
-    unit_id = config.get("unit_id", config.get("slave_id", 1))
+    unit_id = config.get("unit_id", 1)
     framer = config.get("modbus_framer", DEFAULT_MODBUS_FRAMER)
 
     try:

--- a/custom_components/neopool/migration.py
+++ b/custom_components/neopool/migration.py
@@ -104,9 +104,24 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             return True
 
     if config_entry.version == 3:
-        hass.config_entries.async_update_entry(config_entry, version=CURRENT_VERSION)
+        hass.config_entries.async_update_entry(config_entry, version=4)
         _LOGGER.info(
-            "Bumped %s config entry %s to v%d (neopool-modbus library marker)",
+            "Bumped %s config entry %s to v4 (neopool-modbus library marker)",
+            DOMAIN,
+            config_entry.entry_id,
+        )
+
+    if config_entry.version == 4:
+        new_data = dict(config_entry.data)
+        if "slave_id" in new_data and "unit_id" not in new_data:
+            new_data["unit_id"] = new_data.pop("slave_id")
+        else:
+            new_data.pop("slave_id", None)
+        hass.config_entries.async_update_entry(
+            config_entry, data=new_data, version=CURRENT_VERSION
+        )
+        _LOGGER.info(
+            "Migrated %s config entry %s to v%d (slave_id → unit_id)",
             DOMAIN,
             config_entry.entry_id,
             CURRENT_VERSION,

--- a/tests/snapshots/test_diagnostics.ambr
+++ b/tests/snapshots/test_diagnostics.ambr
@@ -43,7 +43,7 @@
       }),
       'title': 'Pool',
       'unique_id': 'neopool_1234567890',
-      'version': 4,
+      'version': 5,
     }),
     'connection_stats': dict({
     }),

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -274,18 +274,6 @@ async def test_async_get_device_serial_success() -> None:
         assert await async_get_device_serial(config) == "ABCDEF1234"
 
 
-async def test_async_get_device_serial_legacy_slave_id_fallback() -> None:
-    """Legacy configs with only ``slave_id`` are still routed correctly."""
-
-    config = {"host": "192.0.2.1", "port": 502, "slave_id": 5, "modbus_framer": "tcp"}
-    probe = AsyncMock(return_value="ABCDEF1234")
-    with patch("custom_components.neopool.helpers.async_probe_serial", new=probe):
-        assert await async_get_device_serial(config) == "ABCDEF1234"
-    probe.assert_awaited_once()
-    kwargs = probe.await_args.kwargs
-    assert kwargs["unit_id"] == 5
-
-
 async def test_async_get_device_serial_neopool_error_returns_none() -> None:
     """A NeoPoolError from the probe yields None and a warning log entry."""
 

--- a/tests/test_init_custom.py
+++ b/tests/test_init_custom.py
@@ -11,6 +11,7 @@ Core ships fresh entries at v1 with no migration story — the sync
 script excludes this whole file via ``EXCLUDE_TEST_FILES``.
 """
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -148,14 +149,12 @@ async def test_async_migrate_entry_v1_to_v2_serial_unavailable() -> None:
 
 
 async def test_async_migrate_entry_v3_to_v4_marker_bump() -> None:
-    """Test that a v3 entry is bumped to v4 (the neopool-modbus library marker).
+    """Test that a v3 entry is bumped through v4 to v5.
 
     v3 entries are produced by the cross-domain pipeline (vistapool v2 →
     neopool v3 rename). HA picks up the resulting entry, sees its stored
-    version differs from ConfigFlow.VERSION (=CURRENT_VERSION=4) and
-    dispatches to async_migrate_entry, which performs the trivial
-    ``version=4`` write — no data shape change, no serial read, no
-    entity_registry walk.
+    version differs from ConfigFlow.VERSION (=CURRENT_VERSION=5) and
+    dispatches to async_migrate_entry, which bumps v3→v4 then v4→v5.
     """
     hass = MagicMock()
 
@@ -166,31 +165,65 @@ async def test_async_migrate_entry_v3_to_v4_marker_bump() -> None:
     config_entry.title = "My Pool"
     config_entry.data = {"host": "192.168.1.100", "port": DEFAULT_PORT, "unit_id": 1}
 
+    def _update_entry(entry: MagicMock, **kwargs: Any) -> None:
+        for k, v in kwargs.items():
+            if k == "data":
+                entry.data = v
+            else:
+                setattr(entry, k, v)
+
+    hass.config_entries.async_update_entry.side_effect = _update_entry
+
     result = await async_migrate_entry(hass, config_entry)
 
     assert result is True
-    # The v1→v2 prelude is gated on `version < 2` and must not run on a v3
-    # entry — no serial probe, no entity walk, just the marker bump.
-    hass.config_entries.async_update_entry.assert_called_once_with(
-        config_entry, version=4
+    assert hass.config_entries.async_update_entry.call_count == 2
+    hass.config_entries.async_update_entry.assert_any_call(config_entry, version=4)
+    hass.config_entries.async_update_entry.assert_any_call(
+        config_entry,
+        data={"host": "192.168.1.100", "port": DEFAULT_PORT, "unit_id": 1},
+        version=5,
     )
 
 
-async def test_async_migrate_entry_already_at_current_version_is_noop() -> None:
-    """Test that calling async_migrate_entry on a v4 entry does nothing.
-
-    HA may invoke this function on every setup whose stored version
-    differs from ConfigFlow.VERSION. Once entries reach CURRENT_VERSION
-    that should never happen, but guarding the function makes it robust
-    against unexpected dispatches and prevents stale "Migrating … from
-    v4 to v2" log noise.
-    """
+async def test_async_migrate_entry_v4_to_v5_slave_id_renamed() -> None:
+    """Test that a v4 entry with slave_id is migrated to v5 with unit_id."""
     hass = MagicMock()
 
     config_entry = MagicMock()
     config_entry.entry_id = "neopool_entry_v4"
     config_entry.unique_id = "neopool_AABBCCDD11223344EEFF0011"
     config_entry.version = 4
+    config_entry.title = "My Pool"
+    config_entry.data = {"host": "192.168.1.100", "port": DEFAULT_PORT, "slave_id": 3}
+
+    def _update_entry(entry: MagicMock, **kwargs: Any) -> None:
+        for k, v in kwargs.items():
+            if k == "data":
+                entry.data = v
+            else:
+                setattr(entry, k, v)
+
+    hass.config_entries.async_update_entry.side_effect = _update_entry
+
+    result = await async_migrate_entry(hass, config_entry)
+
+    assert result is True
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        config_entry,
+        data={"host": "192.168.1.100", "port": DEFAULT_PORT, "unit_id": 3},
+        version=5,
+    )
+
+
+async def test_async_migrate_entry_already_at_current_version_is_noop() -> None:
+    """Test that calling async_migrate_entry on a v5 entry does nothing."""
+    hass = MagicMock()
+
+    config_entry = MagicMock()
+    config_entry.entry_id = "neopool_entry_v5"
+    config_entry.unique_id = "neopool_AABBCCDD11223344EEFF0011"
+    config_entry.version = 5
     config_entry.title = "My Pool"
     config_entry.data = {"host": "192.168.1.100", "port": DEFAULT_PORT, "unit_id": 1}
 


### PR DESCRIPTION
## Summary

- ⚠️ **Breaking change**: `slave_id` is no longer accepted as a config key
- 🔄 Existing entries with `slave_id` are automatically migrated to `unit_id` on first load (v4→v5)
- 🗑️ Drop `slave_id` runtime fallbacks from `helpers.py`, `config_flow.py`, `__init__.py`

## Migration

Users upgrading from a version that used `slave_id` will have their config entry automatically migrated. No manual action required.