### PR TITLE
fix(select): 🐛 show boost and filtration speed changes without delay

### DIFF
--- a/custom_components/neopool/select.py
+++ b/custom_components/neopool/select.py
@@ -194,7 +194,6 @@ async def _write_config_option(
             return
     write_val = max(0, value + desc.write_offset)
     await client.async_set_config_option(desc.config_kind, write_val)
-    await asyncio.sleep(0.2)
     overrides = entity.apply_optimistic_update(value)
     entity.coordinator.async_set_updated_data({**entity.coordinator.data, **overrides})
     entity.coordinator.request_refresh_with_followup()
@@ -246,9 +245,8 @@ async def _write_relay_mode(entity: "NeoPoolSelect", client: Any, option: str) -
 
 async def _write_cell_boost(entity: "NeoPoolSelect", client: Any, option: str) -> None:
     """Encode the cell boost mode into the composite cell-status register."""
-    del entity
     await client.async_set_cell_boost(option)
-    await asyncio.sleep(0.2)
+    entity.coordinator.request_refresh_with_followup()
 
 
 async def _write_filtration_speed(
@@ -264,7 +262,7 @@ async def _write_filtration_speed(
             translation_key="filtration_speed_not_manual_mode",
         )
     await client.async_set_filtration_speed(option)
-    await asyncio.sleep(0.2)
+    entity.coordinator.request_refresh_with_followup()
 
 
 async def _write_filt_mode(entity: "NeoPoolSelect", client: Any, option: str) -> None:


### PR DESCRIPTION
## 🐛 Problem

Changing the **cell boost** mode (and, on variable-speed pumps, the **filtration speed**) did not update the UI immediately. The device applied the change right away, but Home Assistant only reflected it on the next regular poll interval.

The root cause: `_write_cell_boost` and `_write_filtration_speed` were the only "state" select writers that did not schedule a coordinator refresh after writing. They just called the library setter and slept for `0.2s`, which had no effect on the cached coordinator data.

## ✨ Fix

`custom_components/neopool/select.py`:

- 🔄 `_write_cell_boost` and `_write_filtration_speed` now call `request_refresh_with_followup()` after the write, matching the pattern already used by `_write_timer_period`. This schedules a follow-up poll so the UI reflects the real device state without waiting for the scan interval.
- 🧹 Removed the blocking `sleep(0.2)` stubs, which only delayed the event loop without refreshing any state.
- 🧹 Dropped a redundant `sleep(0.2)` in `_write_config_option`, where the optimistic update already refreshes the UI immediately.

## 📝 Why not an optimistic cache update?

The library setters `async_set_cell_boost` and `async_set_filtration_speed` return the raw write dict (`address` / `value` / `confirmed`), not a coordinator-data key that the decoders read (`MBF_CELL_BOOST`, `MBF_PAR_FILTRATION_CONF`). Merging that into the cache would not produce an immediate optimistic effect and would only pollute it, so the follow-up refresh is the correct mechanism here.

## ✅ Verification

- 🧪 316 passed, 100% coverage
- 🔍 basedpyright: 0 errors
- 🎨 ruff check + format: clean

## 🔎 Scope

Audited every other write path (`number`, `time`, `light`, `switch`, `button`, `services`) — all already apply an optimistic update or a follow-up refresh. This fix is scoped to `select.py`.
