### PR TITLE
chore: 🔧 apply sensor.py review patterns to other platforms

### DIFF
--- a/custom_components/neopool/binary_sensor.py
+++ b/custom_components/neopool/binary_sensor.py
@@ -394,7 +394,8 @@ class NeoPoolBinarySensor(NeoPoolEntity, BinarySensorEntity):
     def is_on(self) -> bool | None:
         """Return True if the binary sensor is on."""
         if (value_fn := self.entity_description.value_fn) is not None:
-            return value_fn(self.coordinator.data, self.hass)
+            value: bool | None = value_fn(self.coordinator.data, self.hass)
+            return value
         if self._is_measurement_active_suppressed():
             return False
         value = self.coordinator.data.get(self._key)

--- a/custom_components/neopool/binary_sensor.py
+++ b/custom_components/neopool/binary_sensor.py
@@ -45,7 +45,7 @@ class NeoPoolBinarySensorEntityDescription(BinarySensorEntityDescription):
     """Describes a NeoPool binary sensor entity."""
 
     supported_fn: _SupportedFn | None = None
-    value_fn: Callable[[Mapping[str, Any], HomeAssistant], bool | None] | None = None
+    value_fn: Callable[[dict[str, Any], HomeAssistant], bool | None] | None = None
 
 
 def _gpio_ok(gpio_key: str) -> _SupportedFn:
@@ -60,14 +60,14 @@ def _module_detected(module_key: str) -> _SupportedFn:
     return lambda data, opts: bool(data.get(module_key))
 
 
-def _device_time_drift(data: Mapping[str, Any], hass: HomeAssistant) -> bool | None:
+def _device_time_drift(data: dict[str, Any], hass: HomeAssistant) -> bool | None:
     """Compute whether the device clock is out of sync with HA."""
     if data.get("MBF_PAR_TIME") is None:
         return None
     return is_device_time_out_of_sync(data, hass)
 
 
-def _pool_cover_open(data: Mapping[str, Any], hass: HomeAssistant) -> bool | None:
+def _pool_cover_open(data: dict[str, Any], hass: HomeAssistant) -> bool | None:
     """Invert the raw cover state to match BinarySensorDeviceClass.OPENING semantics."""
     value = data.get("Pool Cover")
     if value is None:

--- a/custom_components/neopool/binary_sensor.py
+++ b/custom_components/neopool/binary_sensor.py
@@ -395,12 +395,14 @@ class NeoPoolBinarySensor(NeoPoolEntity, BinarySensorEntity):
         """Return True if the binary sensor is on."""
         if (value_fn := self.entity_description.value_fn) is not None:
             return value_fn(self.coordinator.data, self.hass)
-
-        translation_key = self.entity_description.translation_key or ""
-        if translation_key.endswith(_MEASUREMENT_SUFFIXES):
-            filtration_state = self.coordinator.data.get("Filtration Pump")
-            if filtration_state is not None and filtration_state is False:
-                return False
-
+        if self._is_measurement_active_suppressed():
+            return False
         value = self.coordinator.data.get(self._key)
         return None if value is None else bool(value)
+
+    def _is_measurement_active_suppressed(self) -> bool:
+        """Return True if a "*_measurement_active" / "*_module_active" flag should be forced off."""
+        translation_key = self.entity_description.translation_key or ""
+        if not translation_key.endswith(_MEASUREMENT_SUFFIXES):
+            return False
+        return self.coordinator.data.get("Filtration Pump") is False

--- a/custom_components/neopool/light.py
+++ b/custom_components/neopool/light.py
@@ -111,8 +111,20 @@ class NeoPoolLight(NeoPoolEntity, LightEntity):
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light ON."""
+        await self._async_set_state(True)
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the light OFF."""
+        await self._async_set_state(False)
+
+    async def _async_set_state(self, state: bool) -> None:
+        """Dispatch turn_on / turn_off to the per-type writer."""
+        action = "turn_on" if state else "turn_off"
         if self.coordinator.winter_mode:
-            _LOGGER.warning("Winter mode is active, ignoring turn_on for %s", self._key)
+            _LOGGER.warning(
+                "Winter mode is active, ignoring %s for %s", action, self._key
+            )
             return
         client = getattr(self.coordinator, "client", None)
         if client is None:  # pragma: no cover
