### PR TITLE
feat(switch): ✨ guard manual filtration against active boost mode

### DIFF
--- a/.github/workflows/typecheck.yaml
+++ b/.github/workflows/typecheck.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install basedpyright homeassistant-stubs 'neopool-modbus>=4.2.1'
+          pip install basedpyright homeassistant-stubs 'neopool-modbus>=4.3.0'
 
       - name: Run BasedPyright
         run: basedpyright custom_components/neopool

--- a/custom_components/neopool/manifest.json
+++ b/custom_components/neopool/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/svasek/homeassistant-neopool-modbus/issues",
   "loggers": ["neopool_modbus"],
-  "requirements": ["neopool-modbus>=4.2.1"],
+  "requirements": ["neopool-modbus>=4.3.0"],
   "version": "6.4.0"
 }

--- a/custom_components/neopool/strings.json
+++ b/custom_components/neopool/strings.json
@@ -488,6 +488,9 @@
     "entry_not_found": {
       "message": "No NeoPool config entry found for entry_id {entry_id}"
     },
+    "filtration_boost_active": {
+      "message": "Filtration cannot be switched on or off while boost mode is active. Turn off boost mode first."
+    },
     "filtration_not_manual_mode": {
       "message": "Filtration can only be switched on or off when the controller is in manual filtration mode. Change the filtration mode to Manual first."
     },

--- a/custom_components/neopool/switch.py
+++ b/custom_components/neopool/switch.py
@@ -24,6 +24,7 @@ from neopool_modbus.capabilities import (
     is_hydrolysis_present,
     is_temperature_active,
 )
+from neopool_modbus.decoders import is_cell_boost_active
 from neopool_modbus.exceptions import NeoPoolError
 from neopool_modbus.registers import (
     HIDRO_COVER_ENABLE_BIT,
@@ -88,14 +89,19 @@ async def _write_manual_filtration(
 ) -> dict[str, Any]:
     """Toggle the manual filtration pump.
 
-    The controller only honours the pump register while it is in manual
-    filtration mode; validate up-front so the user gets a translated error
-    instead of a raw library exception.
+    Pre-check manual mode and boost up-front so the user gets a translated
+    error instead of a raw library exception.
     """
-    if entity.coordinator.data.get("MBF_PAR_FILT_MODE") != 0:
+    data = entity.coordinator.data
+    if data.get("MBF_PAR_FILT_MODE") != 0:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="filtration_not_manual_mode",
+        )
+    if is_cell_boost_active(data.get("MBF_CELL_BOOST")):
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="filtration_boost_active",
         )
     return await client.async_set_manual_filtration(state)
 
