### PR TITLE
refactor: ♻️ adopt neopool-modbus 3.5.0 labels and codecs

### DIFF
--- a/.github/workflows/typecheck.yaml
+++ b/.github/workflows/typecheck.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install basedpyright homeassistant-stubs 'neopool-modbus>=3.4.1'
+          pip install basedpyright homeassistant-stubs 'neopool-modbus>=3.5.0'
 
       - name: Run BasedPyright
         run: basedpyright custom_components/neopool

--- a/custom_components/neopool/manifest.json
+++ b/custom_components/neopool/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/svasek/homeassistant-neopool-modbus/issues",
   "loggers": ["neopool_modbus"],
-  "requirements": ["neopool-modbus>=3.4.1"],
+  "requirements": ["neopool-modbus>=3.5.0"],
   "version": "6.1.0"
 }

--- a/custom_components/neopool/select.py
+++ b/custom_components/neopool/select.py
@@ -21,7 +21,15 @@ import logging
 from typing import Any, override
 
 from neopool_modbus.capabilities import has_filtvalve, is_hydrolysis_present
-from neopool_modbus.decoders import decode_cell_boost, get_filtration_pump_type
+from neopool_modbus.decoders import (
+    CELL_BOOST_MODE_LABELS,
+    FILTRATION_MODE_LABELS,
+    FILTRATION_SPEED_LABELS,
+    FILTVALVE_MODE_LABELS,
+    decode_cell_boost,
+    decode_filtvalve_mode,
+    get_filtration_pump_type,
+)
 from neopool_modbus.registers import (
     AUX1_TIMER_BLOCK_REGISTER,
     AUX2_TIMER_BLOCK_REGISTER,
@@ -160,31 +168,22 @@ def _decode_filtvalve_mode(
     desc: "NeoPoolSelectEntityDescription", data: Mapping[str, Any]
 ) -> str | None:
     """Map the raw MBF_PAR_FILTVALVE_MODE register to its translation key."""
-    value = data.get("MBF_PAR_FILTVALVE_MODE")
-    if value is None:
-        return None
-    return desc.options_map.get(int(value))
+    del desc
+    return decode_filtvalve_mode(data.get("MBF_PAR_FILTVALVE_MODE"))
 
 
 SELECT_DESCRIPTIONS: dict[str, NeoPoolSelectEntityDescription] = {
     "MBF_PAR_FILT_MODE": NeoPoolSelectEntityDescription(
         key="MBF_PAR_FILT_MODE",
         translation_key="filt_mode",
-        options_map={
-            0: "manual",
-            1: "auto",
-            2: "heating",
-            3: "smart",
-            4: "intelligent",
-            13: "backwash",
-        },
+        options_map=FILTRATION_MODE_LABELS,
         register=FILTRATION_MODE_REGISTER,
         options_fn=_filt_mode_options,
     ),
     "MBF_PAR_FILTRATION_SPEED": NeoPoolSelectEntityDescription(
         key="MBF_PAR_FILTRATION_SPEED",
         translation_key="filtration_speed",
-        options_map={0: "low", 1: "mid", 2: "high"},
+        options_map=FILTRATION_SPEED_LABELS,
         register=FILTRATION_CONF_REGISTER,
         shift=4,
         supported_fn=lambda data, opts: bool(  # pragma: no cover
@@ -195,7 +194,7 @@ SELECT_DESCRIPTIONS: dict[str, NeoPoolSelectEntityDescription] = {
     "MBF_CELL_BOOST": NeoPoolSelectEntityDescription(
         key="MBF_CELL_BOOST",
         translation_key="cell_boost",
-        options_map={0: "inactive", 1: "active", 2: "active_redox"},
+        options_map=CELL_BOOST_MODE_LABELS,
         register=CELL_BOOST_REGISTER,
         entity_registry_enabled_default=False,
         supported_fn=lambda data, opts: is_hydrolysis_present(data),  # pragma: no cover
@@ -206,13 +205,7 @@ SELECT_DESCRIPTIONS: dict[str, NeoPoolSelectEntityDescription] = {
         key="MBF_PAR_FILTVALVE_MODE",
         translation_key="filtvalve_mode",
         entity_category=EntityCategory.CONFIG,
-        options_map={
-            # 0: "disabled",
-            1: "enabled",
-            # 2: "auto_linked",
-            3: "always_on",
-            4: "always_off",
-        },
+        options_map=FILTVALVE_MODE_LABELS,
         register=FILTVALVE_MODE_REGISTER,
         supported_fn=lambda data, opts: has_filtvalve(data),
         current_option_fn=_decode_filtvalve_mode,
@@ -292,7 +285,7 @@ SELECT_DESCRIPTIONS: dict[str, NeoPoolSelectEntityDescription] = {
         key="filtration1_speed",
         translation_key="filtration1_speed",
         entity_category=EntityCategory.CONFIG,
-        options_map={0: "low", 1: "mid", 2: "high"},
+        options_map=FILTRATION_SPEED_LABELS,
         register=FILTRATION_CONF_REGISTER,
         mask=FILTRATION_TIMER1_SPEED_MASK,
         shift=FILTRATION_TIMER1_SPEED_SHIFT,
@@ -306,7 +299,7 @@ SELECT_DESCRIPTIONS: dict[str, NeoPoolSelectEntityDescription] = {
         key="filtration2_speed",
         translation_key="filtration2_speed",
         entity_category=EntityCategory.CONFIG,
-        options_map={0: "low", 1: "mid", 2: "high"},
+        options_map=FILTRATION_SPEED_LABELS,
         register=FILTRATION_CONF_REGISTER,
         mask=FILTRATION_TIMER2_SPEED_MASK,
         shift=FILTRATION_TIMER2_SPEED_SHIFT,
@@ -320,7 +313,7 @@ SELECT_DESCRIPTIONS: dict[str, NeoPoolSelectEntityDescription] = {
         key="filtration3_speed",
         translation_key="filtration3_speed",
         entity_category=EntityCategory.CONFIG,
-        options_map={0: "low", 1: "mid", 2: "high"},
+        options_map=FILTRATION_SPEED_LABELS,
         register=FILTRATION_CONF_REGISTER,
         mask=FILTRATION_TIMER3_SPEED_MASK,
         shift=FILTRATION_TIMER3_SPEED_SHIFT,

--- a/custom_components/neopool/sensor.py
+++ b/custom_components/neopool/sensor.py
@@ -23,11 +23,18 @@ from typing import Any, override
 
 from neopool_modbus.capabilities import has_filtvalve, is_ionization_present
 from neopool_modbus.decoders import (
+    FILTRATION_MODE_LABELS,
+    FILTRATION_SPEED_STATE_LABELS,
+    HIDRO_POLARITY_LABELS,
+    ION_POLARITY_LABELS,
+    PH_STATUS_ALARM_LABELS,
     decode_hidro_polarity,
     decode_ion_polarity,
+    decode_ph_alarm,
     decode_ph_pump_status,
     get_filtration_pump_type,
     is_hydrolysis_in_percent,
+    ph_pump_options,
 )
 
 from homeassistant.components.sensor import (
@@ -60,44 +67,6 @@ from .helpers import calculate_next_interval_time
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
-
-_FILTRATION_MODE_OPTIONS: list[str] = [
-    "manual",
-    "auto",
-    "heating",
-    "smart",
-    "intelligent",
-    "backwash",
-]
-_FILTRATION_SPEED_OPTIONS: list[str] = ["off", "low", "mid", "high"]
-_POLARITY_OPTIONS_HYDRO: list[str] = ["pol1", "pol2", "dead_time", "no_flow", "off"]
-_POLARITY_OPTIONS_ION: list[str] = ["pol1", "pol2", "dead_time", "off"]
-
-PH_STATUS_ALARM_MAP = {
-    0: "ok",
-    1: "ph_high",
-    2: "ph_low",
-    3: "pump_stopped",
-    4: "ph_over",
-    5: "ph_under",
-    6: "tank_level",
-}
-
-
-def _decode_ph_alarm(data: Mapping[str, Any]) -> str | None:
-    """Map the raw MBF_PH_STATUS_ALARM register value to a translation key."""
-    ph_alarm: int | None = data.get("MBF_PH_STATUS_ALARM")
-    return PH_STATUS_ALARM_MAP.get(ph_alarm) if ph_alarm is not None else None
-
-
-def _ph_pump_options(data: Mapping[str, Any]) -> list[str]:
-    """Return the pH pump status enum options narrowed by relay mode."""
-    relay_ph = data.get("MBF_PAR_RELAY_PH", 0) or 0
-    if relay_ph == 1:
-        return ["off", "idle", "acid"]
-    if relay_ph == 2:
-        return ["off", "idle", "base"]
-    return ["off", "idle", "acid", "base", "both"]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -186,7 +155,7 @@ SENSOR_DESCRIPTIONS: dict[str, NeoPoolSensorEntityDescription] = {
         key="MBF_PAR_FILT_MODE",
         translation_key="filt_mode",
         device_class=SensorDeviceClass.ENUM,
-        options=_FILTRATION_MODE_OPTIONS,
+        options=list(FILTRATION_MODE_LABELS.values()),
         value_fn=lambda data: data.get("filtration_mode"),
     ),
     "MBF_PH_STATUS_ALARM": NeoPoolSensorEntityDescription(
@@ -194,8 +163,8 @@ SENSOR_DESCRIPTIONS: dict[str, NeoPoolSensorEntityDescription] = {
         translation_key="ph_status_alarm",
         device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
-        options=list(PH_STATUS_ALARM_MAP.values()),
-        value_fn=_decode_ph_alarm,
+        options=list(PH_STATUS_ALARM_LABELS.values()),
+        value_fn=lambda data: decode_ph_alarm(data),
         supported_fn=lambda data, opts: (
             data.get("pH measurement module detected") is True
         ),
@@ -204,7 +173,7 @@ SENSOR_DESCRIPTIONS: dict[str, NeoPoolSensorEntityDescription] = {
         key="HIDRO_POLARITY",
         translation_key="hidro_polarity",
         device_class=SensorDeviceClass.ENUM,
-        options=_POLARITY_OPTIONS_HYDRO,
+        options=list(HIDRO_POLARITY_LABELS),
         value_fn=lambda data: decode_hidro_polarity(data),
         supported_fn=lambda data, opts: bool(data.get("Hydrolysis module detected")),
     ),
@@ -212,7 +181,7 @@ SENSOR_DESCRIPTIONS: dict[str, NeoPoolSensorEntityDescription] = {
         key="ION_POLARITY",
         translation_key="ion_polarity",
         device_class=SensorDeviceClass.ENUM,
-        options=_POLARITY_OPTIONS_ION,
+        options=list(ION_POLARITY_LABELS),
         value_fn=lambda data: decode_ion_polarity(data),
         supported_fn=lambda data, opts: is_ionization_present(data),
     ),
@@ -221,7 +190,7 @@ SENSOR_DESCRIPTIONS: dict[str, NeoPoolSensorEntityDescription] = {
         translation_key="ph_pump_status",
         device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
-        options_fn=_ph_pump_options,
+        options_fn=lambda data: ph_pump_options(data),
         value_fn=lambda data: decode_ph_pump_status(data),
         supported_fn=lambda data, opts: (
             data.get("pH measurement module detected") is True
@@ -231,7 +200,7 @@ SENSOR_DESCRIPTIONS: dict[str, NeoPoolSensorEntityDescription] = {
         key="FILTRATION_SPEED",
         translation_key="filtration_speed",
         device_class=SensorDeviceClass.ENUM,
-        options=_FILTRATION_SPEED_OPTIONS,
+        options=list(FILTRATION_SPEED_STATE_LABELS),
         value_fn=lambda data: data.get("filtration_speed_state"),
         supported_fn=lambda data, opts: bool(
             get_filtration_pump_type(data.get("MBF_PAR_FILTRATION_CONF", 0))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Runtime dependency (Modbus communication via NeoPool library)
-neopool-modbus>=3.4.1
+neopool-modbus>=3.5.0
 
 # Type stubs for Home Assistant Core
 homeassistant-stubs


### PR DESCRIPTION
## 🎯 Summary

Consumes the label collections and codecs exposed by [neopool-modbus 3.5.0](https://github.com/svasek/python-neopool-modbus/releases/tag/v3.5.0) so the integration no longer duplicates enum maps that already live in the library.

## 📦 Library bump

- 🔖 `neopool-modbus>=3.4.1` → `neopool-modbus>=3.5.0` in `manifest.json`, `requirements-dev.txt`, and `.github/workflows/typecheck.yaml`.

## ♻️ sensor.py

Dropped duplicated helpers and lists, imported the lib equivalents:

- 🗑️ Removed `PH_STATUS_ALARM_MAP`, `_decode_ph_alarm`, `_ph_pump_options`, `_FILTRATION_MODE_OPTIONS`, `_FILTRATION_SPEED_OPTIONS`, `_POLARITY_OPTIONS_HYDRO`, `_POLARITY_OPTIONS_ION`.
- ⬇️ Imported `PH_STATUS_ALARM_LABELS`, `FILTRATION_MODE_LABELS`, `FILTRATION_SPEED_STATE_LABELS`, `HIDRO_POLARITY_LABELS`, `ION_POLARITY_LABELS`, `decode_ph_alarm`, `ph_pump_options` from `neopool_modbus.decoders`.

## ♻️ select.py

Six `options_map` dicts routed to the lib maps (identical keys and values):

- 🧭 `MBF_PAR_FILT_MODE` → `FILTRATION_MODE_LABELS`
- 🎚️ `MBF_PAR_FILTRATION_SPEED`, `filtration1_speed`, `filtration2_speed`, `filtration3_speed` → `FILTRATION_SPEED_LABELS`
- 🔋 `MBF_CELL_BOOST` → `CELL_BOOST_MODE_LABELS`
- 🚿 `MBF_PAR_FILTVALVE_MODE` → `FILTVALVE_MODE_LABELS`
- 🛠️ `_decode_filtvalve_mode` now delegates to `decode_filtvalve_mode` from lib.

UI-quantised maps (`FILTVALVE_PERIOD_MINUTES`, `INTELLIGENT_FILT_MIN_TIME`, `RELAY_ACTIVATION_DELAY`, timer function maps) stay in the integration; those are UI conveniences, not protocol enums.

## ✅ Verification

- 🧪 pytest: 292 passed, 3 skipped, **100% coverage preserved**
- 🔍 basedpyright: 0 errors
- 🧹 ruff check + format: clean

## 🔁 Behaviour

No user-visible change; enum keys and label values are identical to the previous inline definitions.