### PR TITLE
fix(sensor): 🐛 report 0 for hydrolysis/ionization production when filtration off

### DIFF
--- a/custom_components/neopool/sensor.py
+++ b/custom_components/neopool/sensor.py
@@ -359,30 +359,50 @@ class NeoPoolSensor(NeoPoolEntity, SensorEntity):
             return "g/h"
         return self.entity_description.native_unit_of_measurement
 
+    _PRODUCTION_KEYS_REQUIRING_FILTRATION = frozenset(
+        {
+            "MBF_HIDRO_CURRENT",
+            "MBF_HIDRO_VOLTAGE",
+            "MBF_ION_CURRENT",
+        }
+    )
+
     _MEASURE_KEYS_REQUIRING_FILTRATION = frozenset(
         {
             "MBF_MEASURE_TEMPERATURE",
             "MBF_MEASURE_PH",
             "MBF_MEASURE_RX",
+            "MBF_MEASURE_CL",
             "MBF_MEASURE_CONDUCTIVITY",
-            "MBF_HIDRO_VOLTAGE",
             "FILTRATION_SPEED",
         }
     )
+
+    def _filtration_gate_blocks(self) -> bool:
+        """Return True if the filtration-off gate hides the live reading."""
+        if self.coordinator.entry.options.get("measure_when_filtration_off", False):
+            return False
+        return self.coordinator.data.get("Filtration Pump") is False
 
     def _is_measurement_suppressed(self) -> bool:
         """Return True if a measurement sensor should report None."""
         if self._key not in self._MEASURE_KEYS_REQUIRING_FILTRATION:
             return False
-        if self.coordinator.entry.options.get("measure_when_filtration_off", False):
+        return self._filtration_gate_blocks()
+
+    def _is_production_suppressed(self) -> bool:
+        """Return True if a production sensor should report 0."""
+        if self._key not in self._PRODUCTION_KEYS_REQUIRING_FILTRATION:
             return False
-        return self.coordinator.data.get("Filtration Pump") is False
+        return self._filtration_gate_blocks()
 
     @property
     def native_value(self) -> float | int | str | datetime | None:
         """Return the actual sensor value from coordinator data."""
         if self._is_measurement_suppressed():
             return None
+        if self._is_production_suppressed():
+            return 0
         if self._key == "PH_PUMP_STATUS":
             return decode_ph_pump_status(self.coordinator.data)
         if self._key == "HIDRO_POLARITY":

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -296,6 +296,67 @@ async def test_temperature_sensor_suppressed_when_filtration_off(
     assert entity.native_value == coordinator.data.get("MBF_MEASURE_TEMPERATURE")
 
 
+@pytest.mark.parametrize(
+    "key",
+    [
+        "MBF_MEASURE_PH",
+        "MBF_MEASURE_RX",
+        "MBF_MEASURE_CL",
+        "MBF_MEASURE_CONDUCTIVITY",
+    ],
+)
+async def test_measurement_sensors_suppressed_when_filtration_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_neopool_client: MagicMock,
+    key: str,
+) -> None:
+    """Probe sensors report None while filtration pump is off (stale reading)."""
+    await setup_integration(hass, mock_config_entry)
+    entity = _sensor_by_key(hass, key)
+    if entity is None:
+        pytest.skip(f"{key} entity not registered on this fixture")
+    coordinator = mock_config_entry.runtime_data
+    coordinator.data["Filtration Pump"] = False
+    assert entity.native_value is None
+
+    new_options = dict(mock_config_entry.options)
+    new_options["measure_when_filtration_off"] = True
+    hass.config_entries.async_update_entry(mock_config_entry, options=new_options)
+    await hass.async_block_till_done()
+    assert entity.native_value == coordinator.data.get(key)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "MBF_HIDRO_CURRENT",
+        "MBF_HIDRO_VOLTAGE",
+        "MBF_ION_CURRENT",
+    ],
+)
+async def test_production_sensors_zero_when_filtration_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_neopool_client: MagicMock,
+    key: str,
+) -> None:
+    """Production sensors report 0 while filtration pump is off (cell idle)."""
+    await setup_integration(hass, mock_config_entry)
+    entity = _sensor_by_key(hass, key)
+    if entity is None:
+        pytest.skip(f"{key} entity not registered on this fixture")
+    coordinator = mock_config_entry.runtime_data
+    coordinator.data["Filtration Pump"] = False
+    assert entity.native_value == 0
+
+    new_options = dict(mock_config_entry.options)
+    new_options["measure_when_filtration_off"] = True
+    hass.config_entries.async_update_entry(mock_config_entry, options=new_options)
+    await hass.async_block_till_done()
+    assert entity.native_value == coordinator.data.get(key)
+
+
 # ---------------------------------------------------------------------------
 # Filt mode / filtration speed / pH status alarm options
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 🐛 Summary

When the filtration pump turns off, the hydrolysis intensity (`MBF_HIDRO_CURRENT`) kept showing the last value it had before the pump stopped. The cell can't electrolyse without flow, so the reading was stale and misleading.

## 🔧 Changes

- 🆕 `MBF_HIDRO_CURRENT`, `MBF_HIDRO_VOLTAGE` and `MBF_ION_CURRENT` now return **0** while the filtration pump is off (cell is physically idle).
- 🧪 Probe sensors (`MBF_MEASURE_PH`, `MBF_MEASURE_RX`, `MBF_MEASURE_CL`, `MBF_MEASURE_CONDUCTIVITY`, `MBF_MEASURE_TEMPERATURE`) keep returning **None** in the same state. The reading is stale, not zero, so reporting unknown is the honest answer.
- ♻️ Split the single `_MEASURE_KEYS_REQUIRING_FILTRATION` set into a production set and a probe set; share the filtration-off gate through a small helper.
- ⚙️ The `measure_when_filtration_off` option still overrides both arms, so users who want raw readings get them.

## ✅ Tests

- 📐 Parametrized `test_production_sensors_zero_when_filtration_off` covers the new zero path.
- 📐 Existing `test_measurement_sensors_suppressed_when_filtration_off` keeps verifying `None` for probe sensors.
- 🟢 Full suite: 296 passed, 100 % coverage, ruff/basedpyright clean.