### PR TITLE
refactor(config): ♻️ adopt OptionsFlowWithReload for options flow

### DIFF
--- a/custom_components/neopool/options_flow.py
+++ b/custom_components/neopool/options_flow.py
@@ -19,8 +19,7 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant import config_entries
-from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.config_entries import ConfigFlowResult, OptionsFlowWithReload
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 
 # CUSTOM-ONLY START
@@ -37,7 +36,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-class NeoPoolOptionsFlowHandler(config_entries.OptionsFlow):
+class NeoPoolOptionsFlowHandler(OptionsFlowWithReload):
     """Handle options flow for NeoPool integration."""
 
     def __init__(self) -> None:
@@ -152,18 +151,7 @@ class NeoPoolOptionsFlowHandler(config_entries.OptionsFlow):
             # CUSTOM-ONLY START
             data.pop("unlock_advanced", None)
             # CUSTOM-ONLY END
-            prev_options = dict(self.config_entry.options)
-            result = self.async_create_entry(title="", data=data)
-
-            if any(
-                prev_options.get(k) != data.get(k)
-                for k in set(prev_options) | set(data)
-            ):
-                self.hass.async_create_task(
-                    self.hass.config_entries.async_reload(self.config_entry.entry_id)
-                )
-
-            return result
+            return self.async_create_entry(title="", data=data)
 
         return self.async_show_form(
             step_id="init",
@@ -195,19 +183,8 @@ class NeoPoolOptionsFlowHandler(config_entries.OptionsFlow):
         )
 
         if user_input is not None:
-            prev_options = dict(self.config_entry.options)
             all_options = {**self._base_options, **user_input}
-            result = self.async_create_entry(title="", data=all_options)
-
-            if any(
-                prev_options.get(k) != all_options.get(k)
-                for k in set(prev_options) | set(all_options)
-            ):
-                self.hass.async_create_task(
-                    self.hass.config_entries.async_reload(self.config_entry.entry_id)
-                )
-
-            return result
+            return self.async_create_entry(title="", data=all_options)
 
         return self.async_show_form(
             step_id="advanced",


### PR DESCRIPTION
## 🧹 Change

`NeoPoolOptionsFlowHandler` now inherits from `OptionsFlowWithReload` instead of `OptionsFlow`. Home Assistant reloads the config entry automatically when the options flow ends with `async_create_entry(...)`, so the manual `hass.async_create_task(hass.config_entries.async_reload(...))` calls in both the init and advanced steps are dropped.

## 🔧 Details

- Both `async_step_init` and `async_step_advanced` return `self.async_create_entry(...)` directly.
- Removes the "did anything change" diff logic from both steps; every options change now triggers a reload uniformly.
- No user-visible behaviour change: options changes previously always triggered a reload too, just through hand-rolled code.

## ✅ Verification

- `pytest --cov` — 284 passed, 100 % coverage
- `ruff check` + `ruff format --check` — clean
- `basedpyright` — 0 errors, 0 warnings
