### PR TITLE
chore: 🔧 strip custom-only knobs from sync output

### DIFF
--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -66,9 +66,12 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         entry_id: str,
     ) -> None:
         """Initialise the NeoPool data update coordinator."""
+        self.normal_update_interval = timedelta(seconds=DEFAULT_SCAN_INTERVAL)
+        # CUSTOM-ONLY START — HACS-only per-instance polling-interval override.
         self.normal_update_interval = timedelta(
             seconds=entry.options.get("scan_interval", DEFAULT_SCAN_INTERVAL)
         )
+        # CUSTOM-ONLY END
         self.max_update_interval = min(
             self.normal_update_interval * 4, MAX_SCAN_INTERVAL
         )
@@ -199,6 +202,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         data["FILTRATION_REMAINING"] = aggregate_filtration_remaining(data)
 
+    # CUSTOM-ONLY START — HACS-only dev override hatch for live data injection.
     def _apply_dev_overrides(self, data: dict[str, Any]) -> None:
         """Apply developer override values to data, if enabled."""
         if not self.entry.options.get("dev_overrides_enabled", False):
@@ -218,6 +222,8 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return
         data.update(overrides)
         _LOGGER.debug("Applied dev overrides: %s", overrides)
+
+    # CUSTOM-ONLY END
 
     async def _sync_heating_intelligent_setpoints(self, data: dict[str, Any]) -> None:
         """Keep heating and intelligent setpoints synchronized last-change-wins."""
@@ -355,7 +361,9 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.debug("Device time is out of sync, updating")
             await self.client.async_sync_device_time(prepare_device_time(self.hass))
 
+        # CUSTOM-ONLY START
         self._apply_dev_overrides(data)
+        # CUSTOM-ONLY END
 
         try:
             await self._sync_heating_intelligent_setpoints(data)

--- a/custom_components/neopool/select.py
+++ b/custom_components/neopool/select.py
@@ -518,9 +518,12 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):
             option_keys = [k for k in option_keys if k != 3]
 
         if self._key == "MBF_PAR_FILT_MODE":
