### PR TITLE
chore: 🔧 drop dead _firmware coordinator state

### DIFF
--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -20,7 +20,7 @@ import logging
 from typing import Any, override
 
 from neopool_modbus import NeoPoolModbusClient
-from neopool_modbus.decoders import aggregate_filtration_remaining, parse_version
+from neopool_modbus.decoders import aggregate_filtration_remaining
 from neopool_modbus.exceptions import NeoPoolError
 from neopool_modbus.registers import (
     HEATING_SETPOINT_REGISTER,
@@ -89,7 +89,6 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._capability_snapshot: dict[str, Any] = dict(
             entry.options.get("_capabilities", {})
         )
-        self._firmware = "?"
         self._follow_up_unsub: CALLBACK_TYPE | None = None
         # None (not frozenset()) so the first poll clears any stale issue
         # persisted from a previous session.
@@ -317,8 +316,6 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 translation_placeholders={"error": str(err)},
             ) from err
 
-        self._firmware = parse_version(data.get("MBF_POWER_MODULE_VERSION"))
-
         self._check_gpio_registers(data)
 
         await self._read_timers_into_data(data)
@@ -367,8 +364,3 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.hass.config_entries.async_update_entry(self.entry, options=options)
         if enabled:
             self.async_set_updated_data(dict(self._capability_snapshot))
-
-    @property
-    def firmware(self) -> str:
-        """Return the device firmware version string."""
-        return self._firmware

--- a/custom_components/neopool/diagnostics.py
+++ b/custom_components/neopool/diagnostics.py
@@ -16,6 +16,8 @@
 
 from typing import Any
 
+from neopool_modbus.decoders import parse_version
+
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.core import HomeAssistant
 
@@ -55,7 +57,9 @@ async def async_get_config_entry_diagnostics(
         "data": getattr(coordinator, "data", {}),
         "update_interval": str(getattr(coordinator, "update_interval", None)),
         "last_exception": str(getattr(coordinator, "last_exception", "")),
-        "firmware": getattr(coordinator, "firmware", None),
+        "firmware": parse_version(
+            (getattr(coordinator, "data", None) or {}).get("MBF_POWER_MODULE_VERSION")
+        ),
     }
 
     client = getattr(coordinator, "client", None)

--- a/custom_components/neopool/entity.py
+++ b/custom_components/neopool/entity.py
@@ -79,7 +79,7 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
             # CUSTOM-ONLY START, hw_version surface for detected modules.
             hw_version=f"Detected Modules: [{self._format_modules(data)}]",
             # CUSTOM-ONLY END