@@ -120,12 +132,24 @@ class NeoPoolLight(NeoPoolEntity, LightEntity):
             return
         desc = self.entity_description
         if desc.switch_type == "relay_timer":
+            await self._write_relay_timer(client, state)
+
+        # Optimistic update + schedule follow-up
+        self._optimistic_update(state)
+        self.coordinator.async_set_updated_data(self.coordinator.data)
+        self.coordinator.request_refresh_with_followup()
+
+    async def _write_relay_timer(self, client: Any, state: bool) -> None:
+        """Drive the relay light via its timer block."""
+        desc = self.entity_description
+        if desc.timer_block_addr is None:  # pragma: no cover
+            _LOGGER.error("Missing timer_block_addr for %s", self._key)
+            return
+        if state:
             if (
-                desc.function_addr is None
-                or desc.function_code is None
-                or desc.timer_block_addr is None
+                desc.function_addr is None or desc.function_code is None
             ):  # pragma: no cover
-                _LOGGER.error("Missing relay_timer config for %s", self._key)
+                _LOGGER.error("Missing relay_timer function config for %s", self._key)
                 return
             _LOGGER.debug(
                 "Turning ON %s: function_addr=0x%04X, timer_block_addr=0x%04X",
@@ -137,30 +161,7 @@ class NeoPoolLight(NeoPoolEntity, LightEntity):
             await client.async_write_register(
                 desc.timer_block_addr, TimerRelayMode.ALWAYS_ON
             )
-            await client.async_write_register(EXEC_REGISTER, 1)  # Commit
-
-        # Optimistic update + schedule follow-up
-        self._optimistic_update(True)
-        self.coordinator.async_set_updated_data(self.coordinator.data)
-        self.coordinator.request_refresh_with_followup()
-
-    @override
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the light OFF."""
-        if self.coordinator.winter_mode:
-            _LOGGER.warning(
-                "Winter mode is active, ignoring turn_off for %s", self._key
-            )
-            return
-        client = getattr(self.coordinator, "client", None)
-        if client is None:  # pragma: no cover
-            _LOGGER.error("Modbus client not available for writing registers")
-            return
-        desc = self.entity_description
-        if desc.switch_type == "relay_timer":
-            if desc.timer_block_addr is None:  # pragma: no cover
-                _LOGGER.error("Missing timer_block_addr for %s", self._key)
-                return
+        else:
             _LOGGER.debug(
                 "Turning OFF %s: timer_block_addr=0x%04X",
                 self._key,
@@ -169,12 +170,7 @@ class NeoPoolLight(NeoPoolEntity, LightEntity):
             await client.async_write_register(
                 desc.timer_block_addr, TimerRelayMode.ALWAYS_OFF
             )
-            await client.async_write_register(EXEC_REGISTER, 1)  # Commit
-
-        # Optimistic update + schedule follow-up
-        self._optimistic_update(False)
-        self.coordinator.async_set_updated_data(self.coordinator.data)
-        self.coordinator.request_refresh_with_followup()
+        await client.async_write_register(EXEC_REGISTER, 1)  # Commit
 
     def _optimistic_update(self, state: bool) -> None:
         """Apply an optimistic state update to coordinator data."""

--- a/custom_components/neopool/number.py
+++ b/custom_components/neopool/number.py
@@ -74,10 +74,10 @@ class NeoPoolNumberEntityDescription(NumberEntityDescription):
     shift: int = 0
     data_key: str | None = None
     supported_fn: Callable[[dict[str, Any], Mapping[str, Any]], bool] | None = None
-    precision_fn: Callable[[Mapping[str, Any]], int | None] | None = None
-    unit_fn: Callable[[Mapping[str, Any]], str | None] | None = None
-    max_fn: Callable[[Mapping[str, Any]], float | None] | None = None
-    step_fn: Callable[[Mapping[str, Any]], float | None] | None = None
+    precision_fn: Callable[[dict[str, Any]], int | None] | None = None
+    unit_fn: Callable[[dict[str, Any]], str | None] | None = None
+    max_fn: Callable[[dict[str, Any]], float | None] | None = None
+    step_fn: Callable[[dict[str, Any]], float | None] | None = None
 
 
 def _support_heating_temp(data: dict[str, Any], opts: Mapping[str, Any]) -> bool:
@@ -88,23 +88,23 @@ def _support_heating_temp(data: dict[str, Any], opts: Mapping[str, Any]) -> bool
     return bool(data.get("MBF_PAR_TEMPERATURE_ACTIVE"))
 
 
-def _hidro_precision(data: Mapping[str, Any]) -> int:
+def _hidro_precision(data: dict[str, Any]) -> int:
     """0 decimals in percent mode, 1 decimal in g/h mode."""
     return 0 if is_hydrolysis_in_percent(data) else 1
 
 
-def _hidro_unit(data: Mapping[str, Any]) -> str:
+def _hidro_unit(data: dict[str, Any]) -> str:
     """Surface the hydrolysis target unit dynamically: % or g/h."""
     return PERCENTAGE if is_hydrolysis_in_percent(data) else "g/h"
 
 
-def _hidro_max(data: Mapping[str, Any]) -> float | None:
+def _hidro_max(data: dict[str, Any]) -> float | None:
     """Use the device-reported nominal as the hidro maximum, or fall back to the static default."""
     hidro_nom = data.get("MBF_PAR_HIDRO_NOM")
     return float(hidro_nom) if hidro_nom is not None else None
 
 
-def _hidro_step(data: Mapping[str, Any]) -> float:
+def _hidro_step(data: dict[str, Any]) -> float:
     """Step is 1 in percent mode, 0.1 in g/h mode."""
     return 1.0 if is_hydrolysis_in_percent(data) else 0.1
 

--- a/custom_components/neopool/select.py
+++ b/custom_components/neopool/select.py
@@ -89,20 +89,19 @@ class NeoPoolSelectEntityDescription(SelectEntityDescription):
     supported_fn: Callable[[dict[str, Any], Mapping[str, Any]], bool] | None = None
     options_fn: (
         Callable[
-            ["NeoPoolSelectEntityDescription", Mapping[str, Any], Mapping[str, Any]],
+            ["NeoPoolSelectEntityDescription", dict[str, Any], Mapping[str, Any]],
             list[str],
         ]
         | None
     ) = None
     current_option_fn: (
-        Callable[["NeoPoolSelectEntityDescription", Mapping[str, Any]], str | None]
-        | None
+        Callable[["NeoPoolSelectEntityDescription", dict[str, Any]], str | None] | None
     ) = None
 
 
 def _filt_mode_options(
     desc: "NeoPoolSelectEntityDescription",
-    data: Mapping[str, Any],
+    data: dict[str, Any],
     opts: Mapping[str, Any],
 ) -> list[str]:
     """Narrow the filtration mode option list based on detected hardware."""
@@ -131,7 +130,7 @@ def _filt_mode_options(
 
 def _cell_boost_options(
     desc: "NeoPoolSelectEntityDescription",
-    data: Mapping[str, Any],
+    data: dict[str, Any],
     opts: Mapping[str, Any],
 ) -> list[str]:
     """Drop the active_redox option when no redox module is detected."""
@@ -142,7 +141,7 @@ def _cell_boost_options(
 
 
 def _decode_cell_boost(
-    desc: "NeoPoolSelectEntityDescription", data: Mapping[str, Any]
+    desc: "NeoPoolSelectEntityDescription", data: dict[str, Any]
 ) -> str | None:
     """Surface the current cell boost mode via the lib decoder."""
     reg_val = data.get("MBF_CELL_BOOST")
@@ -152,7 +151,7 @@ def _decode_cell_boost(
 
 
 def _decode_filtration_speed(
-    desc: "NeoPoolSelectEntityDescription", data: Mapping[str, Any]
+    desc: "NeoPoolSelectEntityDescription", data: dict[str, Any]
 ) -> str | None:
     """Decode the filtration speed from the packed MBF_PAR_FILTRATION_CONF register."""
     raw = data.get("MBF_PAR_FILTRATION_CONF")
@@ -165,7 +164,7 @@ def _decode_filtration_speed(
 
 
 def _decode_filtvalve_mode(
-    desc: "NeoPoolSelectEntityDescription", data: Mapping[str, Any]
+    desc: "NeoPoolSelectEntityDescription", data: dict[str, Any]
 ) -> str | None:
     """Map the raw MBF_PAR_FILTVALVE_MODE register to its translation key."""
     del desc

--- a/custom_components/neopool/switch.py
+++ b/custom_components/neopool/switch.py
@@ -57,6 +57,13 @@ _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 1
 
+# Switch types that are HA-side settings, not device state: they don't need a
+# client, don't participate in the winter-mode guard, and stay available even
+# while winter mode is active.
+_HA_SETTING_TYPES = frozenset({"winter_mode", "auto_time_sync"})
+
+_SIMPLE_REGISTER_TYPES = frozenset({"climate_mode", "smart_anti_freeze", "uv_mode"})
+
 
 @dataclass(frozen=True, kw_only=True)
 class NeoPoolSwitchEntityDescription(SwitchEntityDescription):
@@ -227,30 +234,67 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch ON."""
+        await self._async_set_state(True)
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch OFF."""
+        await self._async_set_state(False)
+
+    async def _async_set_state(self, state: bool) -> None:
+        """Dispatch turn_on / turn_off to the per-type writer."""
         desc = self.entity_description
-        if (
-            desc.switch_type not in ("winter_mode", "auto_time_sync")
-            and self.coordinator.winter_mode
-        ):
-            _LOGGER.warning("Winter mode is active, ignoring turn_on for %s", self._key)
+        action = "turn_on" if state else "turn_off"
+        if desc.switch_type not in _HA_SETTING_TYPES and self.coordinator.winter_mode:
+            _LOGGER.warning(
+                "Winter mode is active, ignoring %s for %s", action, self._key
+            )
             return
+
+        if desc.switch_type == "winter_mode":
+            await self.coordinator.set_winter_mode(state)
+            await self.coordinator.async_request_refresh()
+            self.async_write_ha_state()
+            return
+        if desc.switch_type == "auto_time_sync":
+            await self.coordinator.set_auto_time_sync(state)
+            await self.coordinator.async_request_refresh()
+            self.async_write_ha_state()
+            return
+
         client = getattr(self.coordinator, "client", None)
         if client is None:  # pragma: no cover
             _LOGGER.error("Modbus client not available for writing registers")
             return
+
         if desc.switch_type == "manual_filtration":
-            await client.async_write_register(MANUAL_FILTRATION_REGISTER, 1)
-        elif desc.switch_type == "auto_time_sync":
-            await self.coordinator.set_auto_time_sync(True)
-        elif desc.switch_type == "winter_mode":
-            await self.coordinator.set_winter_mode(True)
+            await self._write_manual_filtration(client, state)
         elif desc.switch_type == "relay_timer":
+            await self._write_relay_timer(client, state)
+        elif desc.switch_type in _SIMPLE_REGISTER_TYPES:
+            await self._write_simple_register(client, state)
+        elif desc.switch_type == "bitmask":
+            await self._write_bitmask(client, state)
+
+        self._optimistic_update(state)
+        self.coordinator.async_set_updated_data(self.coordinator.data)
+        self.coordinator.request_refresh_with_followup()
+
+    async def _write_manual_filtration(self, client: Any, state: bool) -> None:
+        """Write the manual filtration on/off register."""
+        await client.async_write_register(MANUAL_FILTRATION_REGISTER, 1 if state else 0)
+
+    async def _write_relay_timer(self, client: Any, state: bool) -> None:
+        """Turn an auxiliary relay on/off via its timer block."""
+        desc = self.entity_description
+        if desc.timer_block_addr is None:  # pragma: no cover
+            _LOGGER.error("Missing timer_block_addr for %s", self._key)
+            return
+        if state:
             if (
-                desc.function_addr is None
-                or desc.function_code is None
-                or desc.timer_block_addr is None
+                desc.function_addr is None or desc.function_code is None
             ):  # pragma: no cover
-                _LOGGER.error("Missing relay_timer config for %s", self._key)
+                _LOGGER.error("Missing relay_timer function config for %s", self._key)
                 return
             _LOGGER.debug(
                 "Turning ON relay %s: function_addr=0x%04X, timer_block_addr=0x%04X",
@@ -262,67 +306,7 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
             await client.async_write_register(
                 desc.timer_block_addr, TimerRelayMode.ALWAYS_ON
             )
-            await client.async_write_register(EXEC_REGISTER, 1)  # Commit
-        elif desc.switch_type in ("climate_mode", "smart_anti_freeze", "uv_mode"):
-            if desc.function_addr is None:  # pragma: no cover
-                _LOGGER.error("Missing function_addr for %s", self._key)
-                return
-            _LOGGER.debug(
-                "Setting %s ON via register 0x%04X",
-                desc.switch_type,
-                desc.function_addr,
-            )
-            await client.async_write_register(desc.function_addr, 1)
-        elif desc.switch_type == "bitmask":
-            if desc.function_addr is None or desc.mask_bit is None:  # pragma: no cover
-                _LOGGER.error("Missing bitmask config for %s", self._key)
-                return
-            current = int(self.coordinator.data.get(self._data_key, 0) or 0)
-            new_value = current | desc.mask_bit
-            _LOGGER.debug(
-                "Bitmask ON %s: reg=0x%04X mask=0x%04X current=%s new=%s",
-                self._key,
-                desc.function_addr,
-                desc.mask_bit,
-                current,
-                new_value,
-            )
-            await client.async_write_register(desc.function_addr, new_value, apply=True)
-
-        if desc.switch_type not in ("auto_time_sync", "winter_mode"):
-            self._optimistic_update(True)
-            self.coordinator.async_set_updated_data(self.coordinator.data)
-            self.coordinator.request_refresh_with_followup()
         else:
-            await self.coordinator.async_request_refresh()
-            self.async_write_ha_state()
-
-    @override
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the switch OFF."""
-        desc = self.entity_description
-        if (
-            desc.switch_type not in ("winter_mode", "auto_time_sync")
-            and self.coordinator.winter_mode
-        ):
-            _LOGGER.warning(
-                "Winter mode is active, ignoring turn_off for %s", self._key
-            )
-            return
-        client = getattr(self.coordinator, "client", None)
-        if client is None:  # pragma: no cover
-            _LOGGER.error("Modbus client not available for writing registers")
-            return
-        if desc.switch_type == "manual_filtration":
-            await client.async_write_register(MANUAL_FILTRATION_REGISTER, 0)
-        elif desc.switch_type == "auto_time_sync":
-            await self.coordinator.set_auto_time_sync(False)
-        elif desc.switch_type == "winter_mode":
-            await self.coordinator.set_winter_mode(False)
-        elif desc.switch_type == "relay_timer":
-            if desc.timer_block_addr is None:  # pragma: no cover
-                _LOGGER.error("Missing timer_block_addr for %s", self._key)
-                return
             _LOGGER.debug(
                 "Turning OFF relay %s: timer_block_addr=0x%04X",
                 self._key,
@@ -331,40 +315,40 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
             await client.async_write_register(
                 desc.timer_block_addr, TimerRelayMode.ALWAYS_OFF
             )
-            await client.async_write_register(EXEC_REGISTER, 1)  # Commit
-        elif desc.switch_type in ("climate_mode", "smart_anti_freeze", "uv_mode"):
-            if desc.function_addr is None:  # pragma: no cover
-                _LOGGER.error("Missing function_addr for %s", self._key)
-                return
-            _LOGGER.debug(
-                "Setting %s OFF via register 0x%04X",
-                desc.switch_type,
-                desc.function_addr,
-            )
-            await client.async_write_register(desc.function_addr, 0)
-        elif desc.switch_type == "bitmask":
-            if desc.function_addr is None or desc.mask_bit is None:  # pragma: no cover
-                _LOGGER.error("Missing bitmask config for %s", self._key)
-                return
-            current = int(self.coordinator.data.get(self._data_key, 0) or 0)
-            new_value = current & ~desc.mask_bit
-            _LOGGER.debug(
-                "Bitmask OFF %s: reg=0x%04X mask=0x%04X current=%s new=%s",
-                self._key,
-                desc.function_addr,
-                desc.mask_bit,
-                current,
-                new_value,
-            )
-            await client.async_write_register(desc.function_addr, new_value, apply=True)
+        await client.async_write_register(EXEC_REGISTER, 1)  # Commit
 
-        if desc.switch_type not in ("auto_time_sync", "winter_mode"):
-            self._optimistic_update(False)
-            self.coordinator.async_set_updated_data(self.coordinator.data)
-            self.coordinator.request_refresh_with_followup()
-        else:
-            await self.coordinator.async_request_refresh()
-            self.async_write_ha_state()
+    async def _write_simple_register(self, client: Any, state: bool) -> None:
+        """Write 1/0 into a simple on/off register."""
+        desc = self.entity_description
+        if desc.function_addr is None:  # pragma: no cover
+            _LOGGER.error("Missing function_addr for %s", self._key)
+            return
+        _LOGGER.debug(
+            "Setting %s %s via register 0x%04X",
+            desc.switch_type,
+            "ON" if state else "OFF",
+            desc.function_addr,
+        )
+        await client.async_write_register(desc.function_addr, 1 if state else 0)
+
+    async def _write_bitmask(self, client: Any, state: bool) -> None:
+        """Flip a single bit inside a packed register."""
+        desc = self.entity_description
+        if desc.function_addr is None or desc.mask_bit is None:  # pragma: no cover
+            _LOGGER.error("Missing bitmask config for %s", self._key)
+            return
+        current = int(self.coordinator.data.get(self._data_key, 0) or 0)
+        new_value = current | desc.mask_bit if state else current & ~desc.mask_bit
+        _LOGGER.debug(
+            "Bitmask %s %s: reg=0x%04X mask=0x%04X current=%s new=%s",
+            "ON" if state else "OFF",
+            self._key,
+            desc.function_addr,
+            desc.mask_bit,
+            current,
+            new_value,
+        )
+        await client.async_write_register(desc.function_addr, new_value, apply=True)
 
     def _optimistic_update(self, state: bool) -> None:
         """Apply an optimistic state update to coordinator data."""
@@ -394,25 +378,26 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
     def is_on(self) -> bool:
         """Return True if the switch is on."""
         desc = self.entity_description
+        data = self.coordinator.data
         if desc.switch_type == "manual_filtration":
-            if self.coordinator.data.get("MBF_PAR_FILT_MODE") == 1:
+            if data.get("MBF_PAR_FILT_MODE") == 1:
                 return False
-            return self.coordinator.data.get("MBF_PAR_FILT_MANUAL_STATE") == 1
+            return data.get("MBF_PAR_FILT_MANUAL_STATE") == 1
         if desc.switch_type == "auto_time_sync":
             return getattr(self.coordinator, "auto_time_sync", False)
         if desc.switch_type == "winter_mode":
             return getattr(self.coordinator, "winter_mode", False)
         if desc.switch_type == "relay_timer":
-            enable_val = self.coordinator.data.get(f"relay_{self._key}_enable", None)
+            enable_val = data.get(f"relay_{self._key}_enable", None)
             return enable_val == TimerRelayMode.ALWAYS_ON
         if desc.switch_type == "climate_mode":
-            return bool(self.coordinator.data.get("MBF_PAR_CLIMA_ONOFF", 0))
+            return bool(data.get("MBF_PAR_CLIMA_ONOFF", 0))
         if desc.switch_type == "smart_anti_freeze":
-            return bool(self.coordinator.data.get("MBF_PAR_SMART_ANTI_FREEZE", 0))
+            return bool(data.get("MBF_PAR_SMART_ANTI_FREEZE", 0))
         if desc.switch_type == "uv_mode":
-            return bool(self.coordinator.data.get("MBF_PAR_UV_MODE", 0))
+            return bool(data.get("MBF_PAR_UV_MODE", 0))
         if desc.switch_type == "bitmask" and desc.mask_bit is not None:
-            raw = int(self.coordinator.data.get(self._data_key, 0) or 0)
+            raw = int(data.get(self._data_key, 0) or 0)
             return bool(raw & desc.mask_bit)
         return False  # pragma: no cover
 
@@ -422,20 +407,24 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
         """Return True if the switch is available."""
         desc = self.entity_description
         # These switches are HA settings (not device state)
-        if desc.switch_type in ("winter_mode", "auto_time_sync"):
+        if desc.switch_type in _HA_SETTING_TYPES:
             return True
         if not super().available:
             return False
         if desc.switch_type == "manual_filtration":
             return self.coordinator.data.get("MBF_PAR_FILT_MODE") == 0
         if desc.switch_type == "relay_timer":
-            if self._key.startswith("aux"):
-                timer_name = f"relay_{self._key}_enable"
-            elif self._key == "light":  # pragma: no cover
-                timer_name = "relay_light_enable"
-            else:
-                return True  # pragma: no cover
-            mode_val = self.coordinator.data.get(timer_name, None)
-            # 3 = on, 4 = off → available; 0 (disabled) or 1 (auto) → not available
-            return mode_val in (3, 4)
+            return self._relay_timer_available()
         return True
+
+    def _relay_timer_available(self) -> bool:
+        """Report a relay-timer switch as available only when it is user-controlled."""
+        if self._key.startswith("aux"):
+            timer_name = f"relay_{self._key}_enable"
+        elif self._key == "light":  # pragma: no cover
+            timer_name = "relay_light_enable"
+        else:
+            return True  # pragma: no cover
+        mode_val = self.coordinator.data.get(timer_name, None)
+        # 3 = on, 4 = off → available; 0 (disabled) or 1 (auto) → not available
+        return mode_val in (3, 4)


### PR DESCRIPTION
## 🎯 Motivation

Refactor patterns already applied on `sensor.py`  to the remaining entity platforms. 

## 🔁 Patterns applied

| # | Origin in `sensor.py` | Applied to |
|---|---|---|
| 1 | `dict[str, Any]` for `value_fn` / `options_fn` / `unit_fn` / `precision_fn` inputs (Copilot round 6C on core PR) | `binary_sensor`, `number`, `select` |
| 2 | Extract `_is_*_suppressed()` predicate out of `native_value` / `is_on` (`7c4051e`) | `binary_sensor` |
| 3 | Collapse duplicated `async_turn_on` / `async_turn_off` into a single `_async_set_state` with per-type `_write_*` helpers, mirroring `select.py`'s `_select_*` methods | `switch`, `light` |
| 4 | Explicit-typed intermediate variable to narrow `value_fn` result (`433862d`) | `binary_sensor` |

## 📝 Commits

1. `chore: 🔧 tighten data-parameter typing across platforms` — `dict[str, Any]` instead of `Mapping[str, Any]` where the callback receives `coordinator.data` (which is a real dict). `opts` stays `Mapping` because `entry.options` is immutable.
2. `chore(binary_sensor): 🔧 extract _is_measurement_active_suppressed predicate` — moves the `*_measurement_active` / `*_module_active` filtration-off gate out of `is_on` into a dedicated helper. Also collapses `is not None and is False` to `is False` (semantically identical because `None is False` is `False`).
3. `chore(switch): 🔧 dispatch turn_on/off + per-type writer helpers` — 4 writer helpers (`_write_manual_filtration`, `_write_relay_timer`, `_write_simple_register`, `_write_bitmask`) plus `_relay_timer_available` for the mirrored `available` branch. HA-setting types and simple-register types are pulled out into module-level frozensets.
4. `chore(light): 🔧 dispatch turn_on/off through _async_set_state` — same shape as the switch refactor, adapted to the single `relay_timer` type currently used by the light platform.
5. `chore(binary_sensor): 🔧 narrow value_fn result into bool | None` — matches the `sensor.py` narrowing pattern.

## ✅ Verification

- `pytest` — 271 passed, 17 snapshots, **100% coverage** (1730/1730 stmts)
- `ruff check` — passed
- `ruff format --check` — 18 files formatted
- `basedpyright` — 0 errors, 0 warnings, 0 notes

## 🔍 Scope

- No behaviour change (verified via snapshot suite + parametrized platform tests)
- Net LoC: **+173 / −186 = −13**
- No changes to the library, no changes to translations, no changes to public API

## 🧭 Related

- Follows on from the `sensor.py` refactors in `7c4051e`, `433862d`, and PR #209