-            backwash_allowed = self.coordinator.entry.options.get(
+            backwash_allowed = has_filtvalve(self.coordinator.data)
+            # CUSTOM-ONLY START — HACS-only manual override to expose backwash mode.
+            backwash_allowed = backwash_allowed or self.coordinator.entry.options.get(
                 "enable_backwash_option", False
-            ) or has_filtvalve(self.coordinator.data)
+            )
+            # CUSTOM-ONLY END
             if not backwash_allowed:
                 # Keep backwash (13) in the list if the device is currently in that
                 current_mode = self.coordinator.data.get("MBF_PAR_FILT_MODE")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -90,7 +90,6 @@ async def test_winter_mode_skips_modbus(
             "modbus_framer": "tcp",
         },
         options={
-            "scan_interval": 30,
             "modbus_framer": "tcp",
             "winter_mode": True,
             "_capabilities": snapshot,
@@ -182,7 +181,6 @@ async def test_auto_time_sync_writes_when_drift_detected(
             "modbus_framer": "tcp",
         },
         options={
-            "scan_interval": 30,
             "modbus_framer": "tcp",
             "auto_time_sync": True,
         },
@@ -196,6 +194,7 @@ async def test_auto_time_sync_writes_when_drift_detected(
 # ---------------------------------------------------------------------------
 
 
+# CUSTOM-ONLY START — dev_overrides is a HACS-only knob; both tests exercise it.
 async def test_dev_overrides_applied_when_enabled(
     hass: HomeAssistant,
     mock_neopool_client: MagicMock,
@@ -215,7 +214,6 @@ async def test_dev_overrides_applied_when_enabled(
             "modbus_framer": "tcp",
         },
         options={
-            "scan_interval": 30,
             "modbus_framer": "tcp",
             "dev_overrides_enabled": True,
             "dev_overrides": _json.dumps({"MBF_MEASURE_TEMPERATURE": 999}),
@@ -245,7 +243,6 @@ async def test_dev_overrides_invalid_json_ignored(
             "modbus_framer": "tcp",
         },
         options={
-            "scan_interval": 30,
             "modbus_framer": "tcp",
             "dev_overrides_enabled": True,
             "dev_overrides": "not-valid-json",
@@ -254,6 +251,9 @@ async def test_dev_overrides_invalid_json_ignored(
     await setup_integration(hass, entry)
     assert entry.state is ConfigEntryState.LOADED
     assert "Failed to apply dev_overrides" in caplog.text
+
+
+# CUSTOM-ONLY END
 
 
 # ---------------------------------------------------------------------------
@@ -288,7 +288,7 @@ async def test_setpoint_initial_sync_uses_heating_as_source(
             "unit_id": 1,
             "modbus_framer": "tcp",
         },
-        options={"scan_interval": 30, "modbus_framer": "tcp"},
+        options={"modbus_framer": "tcp"},
     )
     await setup_integration(hass, entry)
 
@@ -347,7 +347,7 @@ async def test_setpoint_last_change_wins_when_only_heating_changed(
             "unit_id": 1,
             "modbus_framer": "tcp",
         },
-        options={"scan_interval": 30, "modbus_framer": "tcp"},
+        options={"modbus_framer": "tcp"},
     )
     await setup_integration(hass, entry)
 
@@ -399,7 +399,7 @@ async def test_setpoint_revert_when_both_changed(
             "unit_id": 1,
             "modbus_framer": "tcp",
         },
-        options={"scan_interval": 30, "modbus_framer": "tcp"},
+        options={"modbus_framer": "tcp"},
     )
     await setup_integration(hass, entry)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock, MagicMock
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.neopool.const import CURRENT_VERSION, DOMAIN
+
+# CUSTOM-ONLY START
 from custom_components.neopool.migration import REMOVED_ENTITY_KEYS
+
+# CUSTOM-ONLY END
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -69,7 +73,6 @@ async def test_setup_in_winter_mode(
             "modbus_framer": "tcp",
         },
         options={
-            "scan_interval": 30,
             "modbus_framer": "tcp",
             "winter_mode": True,
             "_capabilities": snapshot,
@@ -79,6 +82,7 @@ async def test_setup_in_winter_mode(
     assert entry.state is ConfigEntryState.LOADED
 
 
+# CUSTOM-ONLY START — legacy v1→v4 migration cleanup tests (migration is HACS-only).
 async def test_setup_cleans_orphaned_entity_registry_entries(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -164,3 +168,6 @@ async def test_setup_does_not_touch_unrelated_select_entities(
     # The bystander row may have been re-registered by the platform during
     # setup, but it must still exist under its original entity_id.
     assert registry.async_get(bystander_entity_id) is not None
+
+
+# CUSTOM-ONLY END

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -50,7 +50,9 @@ async def test_options_flow_save_changes(
             "use_aux4": False,
             "filtration_pump_power": 0,
             "measure_when_filtration_off": False,
+            # CUSTOM-ONLY START
             "unlock_advanced": "",
+            # CUSTOM-ONLY END
         },
     )
 
@@ -59,6 +61,8 @@ async def test_options_flow_save_changes(
     assert mock_config_entry.options["use_filtration1"] is False
 
 
+# CUSTOM-ONLY START — unlock_advanced / dev_overrides / enable_backwash_option
+# are HACS-only knobs gated by a password-locked "advanced" step.
 async def test_options_flow_unlock_advanced_with_correct_password(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -199,3 +203,6 @@ async def test_options_flow_init_form_when_backwash_already_enabled(
     # The init step renders without erroring; the backwash toggle is now part
     # of the schema directly (no need to unlock_advanced first).
     assert result["step_id"] == "init"
+
+
+# CUSTOM-ONLY END

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -348,7 +348,6 @@ async def test_filtration_pump_energy_sensor_registers_when_power_set(
             "modbus_framer": "tcp",
         },
         options={
-            "scan_interval": 30,
             "modbus_framer": "tcp",
             "filtration_pump_power": 800,  # 800 W → energy sensor enabled
         },
@@ -387,7 +386,6 @@ async def test_filtration_pump_energy_accumulates_while_pump_runs(
             "modbus_framer": "tcp",
         },
         options={
-            "scan_interval": 30,
             "modbus_framer": "tcp",
             "filtration_pump_power": 1000,
         },
@@ -449,7 +447,6 @@ async def test_filtration_pump_energy_restores_native_value_after_restart(
             "modbus_framer": "tcp",
         },
         options={
-            "scan_interval": 30,
             "modbus_framer": "tcp",
             "filtration_pump_power": 1000,
         },
@@ -502,7 +499,6 @@ async def test_filtration_pump_energy_ignores_non_numeric_restore(
             "modbus_framer": "tcp",
         },
         options={
-            "scan_interval": 30,
             "modbus_framer": "tcp",
             "filtration_pump_power": 1000,
         },
@@ -640,7 +636,7 @@ async def test_cell_runtime_sensors_skipped_without_hydrolysis(
             "unit_id": 1,
             "modbus_framer": "tcp",
         },
-        options={"scan_interval": 30, "modbus_framer": "tcp"},
+        options={"modbus_framer": "tcp"},
     )
     await setup_integration(hass, entry)
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -143,7 +143,6 @@ async def test_io_switch_blocked_in_winter_mode(
             "modbus_framer": "tcp",
         },
         options={
-            "scan_interval": 30,
             "modbus_framer": "tcp",
             "winter_mode": True,
             "use_filtration1": True,

--- a/tools/sync_to_core/__main__.py
+++ b/tools/sync_to_core/__main__.py
@@ -40,7 +40,7 @@ from .json_strip import (
     strip_translations_en_json,
 )
 from .manifest import transform_manifest
-from .transformers import transform_python, transform_yaml
+from .transformers import transform_python, transform_snapshot, transform_yaml
 
 # ---------------------------------------------------------------------------
 # Walk helpers
@@ -171,12 +171,17 @@ def _process_test_file(
         )
         _write(dest, transformed)
         return
-    # Snapshots (*.ambr) and other fixtures: verbatim copy, but route
-    # `tests/snapshots/` into `dist/.../snapshots/` so the layout
-    # matches HA core.
+    # Snapshots (*.ambr) and other fixtures: route `tests/snapshots/`
+    # into `dist/.../snapshots/` so the layout matches HA core.
     rel = src.relative_to(SOURCE_TESTS)
     if rel.parts and rel.parts[0] == "snapshots":
         dest = DEST_SNAPSHOTS / Path(*rel.parts[1:])
+    if src.suffix == ".ambr":
+        # Strip HACS-only entry-options keys (scan_interval, unlock_advanced,
+        # ...) from syrupy snapshots so they stay consistent with the dist
+        # conftest fixtures, which had those keys stripped via CUSTOM-ONLY.
+        _write(dest, transform_snapshot(src.read_text(encoding="utf-8")))
+        return
     _write(dest, src.read_bytes())
 
 

--- a/tools/sync_to_core/transformers.py
+++ b/tools/sync_to_core/transformers.py
@@ -271,3 +271,24 @@ def transform_yaml(source: str, *, strip_license: bool) -> str:
     if strip_license:
         source = strip_license_header(source)
     return collapse_blank_lines(source)
+
+
+# Match a syrupy snapshot dict line like `        'scan_interval': 30,`
+# (any indent, any scalar value before the trailing comma). Used to drop
+# HACS-only entry-options keys from .ambr snapshots so the snapshot stays
+# consistent with the stripped dist conftest fixtures.
+_AMBR_HACS_ONLY_OPTIONS = re.compile(
+    r"^[ \t]+'(?:scan_interval|unlock_advanced|enable_backwash_option|"
+    r"dev_overrides|dev_overrides_enabled)':[^\n]*\n",
+    flags=re.MULTILINE,
+)
+
+
+def transform_snapshot(source: str) -> str:
+    """Strip HACS-only entry-options keys from a syrupy .ambr snapshot.
+
+    The snapshot is otherwise copied verbatim — only the lines whose key
+    matches a HACS-only options name are removed. Leaves indentation,
+    surrounding context and ordering intact.
+    """
+    return _AMBR_HACS_ONLY_OPTIONS.sub("", source)


### PR DESCRIPTION
## What

- New `transform_snapshot()` in `tools/sync_to_core/transformers.py` drops a few entry-options keys from `.ambr` snapshots when generating `dist/`. Wired into `_process_test_file()` for `.ambr` files.
- Added `CUSTOM-ONLY` markers around HACS-only knobs:
  - `coordinator.py`: `scan_interval` read, `_apply_dev_overrides()` method + call
  - `select.py`: `enable_backwash_option` override in `backwash_allowed`
  - `test_coordinator.py`: `dev_overrides` tests
  - `test_init.py`: `migration` import + cleanup tests
  - `test_options_flow.py`: `unlock_advanced` / `enable_backwash_option` / `dev_overrides` tests
- Dropped dead `"scan_interval": 30` keys from a few test fixtures.

## Why

The dist tree should not contain HACS-only options keys. With this change, `python -m tools.sync_to_core` produces a clean `dist/`.

## Verification

- `pytest tests/`: 293 passed, 17 snapshots
- `ruff check`, `ruff format --check`, `basedpyright`: clean
- `python -m tools.sync_to_core` then `grep` over `dist/`: no leaks left.
