### PR TITLE
test: ✅ drive updates through mocked client across all platforms

### DIFF
--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,8 +1,12 @@
 """Tests for the NeoPool binary_sensor platform value decoders."""
 
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 from syrupy.assertion import SnapshotAssertion
 
 from custom_components.neopool.const import DOMAIN
@@ -11,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform as ep, entity_registry as er
 
 from . import setup_integration
-from .conftest import MOCK_SERIAL
+from .conftest import MOCK_POOL_DATA, MOCK_SERIAL
 
 
 def _binary_by_key(hass: HomeAssistant, key: str):
@@ -44,20 +48,28 @@ async def test_direct_key_reflects_coordinator_value(
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """A simple boolean key from coordinator.data flows straight through is_on."""
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
 
-    coordinator.data["Filtration Pump"] = True
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "Filtration Pump": True,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     state = _binary_state(hass, entity_registry, "Filtration Pump")
     assert state is not None
     assert state.state == STATE_ON
 
-    coordinator.data["Filtration Pump"] = False
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "Filtration Pump": False,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     state = _binary_state(hass, entity_registry, "Filtration Pump")
     assert state is not None
@@ -74,6 +86,7 @@ async def test_pool_cover_inverts_hardware_value(
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """Pool Cover: hardware 1 (covered) → HA OFF; hardware 0 → HA ON.
 
@@ -81,17 +94,24 @@ async def test_pool_cover_inverts_hardware_value(
     register, so the entity inverts the value before returning is_on.
     """
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
 
-    coordinator.data["Pool Cover"] = True
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "Pool Cover": True,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     state = _binary_state(hass, entity_registry, "Pool Cover")
     assert state is not None
     assert state.state == STATE_OFF
 
-    coordinator.data["Pool Cover"] = False
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "Pool Cover": False,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     state = _binary_state(hass, entity_registry, "Pool Cover")
     assert state is not None
@@ -103,13 +123,17 @@ async def test_pool_cover_none_yields_unknown(
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """Missing Pool Cover key surfaces as STATE_UNKNOWN, not on/off."""
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
 
-    coordinator.data["Pool Cover"] = None
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "Pool Cover": None,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     state = _binary_state(hass, entity_registry, "Pool Cover")
     assert state is not None

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,9 +1,13 @@
 """Tests for the NeoPool button platform."""
 
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 from syrupy.assertion import SnapshotAssertion
 
 from custom_components.neopool.const import DOMAIN
@@ -13,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform as ep, entity_registry as er
 
 from . import setup_integration
-from .conftest import MOCK_SERIAL
+from .conftest import MOCK_POOL_DATA, MOCK_SERIAL
 
 
 def _button_entity_id(
@@ -115,17 +119,21 @@ async def test_backwash_button_aborts_when_valve_disappears(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """If the valve disappears between setup and press, the press logs and exits."""
     await setup_integration(hass, mock_config_entry)
     entity_id = _button_entity_id(hass, mock_config_entry, "backwash")
 
-    # Drop the filt valve from coordinator data after the entity is registered.
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["MBF_PAR_FILTVALVE_GPIO"] = 0
-    coordinator.data["MBF_PAR_FILTVALVE_ENABLE"] = 0
-    coordinator.async_set_updated_data(coordinator.data)
+    # Drop the filt valve from the next read after the entity is registered.
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_FILTVALVE_GPIO": 0,
+        "MBF_PAR_FILTVALVE_ENABLE": 0,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     mock_neopool_client.async_set_filtration_mode.reset_mock()

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,9 +1,13 @@
 """Tests for the NeoPool light platform."""
 
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 from syrupy.assertion import SnapshotAssertion
 
 from custom_components.neopool.light import LIGHT_DESCRIPTIONS
@@ -20,6 +24,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform as ep, entity_registry as er
 
 from . import setup_integration
+from .conftest import MOCK_POOL_DATA
 
 
 def _light_entity_id(hass: HomeAssistant, entry: MockConfigEntry) -> str:
@@ -92,19 +97,27 @@ async def test_light_is_on_reflects_relay_enable(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """is_on tracks coordinator.data['relay_light_enable']."""
     await setup_integration(hass, mock_config_entry)
     entity_id = _light_entity_id(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
 
-    coordinator.data["relay_light_enable"] = 3  # always ON
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "relay_light_enable": 3,  # always ON
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_ON
 
-    coordinator.data["relay_light_enable"] = 4  # always OFF
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "relay_light_enable": 4,  # always OFF
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_OFF
 
@@ -113,14 +126,18 @@ async def test_light_unavailable_when_relay_in_auto_mode(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """When the relay is set to auto (1), the light entity goes UNAVAILABLE."""
     await setup_integration(hass, mock_config_entry)
     entity_id = _light_entity_id(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
 
-    coordinator.data["relay_light_enable"] = 1  # auto
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "relay_light_enable": 1,  # auto
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,10 +1,14 @@
 """Tests for the NeoPool number platform."""
 
 import asyncio
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.number import (
@@ -17,6 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform as ep, entity_registry as er
 
 from . import setup_integration
+from .conftest import MOCK_POOL_DATA
 
 
 def _number_entity_id(
@@ -158,13 +163,17 @@ async def test_number_native_value_returns_rounded_raw(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """native_value returns round(raw, 2) when coordinator has the register."""
 
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["MBF_PAR_PH1"] = 7.55
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_PH1": 7.55,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     entity_obj = None
@@ -187,14 +196,18 @@ async def test_hidro_native_value_in_percent_mode(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """MBF_PAR_HIDRO with hidro_nom set surfaces it as native_max_value."""
 
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["MBF_PAR_HIDRO_NOM"] = 100
-    coordinator.data["MBF_PAR_MODEL"] = 0x0002  # has hydro
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_HIDRO_NOM": 100,
+        "MBF_PAR_MODEL": 0x0002,  # has hydro
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     entity_obj = None
@@ -217,6 +230,7 @@ async def test_masked_number_native_value_decodes_via_mask_shift(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """Test that masked compound numbers decode via _mask/_shift.
 
@@ -225,10 +239,13 @@ async def test_masked_number_native_value_decodes_via_mask_shift(
     temperature. native_value must isolate each via _mask/_shift.
     """
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
     # Pack: cover reduction = 25 (0x19), shutdown temp = 12 (0x0C) → 0x0C19.
-    coordinator.data["MBF_PAR_HIDRO_COVER_REDUCTION"] = 0x0C19
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_HIDRO_COVER_REDUCTION": 0x0C19,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     cover, shutdown = None, None
@@ -253,14 +270,18 @@ async def test_masked_number_write_preserves_other_byte(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """Writing one masked number must read-modify-write to preserve the other byte."""
     await setup_integration(hass, mock_config_entry)
     _disable_debounce(hass)
-    coordinator = mock_config_entry.runtime_data
     # Existing combined register: cover=25, shutdown=12 (0x0C19).
-    coordinator.data["MBF_PAR_HIDRO_COVER_REDUCTION"] = 0x0C19
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_HIDRO_COVER_REDUCTION": 0x0C19,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     cover_entity_id = None

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -13,6 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform as ep, entity_registry as er
 
 from . import setup_integration
+from .conftest import MOCK_POOL_DATA
 
 
 def _select_entity_id(
@@ -75,13 +76,13 @@ async def test_filt_mode_leaving_manual_stops_pump_first(
     must first write 0 to MANUAL_FILTRATION_REGISTER before the lib write.
     """
 
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_FILT_MODE": 0,
+        "filtration_mode": "manual",
+        "MBF_PAR_FILT_MANUAL_STATE": 1,
+    }
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["MBF_PAR_FILT_MODE"] = 0
-    coordinator.data["filtration_mode"] = "manual"
-    coordinator.data["MBF_PAR_FILT_MANUAL_STATE"] = 1
-    coordinator.async_set_updated_data(coordinator.data)
-    await hass.async_block_till_done()
 
     entity_id = _select_entity_id(hass, mock_config_entry, "mbf_par_filt_mode")
     mock_neopool_client.async_write_register.reset_mock()
@@ -105,12 +106,12 @@ async def test_filt_mode_backwash_with_auto_valve_keeps_pump_running(
     The Besgo valve needs the pump running to open correctly.
     """
 
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_FILT_MODE": 0,
+        "filtration_mode": "manual",
+    }
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["MBF_PAR_FILT_MODE"] = 0
-    coordinator.data["filtration_mode"] = "manual"
-    coordinator.async_set_updated_data(coordinator.data)
-    await hass.async_block_till_done()
 
     entity_id = _select_entity_id(hass, mock_config_entry, "mbf_par_filt_mode")
     mock_neopool_client.async_write_register.reset_mock()
@@ -270,12 +271,12 @@ async def test_timer_period_options_and_current_option(
     mock_neopool_client: MagicMock,
 ) -> None:
     """timer_period select reads options + current_option from coordinator data."""
-    await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
     # Pre-set the relay_aux1_period to a known PERIOD_MAP value (1 day).
-    coordinator.data["relay_aux1_period"] = 86400
-    coordinator.async_set_updated_data(coordinator.data)
-    await hass.async_block_till_done()
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "relay_aux1_period": 86400,
+    }
+    await setup_integration(hass, mock_config_entry)
 
     entity_obj = None
     for platforms in ep.async_get_platforms(hass, "neopool"):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -7,6 +7,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
+    async_fire_time_changed,
     mock_restore_cache_with_extra_data,
 )
 from syrupy.assertion import SnapshotAssertion
@@ -52,13 +53,17 @@ async def test_temperature_sensor_suppressed_when_filtration_off(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Temperature sensor is unknown while the filtration pump is off."""
     await setup_integration(hass, mock_config_entry)
     entity_id = _ENTITY_ID_BY_KEY["MBF_MEASURE_TEMPERATURE"]
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["Filtration Pump"] = False
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "Filtration Pump": False,
+    }
+    freezer.tick(_td(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_UNKNOWN
 
@@ -66,10 +71,11 @@ async def test_temperature_sensor_suppressed_when_filtration_off(
     new_options = dict(mock_config_entry.options)
     new_options["measure_when_filtration_off"] = True
     hass.config_entries.async_update_entry(mock_config_entry, options=new_options)
-    coordinator.async_set_updated_data(coordinator.data)
+    freezer.tick(_td(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == str(
-        coordinator.data["MBF_MEASURE_TEMPERATURE"]
+        MOCK_POOL_DATA["MBF_MEASURE_TEMPERATURE"]
     )
 
 
@@ -86,23 +92,28 @@ async def test_measurement_sensors_suppressed_when_filtration_off(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
     key: str,
 ) -> None:
     """Probe sensors are unknown while filtration pump is off (stale reading)."""
     await setup_integration(hass, mock_config_entry)
     entity_id = _ENTITY_ID_BY_KEY[key]
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["Filtration Pump"] = False
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "Filtration Pump": False,
+    }
+    freezer.tick(_td(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_UNKNOWN
 
     new_options = dict(mock_config_entry.options)
     new_options["measure_when_filtration_off"] = True
     hass.config_entries.async_update_entry(mock_config_entry, options=new_options)
-    coordinator.async_set_updated_data(coordinator.data)
+    freezer.tick(_td(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert hass.states.get(entity_id).state == str(coordinator.data[key])
+    assert hass.states.get(entity_id).state == str(MOCK_POOL_DATA[key])
 
 
 @pytest.mark.parametrize(
@@ -117,6 +128,7 @@ async def test_production_sensors_zero_when_filtration_off(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
     key: str,
 ) -> None:
     """Production sensors report 0 while filtration pump is off (cell idle)."""
@@ -136,18 +148,22 @@ async def test_production_sensors_zero_when_filtration_off(
     else:
         entity_id = _ENTITY_ID_BY_KEY[key]
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["Filtration Pump"] = False
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "Filtration Pump": False,
+    }
+    freezer.tick(_td(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == "0"
 
     new_options = dict(mock_config_entry.options)
     new_options["measure_when_filtration_off"] = True
     hass.config_entries.async_update_entry(mock_config_entry, options=new_options)
-    coordinator.async_set_updated_data(coordinator.data)
+    freezer.tick(_td(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert hass.states.get(entity_id).state == str(coordinator.data[key])
+    assert hass.states.get(entity_id).state == str(MOCK_POOL_DATA[key])
 
 
 # ---------------------------------------------------------------------------
@@ -170,15 +186,19 @@ async def test_filt_mode_native_value(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
     filt_mode: int,
     expected: str,
 ) -> None:
     """Filt mode native value reads the lib's decoded filtration_mode key."""
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["MBF_PAR_FILT_MODE"] = filt_mode
-    coordinator.data["filtration_mode"] = expected
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_FILT_MODE": filt_mode,
+        "filtration_mode": expected,
+    }
+    freezer.tick(_td(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert hass.states.get(_ENTITY_ID_BY_KEY["MBF_PAR_FILT_MODE"]).state == expected
 
@@ -358,46 +378,32 @@ async def test_ph_pump_status_options_per_relay_config(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """The pH pump status options list shrinks based on the relay configuration."""
     await setup_integration(hass, mock_config_entry)
     entity_id = _ENTITY_ID_BY_KEY["PH_PUMP_STATUS"]
-    coordinator = mock_config_entry.runtime_data
 
-    coordinator.data["MBF_PAR_RELAY_PH"] = 1
-    coordinator.async_set_updated_data(coordinator.data)
-    await hass.async_block_till_done()
-    assert hass.states.get(entity_id).attributes[ATTR_OPTIONS] == [
-        "off",
-        "idle",
-        "acid",
-    ]
-
-    coordinator.data["MBF_PAR_RELAY_PH"] = 2
-    coordinator.async_set_updated_data(coordinator.data)
-    await hass.async_block_till_done()
-    assert hass.states.get(entity_id).attributes[ATTR_OPTIONS] == [
-        "off",
-        "idle",
-        "base",
-    ]
-
-    coordinator.data["MBF_PAR_RELAY_PH"] = 0
-    coordinator.async_set_updated_data(coordinator.data)
-    await hass.async_block_till_done()
-    assert hass.states.get(entity_id).attributes[ATTR_OPTIONS] == [
-        "off",
-        "idle",
-        "acid",
-        "base",
-        "both",
-    ]
+    for relay, expected_options in (
+        (1, ["off", "idle", "acid"]),
+        (2, ["off", "idle", "base"]),
+        (0, ["off", "idle", "acid", "base", "both"]),
+    ):
+        mock_neopool_client.async_read_all.return_value = {
+            **MOCK_POOL_DATA,
+            "MBF_PAR_RELAY_PH": relay,
+        }
+        freezer.tick(_td(seconds=60))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        assert hass.states.get(entity_id).attributes[ATTR_OPTIONS] == expected_options
 
 
 async def test_hidro_current_g_per_hour_mode(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """In g/h mode HIDRO_CURRENT swaps unit and bumps display precision.
 
@@ -405,10 +411,13 @@ async def test_hidro_current_g_per_hour_mode(
     rather than %; the sensor adapts unit + precision accordingly.
     """
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
     # HIDROLIFE machine type → is_hydrolysis_in_percent returns False.
-    coordinator.data["MBF_PAR_UICFG_MACHINE"] = 1
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_UICFG_MACHINE": 1,
+    }
+    freezer.tick(_td(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     state = hass.states.get(_ENTITY_ID_BY_KEY["MBF_HIDRO_CURRENT"])
@@ -507,6 +516,7 @@ async def test_cell_runtime_sensor_returns_none_when_key_missing(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Sensor returns None when the combined key is absent from coordinator data."""
     # CELL_RUNTIME_PART is disabled-by-default; pre-enable it so the platform
@@ -521,36 +531,14 @@ async def test_cell_runtime_sensor_returns_none_when_key_missing(
         disabled_by=None,
     )
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
-    # Remove the combined key entirely -- coordinator.data.get() returns None.
-    coordinator.data.pop("CELL_RUNTIME_PART", None)
-    coordinator.async_set_updated_data(coordinator.data)
+    # Drop the combined key from the next read entirely so the sensor sees None.
+    reduced = {k: v for k, v in MOCK_POOL_DATA.items() if k != "CELL_RUNTIME_PART"}
+    mock_neopool_client.async_read_all.return_value = reduced
+    freezer.tick(_td(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     assert hass.states.get(entry.entity_id).state == STATE_UNKNOWN
-
-
-async def test_cell_runtime_default_enabled_state(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_neopool_client: MagicMock,
-) -> None:
-    """All five cell-runtime sensors default to disabled.
-
-    Cell-life metrics are diagnostic information rather than headline state;
-    surfacing them silently in every install would clutter dashboards. Users
-    who care about cell-life can enable the sensors explicitly in the entity
-    registry.
-    """
-
-    for key in (
-        "CELL_RUNTIME_TOTAL",
-        "CELL_RUNTIME_PART",
-        "CELL_RUNTIME_POLA",
-        "CELL_RUNTIME_POLB",
-        "CELL_RUNTIME_POL_CHANGES",
-    ):
-        assert SENSOR_DESCRIPTIONS[key].entity_registry_enabled_default is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,9 +1,13 @@
 """Tests for the NeoPool switch platform."""
 
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 from syrupy.assertion import SnapshotAssertion
 
 from custom_components.neopool.const import CURRENT_VERSION
@@ -20,6 +24,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform as ep, entity_registry as er
 
 from . import setup_integration
+from .conftest import MOCK_POOL_DATA
 
 
 async def _turn_on(hass: HomeAssistant, entity_id: str) -> None:
@@ -176,23 +181,32 @@ async def test_manual_filtration_is_on_reflects_state(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """is_on tracks MBF_PAR_FILT_MANUAL_STATE, available tracks FILT_MODE."""
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
 
     # Set FILT_MODE=0 (manual) and MANUAL_STATE=1 (on)
-    coordinator.data["MBF_PAR_FILT_MODE"] = 0
-    coordinator.data["MBF_PAR_FILT_MANUAL_STATE"] = 1
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_FILT_MODE": 0,
+        "MBF_PAR_FILT_MANUAL_STATE": 1,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     state = hass.states.get("switch.neopool_manual_filtration")
     assert state is not None
     assert state.state == STATE_ON
 
     # Switch FILT_MODE to non-manual → entity becomes unavailable
-    coordinator.data["MBF_PAR_FILT_MODE"] = 1
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_FILT_MODE": 1,
+        "MBF_PAR_FILT_MANUAL_STATE": 1,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     state = hass.states.get("switch.neopool_manual_filtration")
     assert state is not None
@@ -203,6 +217,7 @@ async def test_manual_filtration_is_on_returns_false_when_filt_mode_is_auto(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """is_on returns False directly when FILT_MODE is in auto (1).
 
@@ -211,10 +226,14 @@ async def test_manual_filtration_is_on_returns_false_when_filt_mode_is_auto(
     """
 
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["MBF_PAR_FILT_MODE"] = 1  # auto
-    coordinator.data["MBF_PAR_FILT_MANUAL_STATE"] = 1
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_FILT_MODE": 1,  # auto
+        "MBF_PAR_FILT_MANUAL_STATE": 1,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     entity_obj = None
     for platforms in ep.async_get_platforms(hass, "neopool"):

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,11 +1,14 @@
 """Tests for the NeoPool time platform."""
 
 import asyncio
-from datetime import time as dt_time
+from datetime import time as dt_time, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.time import DOMAIN as TIME_DOMAIN, SERVICE_SET_VALUE
@@ -14,6 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform as ep, entity_registry as er
 
 from . import setup_integration
+from .conftest import MOCK_POOL_DATA
 
 
 def _time_entity_id(
@@ -81,12 +85,17 @@ async def test_native_value_decodes_seconds_since_midnight(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """Coordinator seconds become HH:MM:SS state."""
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["filtration1_start"] = 6 * 3600 + 30 * 60  # 06:30
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "filtration1_start": 6 * 3600 + 30 * 60,  # 06:30
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     entity_id = _time_entity_id(hass, mock_config_entry, "filtration1_start")
     state = hass.states.get(entity_id)
@@ -98,12 +107,15 @@ async def test_native_value_returns_none_when_data_missing(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """Missing coordinator key surfaces as 'unknown'."""
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data.pop("filtration1_start", None)
-    coordinator.async_set_updated_data(coordinator.data)
+    reduced = {k: v for k, v in MOCK_POOL_DATA.items() if k != "filtration1_start"}
+    mock_neopool_client.async_read_all.return_value = reduced
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     entity_id = _time_entity_id(hass, mock_config_entry, "filtration1_start")
     state = hass.states.get(entity_id)
@@ -115,12 +127,17 @@ async def test_native_value_handles_out_of_range_seconds(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """Values >= 86400 wrap modulo 86400."""
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["filtration1_start"] = 86400 + 3600  # 25:00 -> 01:00
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "filtration1_start": 86400 + 3600,  # 25:00 -> 01:00
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     entity_id = _time_entity_id(hass, mock_config_entry, "filtration1_start")
     state = hass.states.get(entity_id)
@@ -137,13 +154,18 @@ async def test_set_value_on_start_calls_set_timer(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """Setting *_start preserves the existing stop."""
     await setup_integration(hass, mock_config_entry)
     _disable_debounce(hass)
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["filtration1_stop"] = 10 * 3600
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "filtration1_stop": 10 * 3600,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     entity_id = _time_entity_id(hass, mock_config_entry, "filtration1_start")
     mock_neopool_client.write_timer.reset_mock()
@@ -161,13 +183,18 @@ async def test_set_value_on_stop_calls_set_timer(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """Setting *_stop preserves the existing start."""
     await setup_integration(hass, mock_config_entry)
     _disable_debounce(hass)
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["filtration1_start"] = 6 * 3600
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "filtration1_start": 6 * 3600,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     entity_id = _time_entity_id(hass, mock_config_entry, "filtration1_stop")
     mock_neopool_client.write_timer.reset_mock()
@@ -185,14 +212,19 @@ async def test_rapid_set_value_coalesces_via_debounce(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """Sibling start/stop writes both reach the device with the latest pair."""
     await setup_integration(hass, mock_config_entry)
     _disable_debounce(hass)
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["filtration1_start"] = 0
-    coordinator.data["filtration1_stop"] = 0
-    coordinator.async_set_updated_data(coordinator.data)
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "filtration1_start": 0,
+        "filtration1_stop": 0,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     start_id = _time_entity_id(hass, mock_config_entry, "filtration1_start")
     stop_id = _time_entity_id(hass, mock_config_entry, "filtration1_stop")
@@ -217,10 +249,11 @@ async def test_repeated_set_value_on_same_entity_coalesces(
     mock_neopool_client: MagicMock,
 ) -> None:
     """A second set_value cancels the first pending task; only the latest writes."""
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "filtration1_stop": 12 * 3600,
+    }
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
-    coordinator.data["filtration1_stop"] = 12 * 3600
-    coordinator.async_set_updated_data(coordinator.data)
 
     entity_id = _time_entity_id(hass, mock_config_entry, "filtration1_start")
     entity_obj = _time_entity(hass, entity_id)


### PR DESCRIPTION
## 🎯 Motivation

Align the test suite with the [Home Assistant integration testing guidelines](https://developers.home-assistant.io/docs/development_testing/#writing-tests-for-integrations): drive state changes through the mocked lib client + a time advance rather than mutating `coordinator.data` in place and calling `async_set_updated_data(...)`.

The old pattern reached into coordinator internals and bypassed the update path an integration would actually take in production. The new pattern goes through the same `async_read_all` + scheduled coordinator refresh a real deployment does, which keeps the tests aligned with runtime behavior and makes future refactors (coordinator internals, follow-up platform sync to core) safer.

## 📝 What changed

Refactored across every affected platform test module:

- 🧪 `tests/test_sensor.py`
- 🧪 `tests/test_binary_sensor.py`
- 🧪 `tests/test_button.py`
- 🧪 `tests/test_light.py`
- 🧪 `tests/test_number.py`
- 🧪 `tests/test_select.py`
- 🧪 `tests/test_switch.py`
- 🧪 `tests/test_time.py`

**Old:**

```python
coordinator = mock_config_entry.runtime_data
coordinator.data["some_key"] = new_value
coordinator.async_set_updated_data(coordinator.data)
await hass.async_block_till_done()
```

**New:**

```python
mock_neopool_client.async_read_all.return_value = {
    **MOCK_POOL_DATA,
    "some_key": new_value,
}
freezer.tick(timedelta(seconds=60))
async_fire_time_changed(hass)
await hass.async_block_till_done()
```

Where the data mutation must be present at setup time (platform gating on a register value), the alternative form is used: set `mock_neopool_client.async_read_all.return_value` **before** `setup_integration(...)`.

Also dropped `test_cell_runtime_default_disabled_state` in `test_sensor.py`: it asserted an internal `SENSOR_DESCRIPTIONS[key].entity_registry_enabled_default` constant that is already covered behaviorally by the `disabled_by` field in the `test_all_entities` registry snapshot.

## ✅ Verification

- 🧪 `pytest tests/` : **269 passed**, 17 snapshots
- 📊 Coverage: **100 %** (1732 stmts / 0 miss / 18 files)
- 🎨 `ruff check` : all checks passed
- 🎨 `ruff format --check` : all files already formatted
- 🔍 `basedpyright` : 0 errors, 0 warnings, 0 notes