### PR TITLE
refactor(coordinator): ♻️ use self.config_entry from base class

### DIFF
--- a/custom_components/neopool/__init__.py
+++ b/custom_components/neopool/__init__.py
@@ -48,7 +48,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: NeoPoolConfigEntry) -> bool:
     """Set up the NeoPool integration from a config entry."""
     client = NeoPoolModbusClient(entry.data)
-    coordinator = NeoPoolCoordinator(hass, client, entry, entry.entry_id)
+    coordinator = NeoPoolCoordinator(hass, client, entry)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
 

--- a/custom_components/neopool/binary_sensor.py
+++ b/custom_components/neopool/binary_sensor.py
@@ -370,7 +370,7 @@ async def async_setup_entry(
     options = entry.options
 
     async_add_entities(
-        NeoPoolBinarySensor(coordinator, entry.entry_id, key, desc)
+        NeoPoolBinarySensor(coordinator, key, desc)
         for key, desc in BINARY_SENSOR_DESCRIPTIONS.items()
         if (
             (option_key := _ENTITY_OPTION_KEY.get(key)) is None
@@ -389,15 +389,16 @@ class NeoPoolBinarySensor(NeoPoolEntity, BinarySensorEntity):
     def __init__(
         self,
         coordinator: NeoPoolCoordinator,
-        entry_id: str,
         key: str,
         description: NeoPoolBinarySensorEntityDescription,
     ) -> None:
         """Initialize the binary sensor."""
-        super().__init__(coordinator, entry_id)
+        super().__init__(coordinator)
         self.entity_description = description
         self._key = key
-        self._attr_unique_id = f"{self.coordinator.entry.unique_id}_{key.lower()}"
+        self._attr_unique_id = (
+            f"{self.coordinator.config_entry.unique_id}_{key.lower()}"
+        )
 
     @property
     @override

--- a/custom_components/neopool/button.py
+++ b/custom_components/neopool/button.py
@@ -67,10 +67,12 @@ async def _press_backwash(entity: "NeoPoolButton") -> None:
             "- ignoring backwash command for %s",
             data.get("MBF_PAR_FILTVALVE_ENABLE"),
             data.get("MBF_PAR_FILTVALVE_GPIO"),
-            entity.coordinator.entry.title,
+            entity.coordinator.config_entry.title,
         )
         return
-    _LOGGER.info("Starting backwash on device '%s'", entity.coordinator.entry.title)
+    _LOGGER.info(
+        "Starting backwash on device '%s'", entity.coordinator.config_entry.title
+    )
     await entity.coordinator.client.async_set_filtration_mode("backwash")
 
 
@@ -78,7 +80,7 @@ async def _press_reset_cell_partial(entity: "NeoPoolButton") -> None:
     """Reset the partial cell-runtime counter on the device."""
     _LOGGER.info(
         "Resetting partial cell runtime counter on device '%s'",
-        entity.coordinator.entry.title,
+        entity.coordinator.config_entry.title,
     )
     await entity.coordinator.client.async_reset_user_counters()
 
@@ -122,7 +124,7 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     async_add_entities(
-        NeoPoolButton(coordinator, entry.entry_id, key, desc)
+        NeoPoolButton(coordinator, key, desc)
         for key, desc in BUTTON_DESCRIPTIONS.items()
         if desc.supported_fn is None or desc.supported_fn(coordinator.data)
     )
@@ -136,15 +138,16 @@ class NeoPoolButton(NeoPoolEntity, ButtonEntity):
     def __init__(
         self,
         coordinator: NeoPoolCoordinator,
-        entry_id: str,
         key: str,
         description: NeoPoolButtonEntityDescription,
     ) -> None:
         """Initialize the NeoPool button entity."""
-        super().__init__(coordinator, entry_id)
+        super().__init__(coordinator)
         self.entity_description = description
         self._key = key
-        self._attr_unique_id = f"{self.coordinator.entry.unique_id}_{key.lower()}"
+        self._attr_unique_id = (
+            f"{self.coordinator.config_entry.unique_id}_{key.lower()}"
+        )
 
     @override
     async def async_press(self) -> None:

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -70,7 +70,6 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         hass: HomeAssistant,
         client: NeoPoolModbusClient,
         entry: NeoPoolConfigEntry,
-        entry_id: str,
     ) -> None:
         """Initialise the NeoPool data update coordinator."""
         # CUSTOM-ONLY START, HACS-only per-instance polling-interval override.
@@ -87,10 +86,8 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             config_entry=entry,
         )
         self.client = client
