### PR TITLE
refactor: ♻️ adopt merged-copy pattern for optimistic updates

### DIFF
--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -310,6 +310,11 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         try:
             data = await self.client.async_read_all()
+            await self._read_timers_into_data(data)
+
+            if self.auto_time_sync and is_device_time_out_of_sync(data, self.hass):
+                _LOGGER.debug("Device time is out of sync, updating")
+                await self.client.async_sync_device_time(prepare_device_time(self.hass))
         except (NeoPoolError, OSError, TimeoutError) as err:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -319,18 +324,12 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self._check_gpio_registers(data)
 
-        await self._read_timers_into_data(data)
-
         pump_power = max(
             0, int(self.config_entry.options.get(CONF_FILTRATION_PUMP_POWER, 0) or 0)
         )
         data[CONF_FILTRATION_PUMP_POWER] = (
             pump_power if data.get("Filtration Pump") else 0
         )
-
-        if self.auto_time_sync and is_device_time_out_of_sync(data, self.hass):
-            _LOGGER.debug("Device time is out of sync, updating")
-            await self.client.async_sync_device_time(prepare_device_time(self.hass))
 
         # CUSTOM-ONLY START
         self._apply_dev_overrides(data)

--- a/custom_components/neopool/light.py
+++ b/custom_components/neopool/light.py
@@ -51,8 +51,8 @@ LIGHT_DESCRIPTIONS: dict[str, NeoPoolLightEntityDescription] = {
         key="light",
         translation_key="light",
         supported_fn=lambda data: (
-            "MBF_PAR_LIGHTING_GPIO" not in data
-            or is_valid_relay_gpio(data["MBF_PAR_LIGHTING_GPIO"] or 0)
+            "MBF_PAR_LIGHTING_GPIO" in data
+            and is_valid_relay_gpio(data["MBF_PAR_LIGHTING_GPIO"] or 0)
         ),
     ),
 }
@@ -127,10 +127,7 @@ class NeoPoolLight(NeoPoolEntity, LightEntity):
                 translation_key="relay_in_auto_mode",
             ) from err
 
-        # Optimistic update + schedule follow-up.
-        data = self.coordinator.data
-        data.update(overrides)
-        self.coordinator.async_set_updated_data(data)
+        self.coordinator.async_set_updated_data({**self.coordinator.data, **overrides})
         self.coordinator.request_refresh_with_followup()
 
     @property

--- a/custom_components/neopool/number.py
+++ b/custom_components/neopool/number.py
@@ -362,8 +362,9 @@ class NeoPoolNumber(NeoPoolEntity, NumberEntity):
                 )
             else:  # pragma: no cover - description validated upstream
                 return
-            self.coordinator.data.update(overrides)
-            self.coordinator.async_set_updated_data(self.coordinator.data)
+            self.coordinator.async_set_updated_data(
+                {**self.coordinator.data, **overrides}
+            )
             await self.coordinator.async_request_refresh()
         except asyncio.CancelledError:  # pragma: no cover
             pass

--- a/custom_components/neopool/select.py
+++ b/custom_components/neopool/select.py
@@ -195,8 +195,8 @@ async def _write_config_option(
     write_val = max(0, value + desc.write_offset)
     await client.async_set_config_option(desc.config_kind, write_val)
     await asyncio.sleep(0.2)
-    entity.apply_optimistic_update(value)
-    entity.coordinator.async_set_updated_data(entity.coordinator.data)
+    overrides = entity.apply_optimistic_update(value)
+    entity.coordinator.async_set_updated_data({**entity.coordinator.data, **overrides})
     entity.coordinator.request_refresh_with_followup()
 
 
@@ -254,8 +254,7 @@ async def _write_relay_mode(entity: "NeoPoolSelect", client: Any, option: str) -
             translation_key="timer_failed",
             translation_placeholders={"error": str(err)},
         ) from err
-    entity.coordinator.data.update(overrides)
-    entity.coordinator.async_set_updated_data(entity.coordinator.data)
+    entity.coordinator.async_set_updated_data({**entity.coordinator.data, **overrides})
     entity.coordinator.request_refresh_with_followup()
 
 
@@ -300,8 +299,8 @@ async def _write_filt_mode(entity: "NeoPoolSelect", client: Any, option: str) ->
         (k for k, v in entity.entity_description.options_map.items() if v == option),
         None,
     )
-    entity.apply_optimistic_update(value)
-    entity.coordinator.async_set_updated_data(entity.coordinator.data)
+    overrides = entity.apply_optimistic_update(value)
+    entity.coordinator.async_set_updated_data({**entity.coordinator.data, **overrides})
     entity.coordinator.request_refresh_with_followup()
 
 
