### PR TITLE
fix: 🔒️ harden diagnostics, GPIO repair and platform tests

### DIFF
--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -91,7 +91,9 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         self._firmware = "?"
         self._follow_up_unsub: CALLBACK_TYPE | None = None
-        self._corrupted_gpio_keys: frozenset[str] = frozenset()
+        # None (not frozenset()) so the first poll clears any stale issue
+        # persisted from a previous session.
+        self._corrupted_gpio_keys: frozenset[str] | None = None
 
     def request_refresh_with_followup(
         self, delay: float = FOLLOW_UP_REFRESH_DELAY

--- a/custom_components/neopool/diagnostics.py
+++ b/custom_components/neopool/diagnostics.py
@@ -40,7 +40,7 @@ async def async_get_config_entry_diagnostics(
             "unique_id": entry.unique_id,
             "version": entry.version,
         },
-        TO_REDACT | {"title"},
+        TO_REDACT | {"title", "unique_id"},
     )
 
     coordinator = getattr(entry, "runtime_data", None)

--- a/custom_components/neopool/diagnostics.py
+++ b/custom_components/neopool/diagnostics.py
@@ -31,14 +31,17 @@ async def async_get_config_entry_diagnostics(
 
     diagnostics: dict[str, Any] = {}
 
-    diagnostics["config_entry"] = {
-        "data": async_redact_data(dict(entry.data), TO_REDACT),
-        "options": dict(entry.options),
-        "title": entry.title,
-        "entry_id": entry.entry_id,
-        "unique_id": entry.unique_id,
-        "version": entry.version,
-    }
+    diagnostics["config_entry"] = async_redact_data(
+        {
+            "data": dict(entry.data),
+            "options": dict(entry.options),
+            "title": entry.title,
+            "entry_id": entry.entry_id,
+            "unique_id": entry.unique_id,
+            "version": entry.version,
+        },
+        TO_REDACT | {"title"},
+    )
 
     coordinator = getattr(entry, "runtime_data", None)
 

--- a/custom_components/neopool/sensor.py
+++ b/custom_components/neopool/sensor.py
@@ -480,7 +480,7 @@ class NeoPoolFiltrationEnergySensor(NeoPoolEntity, RestoreSensor):
             restored = float(value)
         except (TypeError, ValueError):  # pragma: no cover
             return
-        if math.isfinite(restored) and restored >= 0:  # pragma: no cover
+        if math.isfinite(restored) and restored >= 0:
             self._total_wh = restored
 
     @override

--- a/tests/snapshots/test_diagnostics.ambr
+++ b/tests/snapshots/test_diagnostics.ambr
@@ -45,7 +45,7 @@
         'use_light': True,
       }),
       'title': '**REDACTED**',
-      'unique_id': '1234567890',
+      'unique_id': '**REDACTED**',
       'version': 6,
     }),
     'connection_stats': dict({

--- a/tests/snapshots/test_diagnostics.ambr
+++ b/tests/snapshots/test_diagnostics.ambr
@@ -44,7 +44,7 @@
         'use_filtration3': True,
         'use_light': True,
       }),
-      'title': 'Pool',
+      'title': '**REDACTED**',
       'unique_id': '1234567890',
       'version': 6,
     }),

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -150,6 +150,7 @@ async def test_measurement_module_off_when_filtration_off(
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    freezer,
 ) -> None:
     """Measurement-module sensors report OFF when the filtration pump is idle."""
     mock_config_entry.add_to_hass(hass)
@@ -162,20 +163,40 @@ async def test_measurement_module_off_when_filtration_off(
         disabled_by=None,
     )
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
 
     entity = _binary_by_key(hass, "pH measurement active")
     assert entity is not None
+    entity_id = entity.entity_id
 
-    coordinator.data["pH measurement active"] = True
-    coordinator.data["Filtration Pump"] = False
-    assert entity.is_on is False
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "pH measurement active": True,
+        "Filtration Pump": False,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == STATE_OFF
 
-    coordinator.data["Filtration Pump"] = True
-    assert entity.is_on is True
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "pH measurement active": True,
+        "Filtration Pump": True,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == STATE_ON
 
