### PR TITLE
fix(coordinator): 🐛 track corrupted GPIO values in change detection

### DIFF
--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -93,7 +93,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._follow_up_unsub: CALLBACK_TYPE | None = None
         # None (not frozenset()) so the first poll clears any stale issue
         # persisted from a previous session.
-        self._corrupted_gpio_keys: frozenset[str] | None = None
+        self._corrupted_gpio_state: frozenset[tuple[str, int]] | None = None
 
     def request_refresh_with_followup(
         self, delay: float = FOLLOW_UP_REFRESH_DELAY
@@ -127,9 +127,9 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _check_gpio_registers(self, data: dict) -> None:
         """Validate GPIO register values and (re-)raise or clear the repair issue."""
         corrupted = find_corrupted_gpio_registers(data)
-        corrupted_keys = frozenset(key for key, _, _ in corrupted)
+        corrupted_state = frozenset((key, value) for key, _, value in corrupted)
 
-        if corrupted_keys == self._corrupted_gpio_keys:
+        if corrupted_state == self._corrupted_gpio_state:
             return
 
         for key, label, value in corrupted:
@@ -143,7 +143,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 MAX_RELAY_GPIO,
             )
 
-        self._corrupted_gpio_keys = corrupted_keys
+        self._corrupted_gpio_state = corrupted_state
 
         if corrupted:
             details = "\n".join(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -208,6 +208,37 @@ async def test_corrupt_gpio_logs_error_only_on_state_change(
     assert total_errors == 1
 
 
+async def test_corrupt_gpio_updates_issue_on_value_change(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_neopool_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The repair issue details refresh when a corrupted register value changes."""
+    first = dict(MOCK_POOL_DATA)
+    first["MBF_PAR_FILT_GPIO"] = MAX_RELAY_GPIO + 1
+    mock_neopool_client.async_read_all = AsyncMock(return_value=first)
+
+    await setup_integration(hass, mock_config_entry)
+    issue_registry = ir.async_get(hass)
+    issue = issue_registry.async_get_issue(DOMAIN, "corrupted_gpio")
+    assert issue is not None
+    assert issue.translation_placeholders is not None
+    assert str(MAX_RELAY_GPIO + 1) in issue.translation_placeholders["details"]
+
+    second = dict(MOCK_POOL_DATA)
+    second["MBF_PAR_FILT_GPIO"] = MAX_RELAY_GPIO + 2
+    mock_neopool_client.async_read_all = AsyncMock(return_value=second)
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    issue = issue_registry.async_get_issue(DOMAIN, "corrupted_gpio")
+    assert issue is not None
+    assert issue.translation_placeholders is not None
+    assert str(MAX_RELAY_GPIO + 2) in issue.translation_placeholders["details"]
+
+
 # ---------------------------------------------------------------------------
 # Capability snapshot
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 🐛 Bug

The `corrupted_gpio` repair issue cached only the register keys. When a repeat poll reported the **same key** with a **different invalid value**, the change-detection short-circuit skipped re-raising the issue, so the user-facing details stayed stuck on the first observed value.

## ✅ Fix

Track `(key, value)` tuples instead. A value change on the same register now refreshes the repair issue details.

## 🧪 Tests

- New `test_corrupt_gpio_updates_issue_on_value_change` — first poll `MAX_RELAY_GPIO + 1`, second poll `MAX_RELAY_GPIO + 2`, assert `translation_placeholders["details"]` reflects the new value.
- All existing GPIO tests still pass (change-detection semantics unchanged for identical values).

## 📊 Verification

- 281 tests pass (+1 new)
- 100 % coverage across all 18 source files
- ruff + basedpyright clean
