### PR TITLE
feat(config): ✨ move options out of connection config flow

### DIFF
--- a/custom_components/neopool/__init__.py
+++ b/custom_components/neopool/__init__.py
@@ -19,12 +19,6 @@ import logging
 from neopool_modbus import NeoPoolModbusClient
 
 from homeassistant.config_entries import ConfigEntry
-
-# CUSTOM-ONLY START — these constants are only referenced by the
-# legacy data→options migration block in async_setup_entry below.
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
-
-# CUSTOM-ONLY END
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
@@ -59,20 +53,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: NeoPoolConfigEntry) -> bool:
     """Set up the NeoPool integration from a config entry."""
-    # CUSTOM-ONLY START — historic config flow stored options inside `data`;
-    # the core integration writes options correctly from day one.
-    connection_keys = [CONF_HOST, CONF_PORT, CONF_NAME, "unit_id"]
-    candidate_keys = [k for k in entry.data if k not in connection_keys]
-    if not entry.options or not any(k in entry.options for k in candidate_keys):
-        new_options = {k: entry.data[k] for k in candidate_keys}
-        if new_options:  # pragma: no cover
-            _LOGGER.debug(
-                "NeoPool: Migrating ALL config entry data (except connection params) to options: %s",
-                new_options,
-            )
-            hass.config_entries.async_update_entry(entry, options=new_options)
-    # CUSTOM-ONLY END
-
     client = NeoPoolModbusClient(entry.data)
     coordinator = NeoPoolCoordinator(hass, client, entry, entry.entry_id)
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/neopool/config_flow.py
+++ b/custom_components/neopool/config_flow.py
@@ -21,21 +21,13 @@ from typing import Any
 from neopool_modbus.registers import DEFAULT_MODBUS_FRAMER
 import voluptuous as vol
 
-from homeassistant import config_entries
-from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.helpers import translation as ha_translation
 
 from . import NeoPoolConfigEntry
