### PR TITLE
fix(select): 🐛 decode filtration_speed via FILTRATION_SPEED_MASK

### DIFF
--- a/custom_components/neopool/select.py
+++ b/custom_components/neopool/select.py
@@ -45,6 +45,8 @@ from neopool_modbus.registers import (
     CELL_BOOST_REGISTER,
     FILTRATION_CONF_REGISTER,
     FILTRATION_MODE_REGISTER,
+    FILTRATION_SPEED_MASK,
+    FILTRATION_SPEED_SHIFT,
     FILTRATION_TIMER1_SPEED_MASK,
     FILTRATION_TIMER1_SPEED_SHIFT,
     FILTRATION_TIMER2_SPEED_MASK,
@@ -313,10 +315,13 @@ SELECT_DESCRIPTIONS: dict[str, NeoPoolSelectEntityDescription] = {
         translation_key="filtration_speed",
         options_map=FILTRATION_SPEED_LABELS,
         register=FILTRATION_CONF_REGISTER,
-        shift=4,
+        mask=FILTRATION_SPEED_MASK,
+        shift=FILTRATION_SPEED_SHIFT,
         supported_fn=has_variable_speed_pump,  # pragma: no cover
         write_fn=_write_filtration_speed,
-        current_option_fn=_make_filtration_speed_decoder(None, 4),
+        current_option_fn=_make_filtration_speed_decoder(
+            FILTRATION_SPEED_MASK, FILTRATION_SPEED_SHIFT
+        ),
     ),
     "MBF_CELL_BOOST": NeoPoolSelectEntityDescription(
         key="MBF_CELL_BOOST",

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -417,6 +417,34 @@ async def test_filtration_speed_raises_when_not_manual_mode(
     mock_neopool_client.async_set_filtration_speed.assert_not_awaited()
 
 
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (0x0000, "low"),
+        (0x0010, "mid"),
+        (0x0020, "high"),
+    ],
+)
+@pytest.mark.usefixtures("mock_neopool_client")
+async def test_filtration_speed_current_option_decodes_filtration_conf(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    raw: int,
+    expected: str,
+) -> None:
+    """Current option decodes bits 4-6 of MBF_PAR_FILTRATION_CONF to a speed label."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+    coordinator.data["MBF_PAR_FILTRATION_CONF"] = raw
+    coordinator.async_set_updated_data(coordinator.data)
+    await hass.async_block_till_done()
+
+    entity_id = _select_entity_id(hass, mock_config_entry, "mbf_par_filtration_speed")
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == expected
+
+
 # ---------------------------------------------------------------------------
 # timer_time + timer_period + relay_mode dispatch via set_timer service
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 🐛 Bug

Selecting a speed on the `filtration_speed` entity briefly reflected the choice, then reverted to `unknown` on the next poll. The physical pump switched correctly, but the entity state never held.

## 🔍 Root cause

`_make_filtration_speed_decoder(None, 4)` at `select.py:319` passed `mask=None`. The decoder factory has a defensive guard:

```python
if mask is None or shift is None:
    return None
```

which meant `current_option_fn` always returned `None`. The optimistic update from `async_select_option` was overwritten by the next `coordinator.async_set_updated_data` cycle.

## 🔧 Change

- import `FILTRATION_SPEED_MASK` and `FILTRATION_SPEED_SHIFT` from `neopool_modbus.registers`
- pass both to `_make_filtration_speed_decoder` on the `MBF_PAR_FILTRATION_SPEED` entity description
- add `mask=FILTRATION_SPEED_MASK` to the description for symmetry with the timer-slot speed entities

## ✅ Verification

- 284 passed (3 new parametrized cases: low/mid/high)
- 100 % coverage (1677/1677)
- `ruff check` clean
- `ruff format --check` clean
- `basedpyright` 0 errors

Resolves #220
