### PR TITLE
refactor(switch): ♻️ back winter mode with native pref_disable_polling

### DIFF
--- a/custom_components/neopool/const.py
+++ b/custom_components/neopool/const.py
@@ -83,6 +83,8 @@ _CUSTOM_CAPABILITY_KEYS: tuple[str, ...] = (
     "MBF_PAR_RELAY_PH",
     "MBF_PAR_FILT_GPIO",
     "MBF_PAR_LIGHTING_GPIO",
+    "MBF_POWER_MODULE_VERSION",
+    "MBF_PAR_VERSION",
 )
 
 CAPABILITY_KEYS: tuple[str, ...] = tuple(

--- a/custom_components/neopool/const.py
+++ b/custom_components/neopool/const.py
@@ -56,6 +56,8 @@ CONF_USE_AUX4 = "use_aux4"
 
 # Internal option keys
 CONF_AUTO_TIME_SYNC = "auto_time_sync"
+# Winter mode is backed by the native config_entry.pref_disable_polling flag;
+# this constant survives only as the winter-mode switch translation_key.
 CONF_WINTER_MODE = "winter_mode"
 CONF_CAPABILITIES = "_capabilities"
 

--- a/custom_components/neopool/coordinator.py
+++ b/custom_components/neopool/coordinator.py
@@ -45,7 +45,6 @@ from .const import (
     CONF_FILTRATION_PUMP_POWER,
     CONF_SCAN_INTERVAL,
     CONF_USE_LIGHT,
-    CONF_WINTER_MODE,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     FOLLOW_UP_REFRESH_DELAY,
@@ -89,7 +88,9 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         self.client = client
         self.auto_time_sync = entry.options.get(CONF_AUTO_TIME_SYNC, False)
-        self.winter_mode = entry.options.get(CONF_WINTER_MODE, False)
+        # Winter mode maps onto the native per-entry "disable polling" system
+        # option; the base coordinator already skips scheduling when it's set.
+        self.winter_mode = entry.pref_disable_polling
         # Persisted in options for winter mode (no Modbus reads).
         self._capability_snapshot: dict[str, Any] = dict(
             entry.options.get(CONF_CAPABILITIES, {})
@@ -358,16 +359,22 @@ class NeoPoolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.hass.config_entries.async_update_entry(self.config_entry, options=options)
 
     async def set_winter_mode(self, enabled: bool) -> None:
-        """Toggle winter mode and persist the capability snapshot."""
+        """Toggle winter mode via the native disable-polling flag.
+
+        Winter mode is backed by ``config_entry.pref_disable_polling`` so the
+        base coordinator stops scheduling refreshes entirely (no no-op polls,
+        no reconnect attempts). When enabling, the capability snapshot is
+        persisted first so the reload can set entities up offline, then the
+        entry is reloaded to rebuild the coordinator with the new flag.
+        """
         self.winter_mode = enabled
-        options = dict(self.config_entry.options)
-        options[CONF_WINTER_MODE] = enabled
-        if enabled:
-            if self.data:
-                self._capability_snapshot = {
-                    k: self.data[k] for k in CAPABILITY_KEYS if k in self.data
-                }
+        updates: dict[str, Any] = {"pref_disable_polling": enabled}
+        if enabled and self.data:
+            self._capability_snapshot = {
+                k: self.data[k] for k in CAPABILITY_KEYS if k in self.data
+            }
+            options = dict(self.config_entry.options)
             options[CONF_CAPABILITIES] = dict(self._capability_snapshot)
-        self.hass.config_entries.async_update_entry(self.config_entry, options=options)
-        if enabled:
-            self.async_set_updated_data(dict(self._capability_snapshot))
+            updates["options"] = options
+        self.hass.config_entries.async_update_entry(self.config_entry, **updates)
+        self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)

--- a/custom_components/neopool/entity.py
+++ b/custom_components/neopool/entity.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify as ha_slugify
 
-from .const import CONF_WINTER_MODE, DOMAIN, NAME
+from .const import DOMAIN, NAME
 from .coordinator import NeoPoolCoordinator
 
 # CUSTOM-ONLY START, detected-module labels surfaced as hw_version in HACS.
@@ -53,8 +53,9 @@ class NeoPoolEntity(CoordinatorEntity[NeoPoolCoordinator]):
     @override
     def available(self) -> bool:
         """Return False for control entities while winter mode is active."""
-        if self._winter_mode_active and getattr(
-            self.coordinator, CONF_WINTER_MODE, False
+        if (
+            self._winter_mode_active
+            and self.coordinator.config_entry.pref_disable_polling
         ):
             return False
         return super().available

--- a/custom_components/neopool/switch.py
+++ b/custom_components/neopool/switch.py
@@ -380,9 +380,10 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
 
         # HA-side settings live entirely outside the Modbus client.
         if desc.ha_setting == _HA_SETTING_WINTER_MODE:
+            # set_winter_mode flips pref_disable_polling and schedules an entry
+            # reload, which rebuilds the coordinator and re-renders this entity,
+            # so there's nothing more to write here.
             await self.coordinator.set_winter_mode(state)
-            await self.coordinator.async_request_refresh()
-            self.async_write_ha_state()
             return
         if desc.ha_setting == _HA_SETTING_AUTO_TIME_SYNC:
             await self.coordinator.set_auto_time_sync(state)
@@ -427,7 +428,7 @@ class NeoPoolSwitch(NeoPoolEntity, SwitchEntity):
         if desc.ha_setting == _HA_SETTING_AUTO_TIME_SYNC:
             return getattr(self.coordinator, CONF_AUTO_TIME_SYNC, False)
         if desc.ha_setting == _HA_SETTING_WINTER_MODE:
-            return getattr(self.coordinator, CONF_WINTER_MODE, False)
+            return self.coordinator.config_entry.pref_disable_polling
         return False  # pragma: no cover
 
     @property

--- a/tests/snapshots/test_diagnostics.ambr
+++ b/tests/snapshots/test_diagnostics.ambr
@@ -30,6 +30,8 @@
           'MBF_PAR_RX_RELAY_GPIO': 6,
           'MBF_PAR_TEMPERATURE_ACTIVE': 1,
           'MBF_PAR_UV_RELAY_GPIO': 1,
+          'MBF_PAR_VERSION': 256,
+          'MBF_POWER_MODULE_VERSION': 4660,
           'Redox measurement module detected': True,
           'pH measurement module detected': True,
         }),

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -19,7 +19,6 @@ from custom_components.neopool.const import (
     CONF_DEV_OVERRIDES_ENABLED,
     CONF_MODBUS_FRAMER,
     CONF_UNIT_ID,
-    CONF_WINTER_MODE,
     CURRENT_VERSION,
     DOMAIN,
 )
@@ -81,14 +80,16 @@ async def test_transient_modbus_failure_after_first_success_marks_unavailable(
 @pytest.mark.usefixtures("mock_neopool_client")
 async def test_winter_mode_skips_modbus(
     hass: HomeAssistant,
+    mock_neopool_client: MagicMock,
 ) -> None:
-    """When winter_mode is on we never call async_read_all on subsequent updates."""
+    """When winter mode is on we never call async_read_all, even on manual refresh."""
     snapshot = {"MBF_PAR_FILT_GPIO": 1, "MBF_PAR_LIGHTING_GPIO": 2}
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="Winter Pool",
         unique_id="neopool_winter",
         version=CURRENT_VERSION,
+        pref_disable_polling=True,
         data={
             "host": "192.0.2.5",
             "port": 502,
@@ -98,12 +99,17 @@ async def test_winter_mode_skips_modbus(
         },
         options={
             CONF_MODBUS_FRAMER: "tcp",
-            CONF_WINTER_MODE: True,
             CONF_CAPABILITIES: snapshot,
         },
     )
     await setup_integration(hass, entry)
     assert entry.state is ConfigEntryState.LOADED
+    assert mock_neopool_client.async_read_all.await_count == 0
+
+    # A manual refresh must still no-op against the disconnected controller.
+    await entry.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+    assert mock_neopool_client.async_read_all.await_count == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,7 +9,6 @@ from custom_components.neopool.const import (
     CONF_CAPABILITIES,
     CONF_MODBUS_FRAMER,
     CONF_UNIT_ID,
-    CONF_WINTER_MODE,
     CURRENT_VERSION,
     DOMAIN,
 )
@@ -73,6 +72,7 @@ async def test_setup_in_winter_mode(
         title="Winter Pool",
         unique_id="neopool_winter_serial",
         version=CURRENT_VERSION,
+        pref_disable_polling=True,
         data={
             "host": "192.0.2.2",
             "port": 502,
@@ -82,7 +82,6 @@ async def test_setup_in_winter_mode(
         },
         options={
             CONF_MODBUS_FRAMER: "tcp",
-            CONF_WINTER_MODE: True,
             CONF_CAPABILITIES: snapshot,
         },
     )

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -28,7 +28,6 @@ from custom_components.neopool.const import (
     CONF_MODBUS_FRAMER,
     CONF_UNIT_ID,
     CONF_USE_FILTRATION1,
-    CONF_WINTER_MODE,
     CURRENT_VERSION,
     FOLLOW_UP_REFRESH_DELAY,
 )
@@ -649,15 +648,20 @@ async def test_winter_mode_turn_on_off(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Toggling the winter_mode switch flips its state."""
+    """Toggling the winter_mode switch flips pref_disable_polling."""
     await setup_integration(hass, mock_config_entry)
     entity_id = "switch.neopool_winter_mode"
     assert hass.states.get(entity_id).state == STATE_OFF
+    assert mock_config_entry.pref_disable_polling is False
 
     await _turn_on(hass, entity_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.pref_disable_polling is True
     assert hass.states.get(entity_id).state == STATE_ON
 
     await _turn_off(hass, entity_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.pref_disable_polling is False
     assert hass.states.get(entity_id).state == STATE_OFF
 
 
@@ -693,6 +697,7 @@ async def test_io_switch_unavailable_in_winter_mode(
         title="Winter Pool",
         unique_id="neopool_winter_io",
         version=CURRENT_VERSION,
+        pref_disable_polling=True,
         data={
             "host": "192.0.2.7",
             "port": 502,
@@ -702,7 +707,6 @@ async def test_io_switch_unavailable_in_winter_mode(
         },
         options={
             CONF_MODBUS_FRAMER: "tcp",
-            CONF_WINTER_MODE: True,
             CONF_USE_FILTRATION1: True,
             CONF_CAPABILITIES: {"MBF_PAR_FILT_GPIO": 1},
         },


### PR DESCRIPTION
## ♻️ What

Rework the **Winter mode** switch so it is backed by Home Assistant's native per-entry **"Disable polling"** system option (`config_entry.pref_disable_polling`) instead of a bespoke coordinator no-op.

## 🤔 Why

Winter mode exists so users in regions that dismantle pool equipment over winter can stop the integration from polling a disconnected controller (no error spam, no reconnect attempts). HA already ships exactly this mechanism: when `pref_disable_polling` is set, the base `DataUpdateCoordinator` stops scheduling refreshes entirely. The previous implementation kept a live polling timer and only short-circuited inside `_async_update_data`, firing a no-op poll on every interval. Reusing the native flag is cleaner and aligns with core conventions.

The visible switch stays, because the native toggle lives under System options and is not reachable from automations, scripts, or voice. The switch is now a thin, automation-friendly surface over the native flag (`switch.turn_on` / `turn_off` / `toggle`).

## 🔧 How

- 🧊 `set_winter_mode` flips `pref_disable_polling`, persists the capability snapshot on enable, then schedules an entry reload to rebuild the coordinator.
- 🔀 `switch.is_on` and the entity availability gate read `pref_disable_polling` directly.
- 🏷️ `CONF_WINTER_MODE` survives only as the switch `translation_key`; it is no longer written to entry options.
- 🚫 No schema migration and no version bump. Winter mode is seasonal, so a stale `options[winter_mode]` is simply ignored.

## ⚠️ Upgrade note

Winter mode is now backed by the native "Disable polling" option. If you currently have Winter mode active, turn the switch on again after upgrading.

## ✅ Verification

- `pytest` — all tests pass, 100% coverage.
- `ruff check` / `ruff format --check` — clean.
- `basedpyright` — 0 errors.