@@ -319,8 +318,8 @@ async def _write_default_register(
     if value is None:  # pragma: no cover
         return
     await client.async_set_config_option(desc.config_kind, value)
-    entity.apply_optimistic_update(value)
-    entity.coordinator.async_set_updated_data(entity.coordinator.data)
+    overrides = entity.apply_optimistic_update(value)
+    entity.coordinator.async_set_updated_data({**entity.coordinator.data, **overrides})
     entity.coordinator.request_refresh_with_followup()
 
 
@@ -697,19 +696,19 @@ class NeoPoolSelect(NeoPoolEntity, SelectEntity):
 
         return list(desc.options_map.values())
 
-    def apply_optimistic_update(self, value: int | None) -> None:
-        """Apply an optimistic state update to coordinator data."""
+    def apply_optimistic_update(self, value: int | None) -> dict[str, Any]:
+        """Return the coordinator-data overrides for an optimistic state update."""
         if value is None:  # pragma: no cover
-            return
+            return {}
         desc = self.entity_description
-        data = self.coordinator.data
         if self.key in (
             "MBF_PAR_FILT_MODE",
             "MBF_PAR_FILTVALVE_MODE",
         ):
-            data[self.key] = value
-        elif desc.select_type == "mapped_register":
-            data[self.key] = value
+            return {self.key: value}
+        if desc.select_type == "mapped_register":
+            return {self.key: value}
+        return {}  # pragma: no cover - selects without optimistic update
 
     @property
     @override

--- a/custom_components/neopool/switch.py
+++ b/custom_components/neopool/switch.py
@@ -377,8 +377,7 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
 
         # Merge the library's optimistic-update dict into the coordinator cache
         # so the UI reflects the new state immediately.
-        self.coordinator.data.update(overrides)
-        self.coordinator.async_set_updated_data(self.coordinator.data)
+        self.coordinator.async_set_updated_data({**self.coordinator.data, **overrides})
         self.coordinator.request_refresh_with_followup()
 
     @property

--- a/custom_components/neopool/time.py
+++ b/custom_components/neopool/time.py
@@ -151,8 +151,9 @@ class NeoPoolTime(NeoPoolEntity, TimeEntity):
     async def async_set_value(self, value: dt_time) -> None:
         """Apply optimistically, then debounce-write to the device."""
         seconds = value.hour * 3600 + value.minute * 60 + value.second
-        self.coordinator.data[self._key] = seconds
-        self.coordinator.async_set_updated_data(self.coordinator.data)
+        self.coordinator.async_set_updated_data(
+            {**self.coordinator.data, self._key: seconds}
+        )
 
         if self._pending_write_task is not None and not self._pending_write_task.done():
             self._pending_write_task.cancel()

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -320,6 +320,12 @@ async def test_masked_number_write_preserves_other_byte(
 
     mock_neopool_client.async_set_masked_register.reset_mock()
     await _set_value(hass, cover_entity_id, 50)
+    # Reflect the write in future polls so async_request_refresh doesn't stomp
+    # the optimistic-update overrides with a stale read.
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_HIDRO_COVER_REDUCTION": 0x0C32,
+    }
     await _flush_debounce(hass, cover_obj)
 
     # Entity passes the raw *field* value (50, not the packed 0x0C32).


### PR DESCRIPTION
## Summary

Adopt a merged-copy pattern for optimistic writes so entities never mutate the coordinator's currently-published data dict in place.

## Changes

### coordinator.py

- Move timer polling and device-time sync inside the existing `NeoPoolError / OSError / TimeoutError` try/except so any Modbus I/O during an update turns into a translated `UpdateFailed` instead of crashing the coordinator loop.

### light.py

- Tighten `supported_fn` so the entity registers only when `MBF_PAR_LIGHTING_GPIO` is present and valid, instead of falling back to permissive registration when the key is absent.
- Publish `{**coordinator.data, **overrides}` on optimistic writes.

### switch / number / time

- Replace `data.update(overrides); async_set_updated_data(data)` with a merged-copy publish across all optimistic-update sites.

### select.py

- `apply_optimistic_update` now returns the overrides dict instead of mutating `coordinator.data`. Callers merge the result into a fresh dict and publish it via `async_set_updated_data`.

### tests

- `test_masked_number_write_preserves_other_byte`: mock `async_read_all` to return the post-write register value so the follow-up refresh does not stomp the optimistic override with a stale read.

## Verification

- ✅ pytest: 301 passed, 100% coverage (1643/1643)
- ✅ basedpyright: 0 errors
- ✅ ruff check / ruff format: clean
