### PR TITLE
fix(switch): 🐛 stop gating high-temp shutdown on cover sensor option

### DIFF
--- a/custom_components/neopool/switch.py
+++ b/custom_components/neopool/switch.py
@@ -313,7 +313,6 @@ SWITCH_DESCRIPTIONS: dict[str, NeoPoolSwitchEntityDescription] = {
 # Entities gated on a config-entry option (in addition to their supported_fn).
 _ENTITY_OPTION_KEY: dict[str, str] = {
     "MBF_PAR_HIDRO_COVER_ENABLE": CONF_USE_COVER_SENSOR,
-    "MBF_PAR_HIDRO_TEMP_SHUTDOWN": CONF_USE_COVER_SENSOR,
     "aux1": CONF_USE_AUX1,
     "aux2": CONF_USE_AUX2,
     "aux3": CONF_USE_AUX3,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ homeassistant-stubs
 pytest
 pytest-cov
 pytest-asyncio
-pytest-homeassistant-custom-component>=0.13.344
+pytest-homeassistant-custom-component>=0.13.355
 syrupy
 
 # Linting & formatting

--- a/tests/snapshots/test_number.ambr
+++ b/tests/snapshots/test_number.ambr
@@ -39,7 +39,7 @@
       'supported_features': 0,
       'translation_key': 'cl1',
       'unique_id': '1234567890_mbf_par_cl1',
-      'unit_of_measurement': 'ppm',
+      'unit_of_measurement': <UnitOfRatio.PARTS_PER_MILLION: 'ppm'>,
     }),
     EntityRegistryEntrySnapshot({
       'aliases': list([

--- a/tests/snapshots/test_sensor.ambr
+++ b/tests/snapshots/test_sensor.ambr
@@ -870,7 +870,7 @@
       'supported_features': 0,
       'translation_key': 'measure_cl',
       'unique_id': '1234567890_mbf_measure_cl',
-      'unit_of_measurement': 'ppm',
+      'unit_of_measurement': <UnitOfRatio.PARTS_PER_MILLION: 'ppm'>,
     }),
     EntityRegistryEntrySnapshot({
       'aliases': list([


### PR DESCRIPTION
## 🐛 What

`MBF_PAR_HIDRO_TEMP_SHUTDOWN` (Enable hydrolysis shutdown on high temperature) was gated on the `CONF_USE_COVER_SENSOR` option in `_ENTITY_OPTION_KEY`. That flag is a hydrolysis/temperature configuration setting and has nothing to do with a pool cover, so the switch stayed hidden unless the user opted into a cover sensor.

## 🔧 Change

- Remove the `MBF_PAR_HIDRO_TEMP_SHUTDOWN -> CONF_USE_COVER_SENSOR` entry from `_ENTITY_OPTION_KEY`.
- The switch now registers purely on its `supported_fn` (hydrolysis present + temperature active), consistent with the other configuration-flag switches that require no opt-in.
- `MBF_PAR_HIDRO_COVER_ENABLE` (cover reduction) keeps its cover-sensor gate, since that feature genuinely depends on a cover.
- Regenerate the `test_sensor` / `test_number` ppm snapshots for HA 2026.8, where `CONCENTRATION_PARTS_PER_MILLION` is now a `UnitOfRatio` enum, and raise the `pytest-homeassistant-custom-component` floor to `0.13.355` so CI runs against that HA version. These two snapshots fail on `main` today regardless of this fix.

## ✅ Verification

- 🟢 `pytest` - 326 passed, 100% coverage
- 🟢 `ruff check` + `ruff format --check` - clean
- 🟢 `basedpyright` - 0 errors