-from .const import (
-    CONF_FILTRATION_PUMP_POWER,
-    CURRENT_VERSION,
-    DEFAULT_PORT,
-    DEFAULT_UNIT_ID,
-    DOMAIN,
-    NAME,
-)
+from .const import CURRENT_VERSION, DEFAULT_PORT, DEFAULT_UNIT_ID, DOMAIN, NAME
 from .helpers import async_get_device_serial
 from .migration import (
     async_abort_if_unmigrated_v1_match,
@@ -58,7 +50,7 @@ async def is_host_port_open(host: str, port: int, timeout: int = 3) -> bool:
     return True
 
 
-class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class NeoPoolConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for NeoPool."""
 
     VERSION = CURRENT_VERSION
@@ -112,30 +104,6 @@ class NeoPoolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     "modbus_framer",
                     default=DEFAULT_MODBUS_FRAMER,
                 ): vol.In(("tcp", "rtu")),
-                vol.Optional(
-                    CONF_FILTRATION_PUMP_POWER,
-                    default=0,
-                ): vol.All(int, vol.Range(min=0)),
-                vol.Optional(
-                    "use_filtration1",
-                    default=True,
-                ): bool,
-                vol.Optional(
-                    "use_filtration2",
-                    default=False,
-                ): bool,
-                vol.Optional(
-                    "use_filtration3",
-                    default=False,
-                ): bool,
-                vol.Optional(
-                    "use_light",
-                    default=False,
-                ): bool,
-                vol.Optional(
-                    "use_cover_sensor",
-                    default=False,
-                ): bool,
             }
         )
         errors = {}

--- a/custom_components/neopool/options_flow.py
+++ b/custom_components/neopool/options_flow.py
@@ -82,7 +82,7 @@ class NeoPoolOptionsFlowHandler(config_entries.OptionsFlow):
             ): vol.All(int, vol.Range(min=0)),
             vol.Optional(
                 "use_filtration1",
-                default=options.get("use_filtration1", True),
+                default=options.get("use_filtration1", False),
             ): bool,
             vol.Optional(
                 "use_filtration2",

--- a/custom_components/neopool/strings.json
+++ b/custom_components/neopool/strings.json
@@ -34,24 +34,14 @@
           "modbus_framer": "Modbus framer",
           "name_default": "Pool",
           "port": "[%key:common::config_flow::data::port%]",
-          "unit_id": "Unit ID",
-          "use_cover_sensor": "Enable Pool Cover Sensor",
-          "use_filtration1": "Enable 1st filtration timer for automatic mode",
-          "use_filtration2": "Enable 2nd filtration timer for automatic mode",
-          "use_filtration3": "Enable 3rd filtration timer for automatic mode",
-          "use_light": "Enable Light Relay"
+          "unit_id": "Unit ID"
         },
         "data_description": {
           "filtration_pump_power": "Set the rated wattage of the filtration pump. When non-zero, two sensors are created: instantaneous power (W) and cumulative energy (Wh), both usable in the Energy dashboard.",
           "host": "Enter the IP address of the Modbus TCP gateway connected to your pool controller.",
           "modbus_framer": "Select 'tcp' for gateways that convert between TCP and RTU. Select 'rtu' for transparent gateways that forward raw RTU frames over TCP.",
           "port": "Standard Modbus TCP port (default: 502). Change only if your gateway uses a non-standard port.",
-          "unit_id": "The Modbus unit (server) ID of the pool controller. Most setups use 1.",
-          "use_cover_sensor": "Creates a binary sensor indicating whether the pool cover is open or closed.",
-          "use_filtration1": "Creates timer entities for configuring automatic filtration schedule.",
-          "use_filtration2": "[%key:component::neopool::config::step::user::data_description::use_filtration1%]",
-          "use_filtration3": "[%key:component::neopool::config::step::user::data_description::use_filtration1%]",
-          "use_light": "Creates entities to control and monitor the pool light relay."
+          "unit_id": "The Modbus unit (server) ID of the pool controller. Most setups use 1."
         },
         "description": "Configure the connection to your NeoPool controller.",
         "title": "NeoPool Connection"
@@ -583,11 +573,11 @@
           "use_aux2": "Enable Aux2 Relay",
           "use_aux3": "Enable Aux3 Relay",
           "use_aux4": "Enable Aux4 Relay",
-          "use_cover_sensor": "[%key:component::neopool::config::step::user::data::use_cover_sensor%]",
-          "use_filtration1": "[%key:component::neopool::config::step::user::data::use_filtration1%]",
-          "use_filtration2": "[%key:component::neopool::config::step::user::data::use_filtration2%]",
-          "use_filtration3": "[%key:component::neopool::config::step::user::data::use_filtration3%]",
-          "use_light": "[%key:component::neopool::config::step::user::data::use_light%]"
+          "use_cover_sensor": "Enable Pool Cover Sensor",
+          "use_filtration1": "Enable 1st filtration timer for automatic mode",
+          "use_filtration2": "Enable 2nd filtration timer for automatic mode",
+          "use_filtration3": "Enable 3rd filtration timer for automatic mode",
+          "use_light": "Enable Light Relay"
         },
         "data_description": {
           "enable_backwash_option": "Adds 'Backwash' to the filtration mode select. Only for systems with manual multi-way valves.",
@@ -600,10 +590,10 @@
           "use_aux3": "[%key:component::neopool::options::step::init::data_description::use_aux1%]",
           "use_aux4": "[%key:component::neopool::options::step::init::data_description::use_aux1%]",
           "use_cover_sensor": "Creates a binary sensor and enables cover-related entities (hydrolysis cover reduction, shutdown temperature).",
-          "use_filtration1": "[%key:component::neopool::config::step::user::data_description::use_filtration1%]",
-          "use_filtration2": "[%key:component::neopool::config::step::user::data_description::use_filtration1%]",
-          "use_filtration3": "[%key:component::neopool::config::step::user::data_description::use_filtration1%]",
-          "use_light": "[%key:component::neopool::config::step::user::data_description::use_light%]"
+          "use_filtration1": "Creates timer entities for configuring automatic filtration schedule.",
+          "use_filtration2": "[%key:component::neopool::options::step::init::data_description::use_filtration1%]",
+          "use_filtration3": "[%key:component::neopool::options::step::init::data_description::use_filtration1%]",
+          "use_light": "Creates entities to control and monitor the pool light relay."
         },
         "description": "WARNING: Changing enabled relays will automatically reload the integration! Changes take effect immediately.",
         "title": "NeoPool Settings"

--- a/custom_components/neopool/translations/cs.json
+++ b/custom_components/neopool/translations/cs.json
@@ -40,24 +40,14 @@
                     "modbus_framer": "Modbus rámec",
                     "name_default": "Bazén",
                     "port": "Port",
-                    "unit_id": "Unit ID",
-                    "use_cover_sensor": "Povolit senzor zakrytí bazénu",
-                    "use_filtration1": "Povolit 1. časovač filtrace pro automatický režim",
-                    "use_filtration2": "Povolit 2. časovač filtrace pro automatický režim",
-                    "use_filtration3": "Povolit 3. časovač filtrace pro automatický režim",
-                    "use_light": "Povolit relé Osvětlení"
+                    "unit_id": "Unit ID"
                 },
                 "data_description": {
                     "filtration_pump_power": "Zadejte jmenovitý příkon filtračního čerpadla. Při nenulové hodnotě se vytvoří dva senzory: okamžitý příkon (W) a kumulativní spotřeba energie (Wh), oba použitelné v přehledu energie.",
                     "host": "Zadejte IP adresu Modbus TCP brány připojené k vašemu řadiči bazénu.",
                     "modbus_framer": "Vyberte 'tcp' pro brány, které převádějí mezi TCP a RTU. Vyberte 'rtu' pro transparentní brány, které přeposílají surové RTU rámce přes TCP.",
                     "port": "Standardní port Modbus TCP. Změňte pouze pokud vaše brána používá nestandardní port (výchozí: 502).",
-                    "unit_id": "Modbus unit (server) ID řadiče bazénu. Většina zařízení používá 1.",
-                    "use_cover_sensor": "Vytvoří binární senzor indikující, zda je bazén zakrytý nebo odkrytý.",
-                    "use_filtration1": "Vytvoří entity časovačů pro konfiguraci automatického plánu filtrace.",
-                    "use_filtration2": "Vytvoří entity časovačů pro konfiguraci automatického plánu filtrace.",
-                    "use_filtration3": "Vytvoří entity časovačů pro konfiguraci automatického plánu filtrace.",
-                    "use_light": "Vytvoří entity pro ovládání a sledování relé osvětlení bazénu."
+                    "unit_id": "Modbus unit (server) ID řadiče bazénu. Většina zařízení používá 1."
                 },
                 "description": "Nakonfigurujte připojení k vašemu řadiči NeoPool.",
                 "title": "Připojení NeoPool"

--- a/custom_components/neopool/translations/de.json
+++ b/custom_components/neopool/translations/de.json
@@ -40,24 +40,14 @@
                     "modbus_framer": "Modbus-Framer",
                     "name_default": "Pool",
                     "port": "Port",
-                    "unit_id": "Unit-ID",
-                    "use_cover_sensor": "Abdeckungssensor aktivieren",
-                    "use_filtration1": "1. Filter-Timer für Automatikbetrieb aktivieren",
-                    "use_filtration2": "2. Filter-Timer für Automatikbetrieb aktivieren",
-                    "use_filtration3": "3. Filter-Timer für Automatikbetrieb aktivieren",
-                    "use_light": "Licht-Relais aktivieren"
+                    "unit_id": "Unit-ID"
                 },
                 "data_description": {
                     "filtration_pump_power": "Geben Sie die Nennleistung der Filtrationspumpe an. Bei einem Wert ungleich null werden zwei Sensoren erstellt: momentane Leistung (W) und kumulierter Energieverbrauch (Wh), beide nutzbar im Energie-Dashboard.",
                     "host": "Geben Sie die IP-Adresse des Modbus-TCP-Gateways ein, das mit Ihrem Pool-Controller verbunden ist.",
                     "modbus_framer": "Wählen Sie 'tcp' für Gateways, die zwischen TCP und RTU konvertieren. Wählen Sie 'rtu' für transparente Gateways, die rohe RTU-Frames über TCP weiterleiten.",
                     "port": "Standard-Modbus-TCP-Port. Ändern Sie ihn nur, wenn Ihr Gateway einen nicht standardmäßigen Port verwendet (Standard: 502).",
-                    "unit_id": "Modbus Unit (Server) ID des Pool-Controllers. Die meisten Setups verwenden 1.",
-                    "use_cover_sensor": "Erstellt einen Binärsensor, der anzeigt, ob die Poolabdeckung geöffnet oder geschlossen ist.",
-                    "use_filtration1": "Erstellt Timer-Entitäten zur Konfiguration des automatischen Filterplans.",
-                    "use_filtration2": "Erstellt Timer-Entitäten zur Konfiguration des automatischen Filterplans.",
-                    "use_filtration3": "Erstellt Timer-Entitäten zur Konfiguration des automatischen Filterplans.",
-                    "use_light": "Erstellt Entitäten zur Steuerung und Überwachung des Licht-Relais."
+                    "unit_id": "Modbus Unit (Server) ID des Pool-Controllers. Die meisten Setups verwenden 1."
                 },
                 "description": "Konfigurieren Sie die Verbindung zu Ihrem NeoPool-Controller.",
                 "title": "NeoPool Verbindung"

--- a/custom_components/neopool/translations/en.json
+++ b/custom_components/neopool/translations/en.json
@@ -40,24 +40,14 @@
                     "modbus_framer": "Modbus framer",
                     "name_default": "Pool",
                     "port": "Port",
-                    "unit_id": "Unit ID",
-                    "use_cover_sensor": "Enable Pool Cover Sensor",
-                    "use_filtration1": "Enable 1st filtration timer for automatic mode",
-                    "use_filtration2": "Enable 2nd filtration timer for automatic mode",
-                    "use_filtration3": "Enable 3rd filtration timer for automatic mode",
-                    "use_light": "Enable Light Relay"
+                    "unit_id": "Unit ID"
                 },
                 "data_description": {
                     "filtration_pump_power": "Set the rated wattage of the filtration pump. When non-zero, two sensors are created: instantaneous power (W) and cumulative energy (Wh), both usable in the Energy dashboard.",
                     "host": "Enter the IP address of the Modbus TCP gateway connected to your pool controller.",
                     "modbus_framer": "Select 'tcp' for gateways that convert between TCP and RTU. Select 'rtu' for transparent gateways that forward raw RTU frames over TCP.",
                     "port": "Standard Modbus TCP port (default: 502). Change only if your gateway uses a non-standard port.",
-                    "unit_id": "The Modbus unit (server) ID of the pool controller. Most setups use 1.",
-                    "use_cover_sensor": "Creates a binary sensor indicating whether the pool cover is open or closed.",
-                    "use_filtration1": "Creates timer entities for configuring automatic filtration schedule.",
-                    "use_filtration2": "Creates timer entities for configuring automatic filtration schedule.",
-                    "use_filtration3": "Creates timer entities for configuring automatic filtration schedule.",
-                    "use_light": "Creates entities to control and monitor the pool light relay."
+                    "unit_id": "The Modbus unit (server) ID of the pool controller. Most setups use 1."
                 },
                 "description": "Configure the connection to your NeoPool controller.",
                 "title": "NeoPool Connection"

--- a/custom_components/neopool/translations/es.json
+++ b/custom_components/neopool/translations/es.json
@@ -40,24 +40,14 @@
                     "modbus_framer": "Framer Modbus",
                     "name_default": "Piscina",
                     "port": "Puerto",
-                    "unit_id": "Unit ID",
-                    "use_cover_sensor": "Activar sensor de cubierta de piscina",
-                    "use_filtration1": "Activar el 1º temporizador de filtración para modo automático",
-                    "use_filtration2": "Activar el 2º temporizador de filtración para modo automático",
-                    "use_filtration3": "Activar el 3º temporizador de filtración para modo automático",
-                    "use_light": "Activar relé de luz"
+                    "unit_id": "Unit ID"
                 },
                 "data_description": {
                     "filtration_pump_power": "Indique la potencia nominal de la bomba de filtración. Con un valor distinto de cero se crean dos sensores: potencia instantánea (W) y energía acumulada (Wh), ambos utilizables en el panel de energía.",
                     "host": "Introduzca la dirección IP de la pasarela Modbus TCP conectada a su controlador de piscina.",
                     "modbus_framer": "Seleccione 'tcp' para pasarelas que convierten entre TCP y RTU. Seleccione 'rtu' para pasarelas transparentes que reenvían tramas RTU sin procesar por TCP.",
                     "port": "Puerto estándar de Modbus TCP. Cámbielo solo si su pasarela usa un puerto no estándar (por defecto: 502).",
-                    "unit_id": "El ID de unidad (servidor) Modbus del controlador de piscina. La mayoría de las configuraciones usan 1.",
-                    "use_cover_sensor": "Crea un sensor binario que indica si la cubierta de la piscina está abierta o cerrada.",
-                    "use_filtration1": "Crea entidades de temporizador para configurar el horario automático de filtración.",
-                    "use_filtration2": "Crea entidades de temporizador para configurar el horario automático de filtración.",
-                    "use_filtration3": "Crea entidades de temporizador para configurar el horario automático de filtración.",
-                    "use_light": "Crea entidades para controlar y monitorear el relé de luz de la piscina."
+                    "unit_id": "El ID de unidad (servidor) Modbus del controlador de piscina. La mayoría de las configuraciones usan 1."
                 },
                 "description": "Configura la conexión a tu controlador NeoPool.",
                 "title": "Conexión NeoPool"

--- a/custom_components/neopool/translations/fr.json
+++ b/custom_components/neopool/translations/fr.json
@@ -40,24 +40,14 @@
                     "modbus_framer": "Framer Modbus",
                     "name_default": "Piscine",
                     "port": "Port",
-                    "unit_id": "Unit ID",
-                    "use_cover_sensor": "Activer le capteur de couverture de piscine",
-                    "use_filtration1": "Activer le 1er minuteur de filtration pour le mode automatique",
-                    "use_filtration2": "Activer le 2ème minuteur de filtration pour le mode automatique",
-                    "use_filtration3": "Activer le 3ème minuteur de filtration pour le mode automatique",
-                    "use_light": "Activer le relais Lumière"
+                    "unit_id": "Unit ID"
                 },
                 "data_description": {
                     "filtration_pump_power": "Indiquez la puissance nominale de la pompe de filtration. Avec une valeur non nulle, deux capteurs sont créés : puissance instantanée (W) et énergie cumulée (Wh), tous deux utilisables dans le tableau de bord énergétique.",
                     "host": "Entrez l'adresse IP de la passerelle Modbus TCP connectée à votre contrôleur de piscine.",
                     "modbus_framer": "Sélectionnez 'tcp' pour les passerelles qui convertissent entre TCP et RTU. Sélectionnez 'rtu' pour les passerelles transparentes qui transmettent les trames RTU brutes via TCP.",
                     "port": "Port Modbus TCP standard. Ne le modifiez que si votre passerelle utilise un port non standard (par défaut : 502).",
-                    "unit_id": "ID d'unité (serveur) Modbus du contrôleur de piscine. La plupart des configurations utilisent 1.",
-                    "use_cover_sensor": "Crée un capteur binaire indiquant si la couverture de la piscine est ouverte ou fermée.",
-                    "use_filtration1": "Crée des entités de minuterie pour configurer le programme automatique de filtration.",
-                    "use_filtration2": "Crée des entités de minuterie pour configurer le programme automatique de filtration.",
-                    "use_filtration3": "Crée des entités de minuterie pour configurer le programme automatique de filtration.",
-                    "use_light": "Crée des entités pour contrôler et surveiller le relais lumière de la piscine."
+                    "unit_id": "ID d'unité (serveur) Modbus du contrôleur de piscine. La plupart des configurations utilisent 1."
                 },
                 "description": "Configurez la connexion à votre contrôleur NeoPool.",
                 "title": "Connexion NeoPool"

--- a/custom_components/neopool/translations/it.json
+++ b/custom_components/neopool/translations/it.json
@@ -40,24 +40,14 @@
                     "modbus_framer": "Framer Modbus",
                     "name_default": "Piscina",
                     "port": "Porta",
-                    "unit_id": "Unit ID",
-                    "use_cover_sensor": "Abilita sensore copertura piscina",
-                    "use_filtration1": "Abilita il 1° timer di filtrazione per la modalità automatica",
-                    "use_filtration2": "Abilita il 2° timer di filtrazione per la modalità automatica",
-                    "use_filtration3": "Abilita il 3° timer di filtrazione per la modalità automatica",
-                    "use_light": "Abilita relè luce"
+                    "unit_id": "Unit ID"
                 },
                 "data_description": {
                     "filtration_pump_power": "Specificare la potenza nominale della pompa di filtrazione. Con un valore diverso da zero vengono creati due sensori: potenza istantanea (W) ed energia cumulata (Wh), entrambi utilizzabili nel pannello energetico.",
                     "host": "Inserire l'indirizzo IP del gateway Modbus TCP collegato al controller della piscina.",
                     "modbus_framer": "Selezionare 'tcp' per gateway che convertono tra TCP e RTU. Selezionare 'rtu' per gateway trasparenti che inoltrano frame RTU grezzi su TCP.",
                     "port": "Porta Modbus TCP standard. Modificare solo se il gateway utilizza una porta non standard (predefinito: 502).",
-                    "unit_id": "L'ID unità (server) Modbus del controller della piscina. La maggior parte delle configurazioni usa 1.",
-                    "use_cover_sensor": "Crea un sensore binario che indica se la copertura della piscina è aperta o chiusa.",
-                    "use_filtration1": "Crea entità timer per configurare la programmazione automatica della filtrazione.",
-                    "use_filtration2": "Crea entità timer per configurare la programmazione automatica della filtrazione.",
-                    "use_filtration3": "Crea entità timer per configurare la programmazione automatica della filtrazione.",
-                    "use_light": "Crea entità per controllare e monitorare il relè luce della piscina."
+                    "unit_id": "L'ID unità (server) Modbus del controller della piscina. La maggior parte delle configurazioni usa 1."
                 },
                 "description": "Configura la connessione al tuo controller NeoPool.",
                 "title": "Connessione NeoPool"

--- a/custom_components/neopool/translations/pl.json
+++ b/custom_components/neopool/translations/pl.json
@@ -40,24 +40,14 @@
                     "modbus_framer": "Framer Modbus",
                     "name_default": "Basen",
                     "port": "Port",
-                    "unit_id": "Unit ID",
-                    "use_cover_sensor": "Włącz czujnik przykrycia basenu",
-                    "use_filtration1": "Włącz 1. timer filtracji w trybie automatycznym",
-                    "use_filtration2": "Włącz 2. timer filtracji w trybie automatycznym",
-                    "use_filtration3": "Włącz 3. timer filtracji w trybie automatycznym",
-                    "use_light": "Włącz przekaźnik oświetlenia"
+                    "unit_id": "Unit ID"
                 },
                 "data_description": {
                     "filtration_pump_power": "Podaj nominalną moc pompy filtracyjnej. Przy wartości różnej od zera tworzone są dwa czujniki: chwilowa moc (W) i skumulowana energia (Wh), oba możliwe do użycia na panelu energetycznym.",
                     "host": "Wprowadź adres IP bramki Modbus TCP podłączonej do kontrolera basenu.",
                     "modbus_framer": "Wybierz 'tcp' dla bramek konwertujących między TCP a RTU. Wybierz 'rtu' dla transparentnych bramek przesyłających surowe ramki RTU przez TCP.",
                     "port": "Standardowy port Modbus TCP. Zmień tylko jeśli bramka używa niestandardowego portu (domyślnie: 502).",
-                    "unit_id": "ID jednostki (serwera) Modbus kontrolera basenu. Większość konfiguracji używa 1.",
-                    "use_cover_sensor": "Tworzy czujnik binarny wskazujący, czy przykrycie basenu jest otwarte czy zamknięte.",
-                    "use_filtration1": "Tworzy encje timerów do konfiguracji automatycznego harmonogramu filtracji.",
-                    "use_filtration2": "Tworzy encje timerów do konfiguracji automatycznego harmonogramu filtracji.",
-                    "use_filtration3": "Tworzy encje timerów do konfiguracji automatycznego harmonogramu filtracji.",
-                    "use_light": "Tworzy encje do sterowania i monitorowania przekaźnika oświetlenia basenu."
+                    "unit_id": "ID jednostki (serwera) Modbus kontrolera basenu. Większość konfiguracji używa 1."
                 },
                 "description": "Skonfiguruj połączenie z kontrolerem NeoPool.",
                 "title": "Połączenie NeoPool"

--- a/tests/test_init_custom.py
+++ b/tests/test_init_custom.py
@@ -1,11 +1,9 @@
-"""HACS-only init tests — version migrations and legacy data→options promotion.
+"""HACS-only init tests — version migrations.
 
 These cover behaviour that has no counterpart in the core integration:
 ``async_migrate_entry`` was added to bridge v1 (no ``unique_id``) → v2
 (serial-based ``unique_id``) → v3 (vistapool→neopool rename) → v4 (the
-``neopool-modbus`` library marker bump). The legacy data→options promo
-runs on every ``async_setup_entry`` so pre-v1.x entries (which kept
-options inside ``data``) self-heal on first load.
+``neopool-modbus`` library marker bump) → v5 (slave_id → unit_id rename).
 
 Core ships fresh entries at v1 with no migration story — the sync
 script excludes this whole file via ``EXCLUDE_TEST_FILES``.
@@ -14,13 +12,8 @@ script excludes this whole file via ``EXCLUDE_TEST_FILES``.
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
 from custom_components.neopool import async_migrate_entry
-from custom_components.neopool.const import CURRENT_VERSION, DEFAULT_PORT, DOMAIN
-from homeassistant.core import HomeAssistant
-
-from . import setup_integration
+from custom_components.neopool.const import DEFAULT_PORT
 
 # ---------------------------------------------------------------------------
 # async_migrate_entry — version transitions
@@ -376,40 +369,3 @@ async def test_async_migrate_entry_rollback_also_fails() -> None:
     # 3 calls: migrate entity1 (ok), migrate entity2 (fail), rollback entity1 (fail)
     assert mock_registry.async_update_entity.call_count == 3
     hass.config_entries.async_update_entry.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# Legacy data → options migration (custom-only; runs on async_setup_entry)
-# ---------------------------------------------------------------------------
-
-
-async def test_legacy_data_to_options_migration(
-    hass: HomeAssistant,
-    mock_neopool_client: MagicMock,
-) -> None:
-    """Pre-v1.x entries kept user options inside `data` — async_setup_entry
-    moves every non-connection key from data to options on first load.
-    """
-    legacy_entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="Legacy Pool",
-        unique_id="neopool_legacy_options",
-        version=CURRENT_VERSION,
-        data={
-            "host": "192.0.2.40",
-            "port": 502,
-            "name": "Legacy Pool",
-            "unit_id": 1,
-            # Old-style: framer + use_* sat in data
-            "modbus_framer": "tcp",
-            "use_filtration1": True,
-            "use_light": True,
-        },
-        options={},  # empty → migration triggers
-    )
-    await setup_integration(hass, legacy_entry)
-
-    # use_* keys must have been promoted to options.
-    assert legacy_entry.options.get("use_filtration1") is True
-    assert legacy_entry.options.get("use_light") is True
-    assert legacy_entry.options.get("modbus_framer") == "tcp"


### PR DESCRIPTION
## 🎯 What

The connection config flow now only asks for connection parameters (host, port, unit ID, framer). Per-installation toggles (`use_filtration1/2/3`, `use_light`, `use_cover_sensor`, `filtration_pump_power`) move out of the initial flow and stay where they already lived: the options flow.

## 🧹 Changes

-  `async_step_user` no longer offers `use_*` and `filtration_pump_power` fields.
-  `use_filtration1` default flipped to `False` so timers are opt-in like every other `use_*` flag.
-  `from homeassistant import config_entries` replaced with a direct `ConfigFlow` import (idiomatic in HA core).
-  Dead `data` → `options` backfill block in `async_setup_entry` removed — no non-connection key ever lands in `entry.data` anymore.
-  `use_*` keys stripped from `config.step.user` in `strings.json` and every translation locale (cs/de/en/es/fr/it/pl). Texts now live in `options.step.init` (placeholders inlined).
-  Obsolete `test_legacy_data_to_options_migration` removed.

## ⚠️ User-visible behaviour

- New entries: the initial form is connection-only; everything else is configured via the **Configure** button.
- Existing entries: unchanged. Whatever you had explicitly enabled in options stays enabled.
- Users who never opened the options flow (rare) will see `use_*` flags effectively at their new defaults (all `False`). One trip into options re-enables anything wanted.

## 🧪 Verification

- `pytest --cov=custom_components/neopool --cov-fail-under=100` — 292 passed, 100% coverage.
- `ruff check`, `ruff format --check`, `basedpyright` — clean.