### PR TITLE
refactor(time): ♻️ write timers directly via the client

### DIFF
--- a/custom_components/neopool/time.py
+++ b/custom_components/neopool/time.py
@@ -20,11 +20,13 @@ from dataclasses import dataclass
 from datetime import time as dt_time
 from typing import Any, Literal, override
 
-from neopool_modbus.decoders import seconds_to_hhmm
+from neopool_modbus.decoders import get_timer_interval
+from neopool_modbus.exceptions import NeoPoolError
 
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import (
@@ -165,18 +167,20 @@ class NeoPoolTime(NeoPoolEntity, TimeEntity):
             await asyncio.sleep(self._debounce_delay)
         except asyncio.CancelledError:  # pragma: no cover
             return
-        desc = self.entity_description
-        block = desc.timer_block
+        block = self.entity_description.timer_block
         data = self.coordinator.data
-        start = seconds_to_hhmm(int(data.get(f"{block}_start", 0)))
-        stop = seconds_to_hhmm(int(data.get(f"{block}_stop", 0)))
-        await self.hass.services.async_call(
-            DOMAIN,
-            "set_timer",
-            {
-                "entry_id": self.coordinator.config_entry.entry_id,
-                "timer": block,
-                "start": start,
-                "stop": stop,
-            },
-        )
+        start_sec = int(data.get(f"{block}_start", 0))
+        stop_sec = int(data.get(f"{block}_stop", 0))
+        timer_data = {
+            "on": start_sec,
+            "interval": get_timer_interval(start_sec, stop_sec),
+        }
+        try:
+            await self.coordinator.client.write_timer(block, timer_data)
+        except (NeoPoolError, OSError) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="modbus_communication_error",
+                translation_placeholders={"error": str(err)},
+            ) from err
+        self.coordinator.request_refresh_with_followup()

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -5,6 +5,7 @@ from datetime import time as dt_time, timedelta
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+from neopool_modbus.exceptions import NeoPoolConnectionError
 import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
@@ -16,6 +17,7 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.time import DOMAIN as TIME_DOMAIN, SERVICE_SET_VALUE
 from homeassistant.const import ATTR_TIME, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform as ep, entity_registry as er
 
 from . import setup_integration
@@ -148,11 +150,11 @@ async def test_native_value_handles_out_of_range_seconds(
 
 
 # ---------------------------------------------------------------------------
-# async_set_value -> set_timer service
+# async_set_value -> client.write_timer
 # ---------------------------------------------------------------------------
 
 
-async def test_set_value_on_start_calls_set_timer(
+async def test_set_value_on_start_writes_timer(
     hass: HomeAssistant,
     mock_config_entry_timers: MockConfigEntry,
     mock_neopool_client: MagicMock,
@@ -181,7 +183,7 @@ async def test_set_value_on_start_calls_set_timer(
     assert payload["interval"] == 4 * 3600
 
 
-async def test_set_value_on_stop_calls_set_timer(
+async def test_set_value_on_stop_writes_timer(
     hass: HomeAssistant,
     mock_config_entry_timers: MockConfigEntry,
     mock_neopool_client: MagicMock,
@@ -208,6 +210,36 @@ async def test_set_value_on_stop_calls_set_timer(
     assert timer_name == "filtration1"
     assert payload["on"] == 6 * 3600
     assert payload["interval"] == 4 * 3600
+
+
+@pytest.mark.parametrize(
+    "write_error",
+    [
+        pytest.param(NeoPoolConnectionError("boom"), id="lib-connection-error"),
+        pytest.param(OSError("boom"), id="os-error"),
+    ],
+)
+async def test_set_value_maps_communication_error_to_home_assistant_error(
+    hass: HomeAssistant,
+    mock_config_entry_timers: MockConfigEntry,
+    mock_neopool_client: MagicMock,
+    freezer,
+    write_error: Exception,
+) -> None:
+    """A failed timer write surfaces as a translated HomeAssistantError."""
+    await setup_integration(hass, mock_config_entry_timers)
+    _disable_debounce(hass)
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    entity_id = _time_entity_id(hass, mock_config_entry_timers, "filtration1_start")
+    entity_obj = _time_entity(hass, entity_id)
+    mock_neopool_client.write_timer.side_effect = write_error
+
+    await entity_obj.async_set_value(dt_time(6, 0))
+    with pytest.raises(HomeAssistantError):
+        await _flush_debounce(hass, entity_obj)
 
 
 async def test_rapid_set_value_coalesces_via_debounce(


### PR DESCRIPTION
## ♻️ Summary

The `time` entity wrote timer changes by calling the internal `neopool.set_timer` **service** (`hass.services.async_call`), while every other write platform (light, switch, select) writes **directly** through `coordinator.client`. This aligns `time` with the rest: it now writes via `client.write_timer` directly, removing the needless service round-trip.

## 🔧 Changes

- 🎯 Replace the `set_timer` service call in the debounced write with a direct `coordinator.client.write_timer(block, {"on", "interval"})` call, mirroring `select._write_timer_period` and the light write path.
- 🧮 Compute `on` / `interval` from the coordinator's seconds via `get_timer_interval`, dropping the redundant seconds -> HH:MM -> seconds conversion the service did.
- ⚠️ Map communication errors (`NeoPoolError`, `OSError`) to a translated `HomeAssistantError`, consistent with the other write entities.
- 🔁 Schedule the coordinator follow-up refresh after a successful write.

## ✅ Notes

- The `set_timer` service is **unchanged** and still available for automations and external callers.
- Tests updated: renamed the two write tests, added a parametrized communication-error test.

## 🧪 Verification

- `pytest tests/` -> 330 passed
- `time.py` coverage 100%, total coverage unchanged
- `ruff check`, `ruff format --check`, `basedpyright` clean