@@ -308,6 +314,7 @@ async def async_setup_entry(
 _INVALID_STATE_TRANSLATION_KEY: dict[InvalidStateReason, str] = {
     InvalidStateReason.RELAY_IN_AUTO_MODE: "relay_in_auto_mode",
     InvalidStateReason.FILTRATION_NOT_IN_MANUAL_MODE: "filtration_not_manual_mode",
+    InvalidStateReason.FILTRATION_BOOST_ACTIVE: "filtration_boost_active",
 }
 
 

--- a/custom_components/neopool/translations/cs.json
+++ b/custom_components/neopool/translations/cs.json
@@ -709,6 +709,9 @@
         "entry_not_found": {
             "message": "Nebyla nalezena konfigurace NeoPool pro entry_id {entry_id}"
         },
+        "filtration_boost_active": {
+            "message": "Filtraci nelze zapnout ani vypnout, když je aktivní režim boost. Nejprve vypněte režim boost."
+        },
         "filtration_not_manual_mode": {
             "message": "Filtraci lze zapnout nebo vypnout jen v ručním režimu filtrace. Nejprve přepněte režim filtrace na Ruční."
         },

--- a/custom_components/neopool/translations/de.json
+++ b/custom_components/neopool/translations/de.json
@@ -709,6 +709,9 @@
         "entry_not_found": {
             "message": "Kein NeoPool-Konfigurationseintrag für entry_id {entry_id} gefunden"
         },
+        "filtration_boost_active": {
+            "message": "Die Filtration kann nicht ein- oder ausgeschaltet werden, während der Boost-Modus aktiv ist. Schalten Sie zuerst den Boost-Modus aus."
+        },
         "filtration_not_manual_mode": {
             "message": "Die Filtration kann nur im manuellen Filtrationsmodus ein- oder ausgeschaltet werden. Wechseln Sie den Filtrationsmodus zuerst auf Manuell."
         },

--- a/custom_components/neopool/translations/en.json
+++ b/custom_components/neopool/translations/en.json
@@ -709,6 +709,9 @@
         "entry_not_found": {
             "message": "No NeoPool config entry found for entry_id {entry_id}"
         },
+        "filtration_boost_active": {
+            "message": "Filtration cannot be switched on or off while boost mode is active. Turn off boost mode first."
+        },
         "filtration_not_manual_mode": {
             "message": "Filtration can only be switched on or off when the controller is in manual filtration mode. Change the filtration mode to Manual first."
         },

--- a/custom_components/neopool/translations/es.json
+++ b/custom_components/neopool/translations/es.json
@@ -709,6 +709,9 @@
         "entry_not_found": {
             "message": "No se encontró la entrada de configuración NeoPool para entry_id {entry_id}"
         },
+        "filtration_boost_active": {
+            "message": "La filtración no se puede encender ni apagar mientras el modo boost está activo. Desactive primero el modo boost."
+        },
         "filtration_not_manual_mode": {
             "message": "La filtración solo se puede encender o apagar cuando el controlador está en modo de filtración manual. Cambie primero el modo de filtración a Manual."
         },

--- a/custom_components/neopool/translations/fr.json
+++ b/custom_components/neopool/translations/fr.json
@@ -709,6 +709,9 @@
         "entry_not_found": {
             "message": "Aucune entrée de configuration NeoPool trouvée pour entry_id {entry_id}"
         },
+        "filtration_boost_active": {
+            "message": "La filtration ne peut pas être activée ou désactivée lorsque le mode boost est actif. Désactivez d'abord le mode boost."
+        },
         "filtration_not_manual_mode": {
             "message": "La filtration ne peut être activée ou désactivée qu'en mode de filtration manuel. Changez d'abord le mode de filtration sur Manuel."
         },

--- a/custom_components/neopool/translations/it.json
+++ b/custom_components/neopool/translations/it.json
@@ -709,6 +709,9 @@
         "entry_not_found": {
             "message": "Nessuna voce di configurazione NeoPool trovata per entry_id {entry_id}"
         },
+        "filtration_boost_active": {
+            "message": "La filtrazione non può essere accesa o spenta mentre la modalità boost è attiva. Disattivare prima la modalità boost."
+        },
         "filtration_not_manual_mode": {
             "message": "La filtrazione può essere accesa o spenta solo quando il controller è in modalità filtrazione manuale. Impostare prima la modalità di filtrazione su Manuale."
         },

--- a/custom_components/neopool/translations/pl.json
+++ b/custom_components/neopool/translations/pl.json
@@ -709,6 +709,9 @@
         "entry_not_found": {
             "message": "Nie znaleziono wpisu konfiguracji NeoPool dla entry_id {entry_id}"
         },
+        "filtration_boost_active": {
+            "message": "Filtracji nie można włączyć ani wyłączyć, gdy tryb boost jest aktywny. Najpierw wyłącz tryb boost."
+        },
         "filtration_not_manual_mode": {
             "message": "Filtrację można włączyć lub wyłączyć tylko w ręcznym trybie filtracji. Najpierw zmień tryb filtracji na Ręczny."
         },

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Runtime dependency (Modbus communication via NeoPool library)
-neopool-modbus>=4.2.1
+neopool-modbus>=4.3.0
 
 # Type stubs for Home Assistant Core
 homeassistant-stubs

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 from neopool_modbus import InvalidStateReason, NeoPoolInvalidStateError
+from neopool_modbus.decoders import encode_cell_boost
 from neopool_modbus.exceptions import NeoPoolConnectionError
 from neopool_modbus.registers import (
     BinaryConfigFlag,
@@ -115,6 +116,37 @@ async def test_manual_filtration_turn_on_raises_when_not_manual_mode(
     with pytest.raises(ServiceValidationError):
         await _turn_off(hass, "switch.neopool_filtration")
     assert mock_neopool_client.async_write_register.await_count == 0
+    assert mock_neopool_client.async_set_manual_filtration.await_count == 0
+
+
+async def test_manual_filtration_raises_when_boost_active(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_neopool_client: MagicMock,
+    freezer,
+) -> None:
+    """Manual mode (FILT_MODE=0) but active boost: the pre-check must block."""
+    await setup_integration(hass, mock_config_entry)
+
+    # Manual mode, but a cell boost is active.
+    mock_neopool_client.async_read_all.return_value = {
+        **MOCK_POOL_DATA,
+        "MBF_PAR_FILT_MODE": 0,
+        "MBF_CELL_BOOST": encode_cell_boost("active"),
+    }
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    mock_neopool_client.async_set_manual_filtration.reset_mock()
+    with pytest.raises(ServiceValidationError) as exc:
+        await _turn_on(hass, "switch.neopool_filtration")
+    assert exc.value.translation_key == "filtration_boost_active"
+    assert mock_neopool_client.async_set_manual_filtration.await_count == 0
+
+    with pytest.raises(ServiceValidationError) as exc:
+        await _turn_off(hass, "switch.neopool_filtration")
+    assert exc.value.translation_key == "filtration_boost_active"
     assert mock_neopool_client.async_set_manual_filtration.await_count == 0
 
 
@@ -535,6 +567,46 @@ async def test_filtration_switch_maps_filtration_reason_to_dedicated_key(
     with pytest.raises(ServiceValidationError) as exc:
         await _turn_on(hass, entity_id)
     assert exc.value.translation_key == "filtration_not_manual_mode"
+
+
+async def test_filtration_switch_maps_boost_reason_to_dedicated_key(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_neopool_client: MagicMock,
+) -> None:
+    """A FILTRATION_BOOST_ACTIVE reason from the lib routes to the boost key.
+
+    Fail-safe branch: both pre-checks pass (manual mode, boost inactive in
+    cache), but the lib rejects because a boost started after the last poll.
+    """
+    await setup_integration(hass, mock_config_entry)
+    registry = er.async_get(hass)
+    entries = [
+        e
+        for e in er.async_entries_for_config_entry(registry, mock_config_entry.entry_id)
+        if e.domain == SWITCH_DOMAIN
+        and e.unique_id.endswith("_mbf_par_filt_manual_state")
+    ]
+    assert entries
+    entity_id = entries[0].entity_id
+
+    # Bypass both custom pre-checks: manual mode, boost inactive in cache.
+    coordinator = mock_config_entry.runtime_data
+    coordinator.data["MBF_PAR_FILT_MODE"] = 0
+    coordinator.data["MBF_CELL_BOOST"] = 0
+    coordinator.async_set_updated_data(coordinator.data)
+    await hass.async_block_till_done()
+
+    mock_neopool_client.async_set_manual_filtration.side_effect = (
+        NeoPoolInvalidStateError(
+            "cell boost is active",
+            reason=InvalidStateReason.FILTRATION_BOOST_ACTIVE,
+        )
+    )
+
+    with pytest.raises(ServiceValidationError) as exc:
+        await _turn_on(hass, entity_id)
+    assert exc.value.translation_key == "filtration_boost_active"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## ✨ Summary

The pool controller forces the filtration pump ON for the entire duration of a cell boost and ignores manual pump toggling while the boost runs. Switching filtration on or off from Home Assistant during a boost therefore did nothing on the device, with no feedback to the user.

This guards the manual filtration switch against an active boost, symmetric with the existing manual-mode guard: the user gets an immediate translated error and the write is never sent.

## 🔧 Changes

- `switch.py`: pre-check in `_write_manual_filtration` raises `ServiceValidationError` (`filtration_boost_active`) when a boost is active, using the library `is_cell_boost_active` helper. Immediate translated error, no Modbus round-trip.
- `switch.py`: map `InvalidStateReason.FILTRATION_BOOST_ACTIVE` in `_INVALID_STATE_TRANSLATION_KEY` as a fail-safe, so a boost that starts between the last poll and the write is still translated correctly. This mirrors how the manual-mode guard works (pre-check plus reason mapping).
- Add the `filtration_boost_active` exception string to `strings.json` and all seven translations.
- Bump `neopool-modbus` to `>=4.3.0` in `manifest.json`, `requirements-dev.txt`, and the typecheck workflow. 4.3.0 introduces the `FILTRATION_BOOST_ACTIVE` reason and the `is_cell_boost_active` helper.

## ✅ Tests

- `test_manual_filtration_raises_when_boost_active`: manual mode with an active boost blocks via the pre-check, no write.
- `test_filtration_switch_maps_boost_reason_to_dedicated_key`: both pre-checks pass but the lib raises `FILTRATION_BOOST_ACTIVE`, and it routes to the `filtration_boost_active` key.
- Full suite: 316 passed, 100% coverage. `basedpyright` 0 errors, `ruff check` and `ruff format --check` clean, all translation JSON valid.