-            sw_version=f"v{self.coordinator.firmware} (v{parse_version(data.get('MBF_PAR_VERSION'))})",
+            sw_version=f"v{parse_version(data.get('MBF_POWER_MODULE_VERSION'))} (v{parse_version(data.get('MBF_PAR_VERSION'))})",
             serial_number=unique_id,
         )
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -19,11 +19,11 @@ from pytest_homeassistant_custom_component.common import (
 from custom_components.neopool.const import CURRENT_VERSION, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 from homeassistant.util import dt as dt_util
 
 from . import setup_integration
-from .conftest import MOCK_POOL_DATA
+from .conftest import MOCK_POOL_DATA, MOCK_SERIAL
 
 # ---------------------------------------------------------------------------
 # Update cycle
@@ -33,13 +33,15 @@ from .conftest import MOCK_POOL_DATA
 @pytest.mark.usefixtures("mock_neopool_client")
 async def test_update_data_populates_firmware(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """The first successful read populates firmware."""
+    """The first successful read populates firmware on the device entry."""
     await setup_integration(hass, mock_config_entry)
-    coordinator = mock_config_entry.runtime_data
+    device = device_registry.async_get_device(identifiers={(DOMAIN, MOCK_SERIAL)})
+    assert device is not None
     # MBF_POWER_MODULE_VERSION = 0x1234 → "18.52"
-    assert coordinator.firmware == "18.52"
+    assert "18.52" in (device.sw_version or "")
 
 
 async def test_transient_modbus_failure_after_first_success_marks_unavailable(
@@ -107,6 +109,7 @@ async def test_corrupt_gpio_creates_repair_issue(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """A GPIO register outside 0..MAX_RELAY_GPIO opens a corrupted_gpio issue."""
     bad_data = dict(MOCK_POOL_DATA)
@@ -115,7 +118,6 @@ async def test_corrupt_gpio_creates_repair_issue(
 
     await setup_integration(hass, mock_config_entry)
 
-    issue_registry = ir.async_get(hass)
     issue = issue_registry.async_get_issue(DOMAIN, "corrupted_gpio")
     assert issue is not None
     assert issue.severity is ir.IssueSeverity.ERROR
@@ -125,10 +127,10 @@ async def test_corrupt_gpio_creates_repair_issue(
 async def test_clean_gpio_does_not_create_issue(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """A clean read does not open a corrupted_gpio issue."""
     await setup_integration(hass, mock_config_entry)
-    issue_registry = ir.async_get(hass)
     assert issue_registry.async_get_issue(DOMAIN, "corrupted_gpio") is None
 
 
@@ -136,6 +138,7 @@ async def test_corrupt_gpio_self_heals_on_next_clean_read(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    issue_registry: ir.IssueRegistry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """The corrupted_gpio issue clears once a subsequent poll reads clean values."""
@@ -144,7 +147,6 @@ async def test_corrupt_gpio_self_heals_on_next_clean_read(
     mock_neopool_client.async_read_all = AsyncMock(return_value=bad_data)
     await setup_integration(hass, mock_config_entry)
 
-    issue_registry = ir.async_get(hass)
     assert issue_registry.async_get_issue(DOMAIN, "corrupted_gpio") is not None
 
     # Recovery: registers return to valid range on the next poll.
@@ -160,9 +162,9 @@ async def test_corrupt_gpio_self_heals_on_next_clean_read(
 async def test_corrupt_gpio_clears_stale_issue_from_previous_session(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Stale issue from a previous HA session clears on first poll."""
-    issue_registry = ir.async_get(hass)
     ir.async_create_issue(
         hass,
         DOMAIN,
@@ -212,6 +214,7 @@ async def test_corrupt_gpio_updates_issue_on_value_change(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_neopool_client: MagicMock,
+    issue_registry: ir.IssueRegistry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """The repair issue details refresh when a corrupted register value changes."""
@@ -220,7 +223,6 @@ async def test_corrupt_gpio_updates_issue_on_value_change(
     mock_neopool_client.async_read_all = AsyncMock(return_value=first)
 
     await setup_integration(hass, mock_config_entry)
-    issue_registry = ir.async_get(hass)
     issue = issue_registry.async_get_issue(DOMAIN, "corrupted_gpio")
     assert issue is not None
     assert issue.translation_placeholders is not None


### PR DESCRIPTION
## 🧹 Change

Drop the dead `_firmware` attribute and `firmware` property from `NeoPoolCoordinator`. The first refresh always writes the value before entities register, so the `"?"` default is unreachable and the accessor just proxies `data["MBF_POWER_MODULE_VERSION"]` through `parse_version()`.

## 🔧 Details

- **coordinator.py** — remove `self._firmware`, remove the `firmware` property, drop the now-unused `parse_version` import.
- **entity.py** — call `parse_version(data.get("MBF_POWER_MODULE_VERSION"))` inline in `device_info`, symmetrical with the existing `MBF_PAR_VERSION` call.
- **diagnostics.py** — compute firmware inline from `coordinator.data`.
- **tests/test_coordinator.py** — adopt the `issue_registry` fixture in five tests instead of `ir.async_get(hass)`; rewrite `test_update_data_populates_firmware` to check `device_registry.sw_version` instead of the removed property.

## ✅ Verification

- `pytest --cov` — 281 passed, 100 % coverage
- `ruff check` + `ruff format --check` — clean
- `basedpyright` — 0 errors, 0 warnings