-    coordinator.data["Filtration Pump"] = None
-    assert entity.is_on is True
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "pH measurement active": True,
+        "Filtration Pump": None,
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == STATE_ON
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -156,6 +156,29 @@ async def test_corrupt_gpio_self_heals_on_next_clean_read(
     assert issue_registry.async_get_issue(DOMAIN, "corrupted_gpio") is None
 
 
+async def test_corrupt_gpio_clears_stale_issue_from_previous_session(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_neopool_client: MagicMock,
+) -> None:
+    """Stale issue from a previous HA session clears on first poll."""
+    issue_registry = ir.async_get(hass)
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "corrupted_gpio",
+        is_fixable=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="corrupted_gpio",
+        translation_placeholders={"details": "- stale"},
+    )
+    assert issue_registry.async_get_issue(DOMAIN, "corrupted_gpio") is not None
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert issue_registry.async_get_issue(DOMAIN, "corrupted_gpio") is None
+
+
 async def test_corrupt_gpio_logs_error_only_on_state_change(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -59,3 +59,14 @@ async def test_entry_diagnostics_without_runtime_data(
     assert result["coordinator"] == {"status": "not loaded"}
     # Host is still redacted on the data block.
     assert result["config_entry"]["data"]["host"] == "**REDACTED**"
+
+
+async def test_entry_diagnostics_redacts_host_in_title(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """entry.title holds the raw host since PR #206; ensure it is redacted."""
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(mock_config_entry, title="192.0.2.15")
+    result = await async_get_config_entry_diagnostics(hass, mock_config_entry)
+    assert result["config_entry"]["title"] == "**REDACTED**"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -70,3 +70,13 @@ async def test_entry_diagnostics_redacts_host_in_title(
     hass.config_entries.async_update_entry(mock_config_entry, title="192.0.2.15")
     result = await async_get_config_entry_diagnostics(hass, mock_config_entry)
     assert result["config_entry"]["title"] == "**REDACTED**"
+
+
+async def test_entry_diagnostics_redacts_unique_id(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """entry.unique_id is the device serial number; ensure it is redacted."""
+    mock_config_entry.add_to_hass(hass)
+    result = await async_get_config_entry_diagnostics(hass, mock_config_entry)
+    assert result["config_entry"]["unique_id"] == "**REDACTED**"

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -298,12 +298,23 @@ async def test_climate_smart_uv_writes_to_function_register(
 
     mock_neopool_client.async_write_register.reset_mock()
     await _turn_on(hass, entity_id)
-    await _turn_off(hass, entity_id)
-
-    addresses = [
-        c.args[0] for c in mock_neopool_client.async_write_register.await_args_list
+    on_calls = [
+        (c.args[0], c.args[1])
+        for c in mock_neopool_client.async_write_register.await_args_list
     ]
-    assert addresses.count(function_addr) >= 2
+    assert (function_addr, 1) in on_calls, (
+        f"expected write ({function_addr}, 1); got: {on_calls}"
+    )
+
+    mock_neopool_client.async_write_register.reset_mock()
+    await _turn_off(hass, entity_id)
+    off_calls = [
+        (c.args[0], c.args[1])
+        for c in mock_neopool_client.async_write_register.await_args_list
+    ]
+    assert (function_addr, 0) in off_calls, (
+        f"expected write ({function_addr}, 0); got: {off_calls}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 🎯 Summary

Follow-ups from a pre-release regression review of `v6.1.0..HEAD`. Two runtime fixes and two test-hardening changes.

## 🔒️ `fix(diagnostics)` — redact host and serial leaked via config-entry metadata

Since the config-flow refactor, `entry.title` holds the raw `CONF_HOST` and `entry.unique_id` holds the device serial. The diagnostics payload redacted `entry.data[CONF_HOST]` but emitted `title` and `unique_id` verbatim, defeating the redaction for users who attach diagnostics to public issues.

- Route the full `config_entry` block through `async_redact_data` with `title` and `unique_id` added to the redact set
- New `test_entry_diagnostics_redacts_host_in_title` and `test_entry_diagnostics_redacts_unique_id` lock the contract
- Snapshot regenerated

## 🐛 `fix(coordinator)` — clear stale `corrupted_gpio` issue on startup

`_corrupted_gpio_keys` was initialised to `frozenset()`; the equality shortcut on the first poll after a HA restart short-circuited when the device was already clean, so any repair issue persisted from a previous session lingered in Settings → Repairs indefinitely.

- Init to `None` so the first poll always reaches `async_delete_issue`
- New `test_corrupt_gpio_clears_stale_issue_from_previous_session` (pre-creates the issue, runs setup with clean data, asserts self-clear)

## ✅ `test` — tighten switch and binary_sensor assertions

- `test_climate_smart_uv_writes_to_function_register` now asserts `(addr, 1)` and `(addr, 0)` tuples instead of counting address occurrences. Catches a regression that would hard-code `1` or `0` in both branches of `_write_simple_register`.
- `test_measurement_module_off_when_filtration_off` moved to the `async_read_all` + `freezer.tick` + `async_fire_time_changed` pattern used by the rest of the file. Catches a hypothetical write-time cache regression that direct `coordinator.data` mutation would miss.

## 🩹 `chore(sensor)` — drop stale `# pragma: no cover` from covered branch

`test_filtration_pump_energy_restores_native_value_after_restart` actually exercises the `isfinite` / `>= 0` branch on `sensor.py:483`. The pragma masked genuine coverage under the 100 % policy. Neighbouring pragmas on the `None` / type / `ValueError` guards stay — those defensive paths are unreachable in the happy path.

## 🧪 Verification

- 274 tests passed (was 271, +3 new regression tests)
- 100 % coverage (1724 statements)
- `ruff format --check` clean
- `ruff check` clean
- `basedpyright` 0 errors
- Both runtime fixes verified by temporary revert → new tests fail as expected