-        self.entry = entry
-        self.entry_id = entry_id
-        self.auto_time_sync = self.entry.options.get(CONF_AUTO_TIME_SYNC, False)
-        self.winter_mode = self.entry.options.get(CONF_WINTER_MODE, False)
+        self.auto_time_sync = entry.options.get(CONF_AUTO_TIME_SYNC, False)
+        self.winter_mode = entry.options.get(CONF_WINTER_MODE, False)
         # Persisted in options for winter mode (no Modbus reads).
         self._capability_snapshot: dict[str, Any] = dict(
             entry.options.get(CONF_CAPABILITIES, {})
@@ -170,7 +167,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def _get_enabled_timers(self) -> list[str]:
         """Return the list of timer block names enabled in entry options."""
-        options = self.entry.options
+        options = self.config_entry.options
         enabled: list[str] = []
         for key in TIMER_BLOCKS:
             if key.startswith("relay_aux"):
@@ -209,9 +206,9 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # CUSTOM-ONLY START, HACS-only dev override hatch for live data injection.
     def _apply_dev_overrides(self, data: dict[str, Any]) -> None:
         """Apply developer override values to data, if enabled."""
-        if not self.entry.options.get(CONF_DEV_OVERRIDES_ENABLED, False):
+        if not self.config_entry.options.get(CONF_DEV_OVERRIDES_ENABLED, False):
             return
-        raw = self.entry.options.get(CONF_DEV_OVERRIDES, "{}")
+        raw = self.config_entry.options.get(CONF_DEV_OVERRIDES, "{}")
         try:
             overrides = json.loads(raw) if isinstance(raw, str) else raw
         except (
@@ -300,9 +297,9 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if new_snapshot == self._capability_snapshot:
             return
         self._capability_snapshot = new_snapshot
-        options = dict(self.entry.options)
+        options = dict(self.config_entry.options)
         options[CONF_CAPABILITIES] = new_snapshot
-        self.hass.config_entries.async_update_entry(self.entry, options=options)
+        self.hass.config_entries.async_update_entry(self.config_entry, options=options)
 
     @override
     async def _async_update_data(self) -> dict[str, Any]:
@@ -325,7 +322,7 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         await self._read_timers_into_data(data)
 
         pump_power = max(
-            0, int(self.entry.options.get(CONF_FILTRATION_PUMP_POWER, 0) or 0)
+            0, int(self.config_entry.options.get(CONF_FILTRATION_PUMP_POWER, 0) or 0)
         )
         data[CONF_FILTRATION_PUMP_POWER] = (
             pump_power if data.get("Filtration Pump") else 0
@@ -350,14 +347,14 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def set_auto_time_sync(self, enabled: bool) -> None:
         """Persist the auto_time_sync flag and refresh the entry options."""
         self.auto_time_sync = enabled
-        options = dict(self.entry.options)
+        options = dict(self.config_entry.options)
         options[CONF_AUTO_TIME_SYNC] = enabled
-        self.hass.config_entries.async_update_entry(self.entry, options=options)
+        self.hass.config_entries.async_update_entry(self.config_entry, options=options)
 
     async def set_winter_mode(self, enabled: bool) -> None:
         """Toggle winter mode and persist the capability snapshot."""
         self.winter_mode = enabled
-        options = dict(self.entry.options)
+        options = dict(self.config_entry.options)
         options[CONF_WINTER_MODE] = enabled
         if enabled:
             if self.data:
@@ -365,6 +362,6 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     k: self.data[k] for k in CAPABILITY_KEYS if k in self.data
                 }
             options[CONF_CAPABILITIES] = dict(self._capability_snapshot)
-        self.hass.config_entries.async_update_entry(self.entry, options=options)
+        self.hass.config_entries.async_update_entry(self.config_entry, options=options)
         if enabled:
             self.async_set_updated_data(dict(self._capability_snapshot))

--- a/custom_components/neopool/entity.py
+++ b/custom_components/neopool/entity.py
@@ -45,10 +45,9 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
     _attr_has_entity_name = True
     _winter_mode_active: bool = True
 
-    def __init__(self, coordinator: NeoPoolCoordinator, entry_id: str) -> None:
+    def __init__(self, coordinator: NeoPoolCoordinator) -> None:
         """Initialise the NeoPool base entity."""
         super().__init__(coordinator)
-        self._entry_id = entry_id
 
     @property
     @override
@@ -65,7 +64,7 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
     def device_info(self) -> DeviceInfo:  # pragma: no cover
         """Return device information for the entity."""
         data = self.coordinator.data or {}
-        unique_id = self.coordinator.entry.unique_id
+        unique_id = self.coordinator.config_entry.unique_id
         assert unique_id is not None
         machine_type = (get_machine_name(data) or "").strip()
         # Hayward supplies the same NeoPool-compatible controller board to

--- a/custom_components/neopool/light.py
+++ b/custom_components/neopool/light.py
@@ -73,7 +73,7 @@ async def async_setup_entry(
         return
 
     async_add_entities(
-        NeoPoolLight(coordinator, entry.entry_id, key, desc)
+        NeoPoolLight(coordinator, key, desc)
         for key, desc in LIGHT_DESCRIPTIONS.items()
         if desc.supported_fn is None or desc.supported_fn(coordinator.data)
     )
@@ -89,15 +89,16 @@ class NeoPoolLight(NeoPoolEntity, LightEntity):
     def __init__(
         self,
         coordinator: NeoPoolCoordinator,
-        entry_id: str,
         key: str,
         description: NeoPoolLightEntityDescription,
     ) -> None:
         """Initialize the NeoPool light entity."""
-        super().__init__(coordinator, entry_id)
+        super().__init__(coordinator)
         self.entity_description = description
         self._key = key
-        self._attr_unique_id = f"{self.coordinator.entry.unique_id}_{key.lower()}"
+        self._attr_unique_id = (
+            f"{self.coordinator.config_entry.unique_id}_{key.lower()}"
+        )
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/custom_components/neopool/number.py
+++ b/custom_components/neopool/number.py
@@ -283,7 +283,7 @@ async def async_setup_entry(
     options = entry.options
 
     async_add_entities(
-        NeoPoolNumber(coordinator, entry.entry_id, key, desc)
+        NeoPoolNumber(coordinator, key, desc)
         for key, desc in NUMBER_DESCRIPTIONS.items()
         if (
             (option_key := _ENTITY_OPTION_KEY.get(key)) is None
@@ -302,16 +302,17 @@ class NeoPoolNumber(NeoPoolEntity, NumberEntity):
     def __init__(
         self,
         coordinator: NeoPoolCoordinator,
-        entry_id: str,
         key: str,
         description: NeoPoolNumberEntityDescription,
     ) -> None:
         """Initialize the NeoPool number entity."""
-        super().__init__(coordinator, entry_id)
+        super().__init__(coordinator)
         self.entity_description = description
         self._key = key
         self._data_key = description.data_key or key
-        self._attr_unique_id = f"{self.coordinator.entry.unique_id}_{key.lower()}"
+        self._attr_unique_id = (
+            f"{self.coordinator.config_entry.unique_id}_{key.lower()}"
+        )
 
         self._pending_write_task: asyncio.Task[None] | None = None
         self._pending_value: float | None = None

--- a/custom_components/neopool/select.py
+++ b/custom_components/neopool/select.py
@@ -294,7 +294,7 @@ async def _write_filt_mode(entity: "NeoPoolSelect", client: Any, option: str) ->
     if option == "backwash":
         _LOGGER.info(
             'Your pool "%s" has been switched to the BACKWASH mode!',
-            NeoPoolEntity.slugify(entity.coordinator.entry.title),
+            NeoPoolEntity.slugify(entity.coordinator.config_entry.title),
         )
     value = next(
         (k for k, v in entity.entity_description.options_map.items() if v == option),
@@ -608,7 +608,7 @@ async def async_setup_entry(
     options = entry.options
 
     async_add_entities(
-        NeoPoolSelect(coordinator, entry.entry_id, key, desc)
+        NeoPoolSelect(coordinator, key, desc)
         for key, desc in SELECT_DESCRIPTIONS.items()
         if (
             (option_key := _ENTITY_OPTION_KEY.get(key)) is None
@@ -626,15 +626,16 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):
     def __init__(
         self,
         coordinator: NeoPoolCoordinator,
-        entry_id: str,
         key: str,
         description: NeoPoolSelectEntityDescription,
     ) -> None:
         """Initialize the NeoPool select entity."""
-        super().__init__(coordinator, entry_id)
+        super().__init__(coordinator)
         self.entity_description = description
         self.key = key
-        self._attr_unique_id = f"{self.coordinator.entry.unique_id}_{key.lower()}"
+        self._attr_unique_id = (
+            f"{self.coordinator.config_entry.unique_id}_{key.lower()}"
+        )
 
     @override
     async def async_select_option(self, option: str) -> None:
@@ -664,7 +665,7 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):
             # on controllers without an auto valve (present in `data`-driven filter).
             if (
                 self.key == "MBF_PAR_FILT_MODE"
-                and self.coordinator.entry.options.get(
+                and self.coordinator.config_entry.options.get(
                     CONF_ENABLE_BACKWASH_OPTION, False
                 )
                 and "backwash" not in options

--- a/custom_components/neopool/sensor.py
+++ b/custom_components/neopool/sensor.py
@@ -316,7 +316,7 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     entities: list[SensorEntity] = [
-        NeoPoolSensor(coordinator, entry.entry_id, key, desc)
+        NeoPoolSensor(coordinator, key, desc)
         for key, desc in SENSOR_DESCRIPTIONS.items()
         if key != CONF_FILTRATION_PUMP_POWER
         and (desc.supported_fn is None or desc.supported_fn(coordinator.data))
@@ -327,14 +327,11 @@ async def async_setup_entry(
         entities.append(
             NeoPoolSensor(
                 coordinator,
-                entry.entry_id,
                 CONF_FILTRATION_PUMP_POWER,
                 SENSOR_DESCRIPTIONS[CONF_FILTRATION_PUMP_POWER],
             )
         )
-        entities.append(
-            NeoPoolFiltrationEnergySensor(coordinator, entry.entry_id, pump_power)
-        )
+        entities.append(NeoPoolFiltrationEnergySensor(coordinator, pump_power))
 
     async_add_entities(entities)
 
@@ -367,15 +364,16 @@ class NeoPoolSensor(NeoPoolEntity, SensorEntity):
     def __init__(
         self,
         coordinator: NeoPoolCoordinator,
-        entry_id: str,
         key: str,
         description: NeoPoolSensorEntityDescription,
     ) -> None:
         """Initialize the NeoPool sensor entity."""
-        super().__init__(coordinator, entry_id)
+        super().__init__(coordinator)
         self.entity_description = description
         self._key = key
-        self._attr_unique_id = f"{self.coordinator.entry.unique_id}_{key.lower()}"
+        self._attr_unique_id = (
+            f"{self.coordinator.config_entry.unique_id}_{key.lower()}"
+        )
 
     @property
     @override
@@ -395,7 +393,9 @@ class NeoPoolSensor(NeoPoolEntity, SensorEntity):
 
     def _filtration_gate_blocks(self) -> bool:
         """Return True if the filtration-off gate hides the live reading."""
-        if self.coordinator.entry.options.get(CONF_MEASURE_WHEN_FILTRATION_OFF, False):
+        if self.coordinator.config_entry.options.get(
+            CONF_MEASURE_WHEN_FILTRATION_OFF, False
+        ):
             return False
         return self.coordinator.data.get("Filtration Pump") is False
 
@@ -451,13 +451,14 @@ class NeoPoolFiltrationEnergySensor(NeoPoolEntity, RestoreSensor):
     def __init__(
         self,
         coordinator: NeoPoolCoordinator,
-        entry_id: str,
         pump_power_w: int,
     ) -> None:
         """Initialise the filtration-pump energy sensor."""
-        super().__init__(coordinator, entry_id)
+        super().__init__(coordinator)
         self._pump_power_w = pump_power_w
-        self._attr_unique_id = f"{coordinator.entry.unique_id}_filtration_pump_energy"
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.unique_id}_filtration_pump_energy"
+        )
         self._total_wh: float = 0.0
         self._last_update: datetime | None = None
         self._last_pump_on: bool = False

--- a/custom_components/neopool/switch.py
+++ b/custom_components/neopool/switch.py
@@ -295,7 +295,7 @@ async def async_setup_entry(
     options = entry.options
 
     async_add_entities(
-        NeoPoolSwitch(coordinator, entry.entry_id, key, desc)
+        NeoPoolSwitch(coordinator, key, desc)
         for key, desc in SWITCH_DESCRIPTIONS.items()
         if (
             (option_key := _ENTITY_OPTION_KEY.get(key)) is None
@@ -321,15 +321,16 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
     def __init__(
         self,
         coordinator: NeoPoolCoordinator,
-        entry_id: str,
         key: str,
         description: NeoPoolSwitchEntityDescription,
     ) -> None:
         """Initialize the NeoPool switch entity."""
-        super().__init__(coordinator, entry_id)
+        super().__init__(coordinator)
         self.entity_description = description
         self.key = key
-        self._attr_unique_id = f"{self.coordinator.entry.unique_id}_{key.lower()}"
+        self._attr_unique_id = (
+            f"{self.coordinator.config_entry.unique_id}_{key.lower()}"
+        )
 
         # The winter_mode switch itself must remain available while winter mode is on.
         if description.ha_setting == _HA_SETTING_WINTER_MODE:

--- a/custom_components/neopool/time.py
+++ b/custom_components/neopool/time.py
@@ -104,7 +104,7 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     async_add_entities(
-        NeoPoolTime(coordinator, entry.entry_id, key, desc)
+        NeoPoolTime(coordinator, key, desc)
         for key, desc in TIME_DESCRIPTIONS.items()
         if desc.supported_fn is None
         or desc.supported_fn(coordinator.data, entry.options)
@@ -119,15 +119,16 @@ class NeoPoolTime(NeoPoolEntity, TimeEntity):
     def __init__(
         self,
         coordinator: NeoPoolCoordinator,
-        entry_id: str,
         key: str,
         description: NeoPoolTimeEntityDescription,
     ) -> None:
         """Initialize the entity."""
-        super().__init__(coordinator, entry_id)
+        super().__init__(coordinator)
         self.entity_description = description
         self._key = key
-        self._attr_unique_id = f"{self.coordinator.entry.unique_id}_{key.lower()}"
+        self._attr_unique_id = (
+            f"{self.coordinator.config_entry.unique_id}_{key.lower()}"
+        )
 
         self._pending_write_task: asyncio.Task[None] | None = None
         self._debounce_delay = _DEBOUNCE_DELAY
@@ -186,7 +187,7 @@ class NeoPoolTime(NeoPoolEntity, TimeEntity):
             DOMAIN,
             "set_timer",
             {
-                "entry_id": self._entry_id,
+                "entry_id": self.coordinator.config_entry.entry_id,
                 "timer": block,
                 "start": start,
                 "stop": stop,


### PR DESCRIPTION
## ♻️ Refactor

Unify the coordinator on `self.config_entry` from the `DataUpdateCoordinator` base class instead of a duplicate `self.entry` / `self.entry_id`.

### 🔧 Changes

- 🗑️ Drop `self.entry` and `self.entry_id` from `NeoPoolCoordinator`
- 🗑️ Drop `entry_id` parameter from `NeoPoolCoordinator.__init__` (the base class already holds it via `config_entry=entry` in `super().__init__`)
- 🗑️ Drop `entry_id` parameter from `NeoPoolEntity.__init__` (no platform entity needs it anymore)
- ♻️ Migrate every consumer (`binary_sensor`, `button`, `light`, `number`, `select`, `sensor`, `switch`, `time`, `entity`) to `self.coordinator.config_entry`
- ♻️ In `time.py`, read `self.coordinator.config_entry.entry_id` directly for the service call instead of a stored `_entry_id`

### 💡 Motivation

`DataUpdateCoordinator` already exposes `config_entry` as a public attribute when `config_entry=entry` is passed to `super().__init__`. The extra `self.entry` was shadowing without added value and diverged from the HA core convention.

### ✅ Verification

- 🧪 **pytest**: 310 passed, 17 snapshots pass
- 📊 **coverage**: 100% (1685/1685 stmts)
- 🔍 **basedpyright**: 0 errors
- 🎨 **ruff check**: all checks passed
- 🎨 **ruff format --check**: 47 files already formatted

### 📦 Diff summary

```
 11 files changed, 71 insertions(+), 65 deletions(-)
```

### ⚠️ Behavioral impact

None. The refactor is a pure internal rename; no service signatures, entity contracts, or user-facing behaviour change.
